### PR TITLE
Cmd palette fixes

### DIFF
--- a/app/actions/ModActionPanel/BlobList.tsx
+++ b/app/actions/ModActionPanel/BlobList.tsx
@@ -33,7 +33,7 @@ export function BlobList(props: {
                 disabled={disabled}
               />
             </div>
-            <div className="ml-3 text-sm min-w-0 text-ellipsis overflow-hidden whitespace-nowrap">
+            <div className="ml-1 sm:ml-3 text-sm min-w-0 overflow-hidden">
               <label
                 htmlFor={`blob-${blob.cid}`}
                 className="font-medium text-gray-700 dark:text-gray-100"
@@ -46,7 +46,8 @@ export function BlobList(props: {
                     </ReviewStateIconLink>{' '}
                   </>
                 )}
-                {blob.cid}
+                {/* blob cids are long strings of random characters. on mobile screens, it will almost always cause overflow so breaking it into multi lines */}
+                <span className="break-all">{blob.cid}</span>
               </label>
               <p id={`blob-${blob.cid}-description`}>
                 <Chip>{blob.mimeType}</Chip>

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -442,6 +442,11 @@ function Form(
         .scrollable-container {
           height: calc(100vh - 100px);
         }
+        @supports (-webkit-touch-callout: none) {
+          .scrollable-container {
+            height: calc(100svh - 100px);
+          }
+        }
         @media (min-width: 640px) {
           .scrollable-container {
             height: calc(100vh - 180px);
@@ -724,17 +729,19 @@ function Form(
       {(subjectOptions?.length || 0) > 1 && (
         <div className="flex justify-between mt-auto">
           <ButtonSecondary
+            className="px-2 py-1"
             onClick={() => navigateQueue(-1)}
             disabled={submission.isSubmitting}
           >
-            <ArrowLeftIcon className="h-4 w-4 inline-block align-text-bottom" />
+            <ArrowLeftIcon className="h-3 w-3 sm:h-4 sm:w-4 inline-block align-text-bottom" />
           </ButtonSecondary>
 
           <ButtonSecondary
+            className="px-2 py-1"
             onClick={() => navigateQueue(1)}
             disabled={submission.isSubmitting}
           >
-            <ArrowRightIcon className="h-4 w-4 inline-block align-text-bottom" />
+            <ArrowRightIcon className="h-3 w-3 sm:h-4 sm:w-4 inline-block align-text-bottom" />
           </ButtonSecondary>
         </div>
       )}

--- a/app/repositories/[id]/[...record]/page.tsx
+++ b/app/repositories/[id]/[...record]/page.tsx
@@ -10,7 +10,7 @@ export default function RecordViewPage({
 }) {
   return (
     <Suspense fallback={<div></div>}>
-      <RedirectFromHandleToDid handle={params.id}>
+      <RedirectFromHandleToDid handle={params.id} record={params.record}>
         <RecordViewPageContent params={params} />
       </RedirectFromHandleToDid>
     </Suspense>

--- a/components/common/PreviewCard.tsx
+++ b/components/common/PreviewCard.tsx
@@ -1,5 +1,5 @@
 import { parseAtUri } from '@/lib/util'
-import { CollectionId } from '@/reports/helpers/subject'
+import { CollectionId, getCollectionName } from '@/reports/helpers/subject'
 import { ReactNode } from 'react'
 import { RecordCard, RepoCard } from './RecordCard'
 
@@ -17,9 +17,7 @@ const getPreviewTitleForAtUri = (uri: string): string => {
   return (
     PreviewTitleMap[collection || CollectionId.Post] ||
     (collection
-      ? // If the collection is a string, use the last two segments as the title
-        // so app.bsky.graph.list -> graph list
-        `Reported ${collection.split('.').slice(-2).join(' ')}`
+      ? `Reported ${getCollectionName(collection)}`
       : PreviewTitleMap[CollectionId.Post])
   )
 }
@@ -37,7 +35,9 @@ export function PreviewCard({
     const displayTitle = title || getPreviewTitleForAtUri(did)
     return (
       <div className="rounded border-2 border-dashed border-gray-300 p-2 pb-0 mb-3">
-        <p className="text-sm font-medium text-gray-500 dark:text-gray-50 mb-3">{displayTitle}</p>
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-50 mb-3">
+          {displayTitle}
+        </p>
         <RecordCard uri={did} />
         {children}
       </div>

--- a/components/mod-event/helpers/subject.tsx
+++ b/components/mod-event/helpers/subject.tsx
@@ -1,4 +1,4 @@
-import { CollectionId } from '@/reports/helpers/subject'
+import { getCollectionName } from '@/reports/helpers/subject'
 import {
   AtUri,
   ComAtprotoAdminDefs,
@@ -16,16 +16,7 @@ export const getSubjectTitle = (
   if (ComAtprotoRepoStrongRef.isMain(subject)) {
     const atUri = new AtUri(subject.uri)
     const collection = atUri.collection
-
-    if (collection === CollectionId.Post) {
-      return 'Post'
-    }
-    if (collection === CollectionId.Profile) {
-      return 'Profile'
-    }
-    if (collection === CollectionId.List) {
-      return 'List'
-    }
+    return getCollectionName(collection)
   }
 
   return 'Subject'

--- a/components/reports/helpers/subject.ts
+++ b/components/reports/helpers/subject.ts
@@ -11,12 +11,13 @@ export const createSubjectFromId = async (
 }> => {
   if (isIdRecord(id)) {
     try {
-      const { data: record } = await client.api.tools.ozone.moderation.getRecord(
-        {
-          uri: id,
-        },
-        { headers: client.proxyHeaders() },
-      )
+      const { data: record } =
+        await client.api.tools.ozone.moderation.getRecord(
+          {
+            uri: id,
+          },
+          { headers: client.proxyHeaders() },
+        )
       return {
         record,
         subject: {
@@ -71,3 +72,27 @@ export enum CollectionId {
 }
 export const getProfileUriForDid = (did: string) =>
   `at://${did}/${CollectionId.Profile}/self`
+
+export const getCollectionName = (collection: string) => {
+  if (collection === CollectionId.Post) {
+    return 'Post'
+  }
+  if (collection === CollectionId.Profile) {
+    return 'Profile'
+  }
+  if (collection === CollectionId.List) {
+    return 'List'
+  }
+  if (collection === CollectionId.FeedGenerator) {
+    return 'Feed'
+  }
+  if (collection === CollectionId.LabelerService) {
+    return 'Labeler'
+  }
+  // If the collection is a string with ., use the last two segments as the title
+  // so app.bsky.graph.list -> graph list
+  if (collection.includes('.')) {
+    return collection.split('.').slice(-2).join(' ')
+  }
+  return ''
+}

--- a/components/repositories/RedirectFromhandleToDid.tsx
+++ b/components/repositories/RedirectFromhandleToDid.tsx
@@ -4,13 +4,16 @@ import { useHandleToDidRedirect } from './useHandleToDidRedirect'
 export const RedirectFromHandleToDid = ({
   handle,
   children,
+  record = [],
 }: {
   handle: string
+  record?: string[]
   children: JSX.Element
 }) => {
-  const { isFetching } = useHandleToDidRedirect(
-    handle,
-    (did) => `/repositories/${did}`,
+  const { isFetching } = useHandleToDidRedirect(handle, (did) =>
+    record?.length
+      ? `/repositories/${did}/${record.join('/')}`
+      : `/repositories/${did}`,
   )
   if (isFetching) {
     return <Loading />

--- a/components/shell/CommandPalette/useAsyncSearch.tsx
+++ b/components/shell/CommandPalette/useAsyncSearch.tsx
@@ -1,13 +1,12 @@
 import clientManager from '@/lib/client'
 import { getDidFromHandle } from '@/lib/identity'
-import { CollectionId } from '@/reports/helpers/subject'
+import { CollectionId, getCollectionName } from '@/reports/helpers/subject'
 import { AtUri } from '@atproto/api'
 import {
   ChatBubbleLeftIcon,
   UserGroupIcon,
   PuzzlePieceIcon,
   LifebuoyIcon,
-  MegaphoneIcon,
 } from '@heroicons/react/24/outline'
 import {
   useKBar,
@@ -25,6 +24,7 @@ import {
   isValidDid,
   isValidHandle,
   parseAtUri,
+  buildAtUriFromFragments,
 } from '../../../lib/util'
 
 const PostIcon = ChatBubbleLeftIcon
@@ -41,12 +41,12 @@ const ActionSections: Record<string, ActionSection> = {
     name: 'Actions',
     priority: 3,
   },
-  reports: {
-    name: 'Reports',
-    priority: 2,
-  },
   details: {
     name: 'Details',
+    priority: 2,
+  },
+  reports: {
+    name: 'Reports',
     priority: 1,
   },
 }
@@ -68,6 +68,7 @@ const buildItemForDid = ({
       icon: <RepoIcon className={iconClassName} />,
       subtitle: `Open DID in action panel`,
       section: ActionSections.actions,
+      priority: 5,
       perform: () => {
         router.push(`?quickOpen=${did}`)
       },
@@ -95,7 +96,20 @@ const buildItemForProfile = ({
   router,
 }: ItemBuilderProps): Action[] => {
   const typeText = type === 'did' ? type.toUpperCase() : type
-  const actions: Action[] = [
+  const actions: Action[] = []
+
+  // Right now, we can't search reports by a handle
+  if (type !== 'handle') {
+    actions.push(
+      ...buildItemForDid({
+        search,
+        router,
+        did: profileKey,
+      }),
+    )
+  }
+
+  actions.push(
     {
       id: `view-profile-by-${type}`,
       name: `Profile for ${profileKey}`,
@@ -131,18 +145,7 @@ const buildItemForProfile = ({
         router.push(`/repositories/${profileKey.replace('@', '')}?tab=email`)
       },
     },
-  ]
-
-  // Right now, we can't search reports by a handle
-  if (type !== 'handle') {
-    actions.push(
-      ...buildItemForDid({
-        search,
-        router,
-        did: profileKey,
-      }),
-    )
-  }
+  )
 
   return actions
 }
@@ -152,26 +155,35 @@ export const useCommandPaletteAsyncSearch = () => {
   const { search } = useKBar<{ search: string }>((state) => ({
     search: state.searchQuery,
   }))
-  const [didFromHandle, setDidFromHandle] = useState<string>('')
-  const setDidFromSearch = () =>
-    getDidFromHandle(search).then((did) => {
+  const [didFromHandle, setDidFromHandle] = useState<{
+    did: string
+    handle: string
+  }>({ did: '', handle: '' })
+  const setDidFromSearch = (handle: string) => {
+    setDidFromHandle({ did: '', handle })
+    if (!handle) return
+    getDidFromHandle(handle).then((did) => {
       if (did) {
-        setDidFromHandle(did)
+        setDidFromHandle({ did, handle })
       } else {
-        setDidFromHandle('')
+        setDidFromHandle({ did: '', handle })
       }
     })
+  }
 
   useEffect(() => {
-    if (isValidHandle(search)) {
-      setDidFromSearch()
-    } else if (isBlueSkyAppUrl(search)) {
+    // When full url is pasted in, it may contain user handle
+    // so let's check for the full URL match first
+    if (isBlueSkyAppUrl(search)) {
       const fragments = getFragmentsFromBlueSkyAppUrl(search)
       if (fragments?.handle) {
-        setDidFromSearch()
+        setDidFromSearch(fragments.handle)
       }
+      // When the search query is an at-uri, it surely won't be a valid handle
+    } else if (isValidHandle(search) && !search.startsWith('at://')) {
+      setDidFromSearch(search)
     } else {
-      setDidFromHandle('')
+      setDidFromSearch('')
     }
   }, [search])
 
@@ -194,56 +206,8 @@ export const useCommandPaletteAsyncSearch = () => {
       })
     } else if (isBlueSkyAppUrl(search)) {
       const fragments = getFragmentsFromBlueSkyAppUrl(search)
-
-      if (fragments?.cid) {
-        actions.push(
-          {
-            id: 'report-post',
-            name: `Report post ${fragments.cid}`,
-            section: ActionSections.actions,
-            icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},report,post`,
-            subtitle: 'Go to post record and open report panel',
-            perform: () => {
-              router.push(
-                `/repositories/${fragments.did || fragments.handle}/${
-                  CollectionId.Post
-                }/${fragments.cid}?reportUri=default`,
-              )
-            },
-          },
-          {
-            id: 'view-post',
-            name: `View post ${fragments.cid}`,
-            section: ActionSections.details,
-            icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},view,post`,
-            subtitle: 'Go to post record',
-            perform: () => {
-              router.push(
-                `/repositories/${fragments.did || fragments.handle}/${
-                  CollectionId.Post
-                }/${fragments.cid}`,
-              )
-            },
-          },
-          {
-            id: 'search-reports-by-post',
-            name: `Reports for post ${fragments.cid}`,
-            section: ActionSections.reports,
-            icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},search,report,post`,
-            subtitle: 'Go to reports page and filter by this post',
-            perform: () => {
-              router.push(
-                `/reports?term=at://${fragments.did || fragments.handle}/${
-                  CollectionId.Post
-                }/${fragments.cid}`,
-              )
-            },
-          },
-        )
-      }
+      const atUri = buildAtUriFromFragments(fragments)
+      const collectionName = getCollectionName(fragments?.collection || '')
 
       if (fragments?.did) {
         actions.push(
@@ -266,18 +230,81 @@ export const useCommandPaletteAsyncSearch = () => {
           }),
         )
       }
+
+      if (fragments?.rkey && collectionName) {
+        actions.push(
+          {
+            id: `show-action-for-${collectionName}`,
+            name: `Take action on ${collectionName}`,
+            keywords: `${search},${collectionName},search,action`,
+            icon: <PostIcon className={iconClassName} />,
+            subtitle: `Open ${collectionName} in action panel`,
+            section: ActionSections.actions,
+            // When we have an exact content by rkey, we want to prioritize it over action for the account by did
+            priority: 6,
+            perform: () => {
+              router.push(`?quickOpen=${atUri}`)
+            },
+          },
+          {
+            id: `report-${collectionName}`,
+            name: `Report ${collectionName} ${fragments.rkey}`,
+            section: ActionSections.actions,
+            icon: <PostIcon className={iconClassName} />,
+            keywords: `${search},report,${collectionName}`,
+            subtitle: `Go to ${collectionName} record and open report panel`,
+            perform: () => {
+              router.push(
+                `/repositories/${fragments.did || fragments.handle}/${
+                  CollectionId.Post
+                }/${fragments.rkey}?reportUri=default`,
+              )
+            },
+          },
+          {
+            id: `view-${collectionName}`,
+            name: `View ${collectionName} ${fragments.rkey}`,
+            section: ActionSections.details,
+            icon: <PostIcon className={iconClassName} />,
+            keywords: `${search},view,${collectionName}`,
+            subtitle: `Go to ${collectionName} record`,
+            perform: () => {
+              router.push(
+                `/repositories/${fragments.did || fragments.handle}/${
+                  CollectionId.Post
+                }/${fragments.rkey}`,
+              )
+            },
+          },
+          {
+            id: `search-reports-by-${collectionName}`,
+            name: `Reports for ${collectionName} ${fragments.rkey}`,
+            section: ActionSections.reports,
+            icon: <PostIcon className={iconClassName} />,
+            keywords: `${search},search,report,${collectionName}`,
+            subtitle: `Go to reports page and filter by this ${collectionName}`,
+            perform: () => {
+              router.push(
+                `/reports?term=at://${fragments.did || fragments.handle}/${
+                  CollectionId.Post
+                }/${fragments.rkey}`,
+              )
+            },
+          },
+        )
+      }
     } else if (search.startsWith('at://')) {
       const { did, collection, rkey } = parseAtUri(search) || {}
       if (did && collection && rkey) {
-        const readableCollection = collection.split('.').pop()
+        const readableCollection = getCollectionName(collection)
         actions.push(
           {
-            id: 'report-post',
+            id: `report-${readableCollection}`,
             name: `Report ${readableCollection} ${rkey}`,
             section: ActionSections.actions,
             icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},report,post`,
-            subtitle: 'Go to post record and open report panel',
+            keywords: `report,${readableCollection},${search}`,
+            subtitle: `Go to ${readableCollection} record and open report panel`,
             perform: () => {
               router.push(
                 `/repositories/${did}/${collection}/${rkey}?reportUri=${search}`,
@@ -285,12 +312,15 @@ export const useCommandPaletteAsyncSearch = () => {
             },
           },
           {
-            id: 'action-post',
+            id: `action-${readableCollection}`,
             name: `Action ${readableCollection} ${rkey}`,
             section: ActionSections.actions,
             icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},action,post`,
+            keywords: `action,${readableCollection},${search}`,
             subtitle: 'Open action panel for post',
+            // for a complete record uri, we would want it to be the first action
+            // the account actions should come after it
+            priority: 7,
             perform: () => {
               router.push(
                 `?quickOpen=${AtUri.make(did, collection, rkey).toString()}`,
@@ -298,12 +328,12 @@ export const useCommandPaletteAsyncSearch = () => {
             },
           },
           {
-            id: 'view-post',
+            id: `view-${readableCollection}`,
             name: `View ${readableCollection} ${rkey}`,
             section: ActionSections.details,
             icon: <PostIcon className={iconClassName} />,
-            keywords: `${search},view,post`,
-            subtitle: 'Go to post record',
+            keywords: `view,${readableCollection},${search}`,
+            subtitle: `Go to ${readableCollection} record`,
             perform: () => {
               router.push(`/repositories/${did}/${collection}/${rkey}`)
             },
@@ -341,13 +371,13 @@ export const useCommandPaletteAsyncSearch = () => {
       )
     }
 
-    if (didFromHandle) {
+    if (didFromHandle.handle) {
       actions.push(
         ...buildItemForDid({
           search,
           router,
-          handle: search,
-          did: didFromHandle,
+          handle: didFromHandle.handle,
+          did: didFromHandle.did,
         }),
       )
     }

--- a/components/subject/table.tsx
+++ b/components/subject/table.tsx
@@ -139,7 +139,7 @@ function SubjectRow({
           subjectRepoHandle={subjectStatus.subjectRepoHandle}
         />
       </td>
-      <td className="hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-100 sm:table-cell">
+      <td className="hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-100 sm:table-cell max-w-sm">
         {lastReviewedAt && (
           <span title={lastReviewedAt.toLocaleString()}>
             {formatDistanceToNow(lastReviewedAt, { addSuffix: true })}
@@ -231,7 +231,9 @@ function EmptyRows({ isInitialLoading }: { isInitialLoading: boolean }) {
         {isInitialLoading ? (
           <>
             <Loading />
-            <p className="pb-4 text-gray-400 dark:text-gray-100">Loading moderation queue...</p>
+            <p className="pb-4 text-gray-400 dark:text-gray-100">
+              Loading moderation queue...
+            </p>
           </>
         ) : (
           <p className="py-4 text-gray-400 dark:text-gray-100 text-center">

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,9 +1,5 @@
 import { CollectionId } from '@/reports/helpers/subject'
-<<<<<<< Updated upstream
-=======
 import { AtUri } from '@atproto/api'
-import { SOCIAL_APP_URL } from './constants'
->>>>>>> Stashed changes
 
 export function classNames(...classes: (string | undefined)[]) {
   return classes.filter(Boolean).join(' ')

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,9 @@
 import { CollectionId } from '@/reports/helpers/subject'
+<<<<<<< Updated upstream
+=======
+import { AtUri } from '@atproto/api'
+import { SOCIAL_APP_URL } from './constants'
+>>>>>>> Stashed changes
 
 export function classNames(...classes: (string | undefined)[]) {
   return classes.filter(Boolean).join(' ')
@@ -72,13 +77,21 @@ export const buildBlueSkyAppUrl = (
   return url
 }
 
+type BlueSkyAppUrlFragments = {
+  did?: string
+  handle?: string
+  rkey?: string
+  collection?: string
+}
+
 export const getFragmentsFromBlueSkyAppUrl = (url: string) => {
   const fragments = url.match(blueSkyUrlMatcher)
   if (!fragments) return null
 
-  const parts: { did?: string; handle?: string; cid?: string } = {}
+  const parts: BlueSkyAppUrlFragments = {}
 
-  let postIndex = -1
+  let collectionIndex = -1
+  const collections = Object.values(CollectionId) as string[]
   const identifiers = url
     .replace(fragments[0], '')
     .replace('/profile', '')
@@ -91,16 +104,45 @@ export const getFragmentsFromBlueSkyAppUrl = (url: string) => {
     if (isValidHandle(part)) {
       parts.handle = part
     }
-    if (part === 'post' || part === CollectionId.Post) {
-      postIndex = i
+
+    // Weirdly, in the app, we use /lists/ instead of /list/ so we need to account for that too
+    if (part === 'lists') {
+      part = 'list'
+    }
+
+    // Usually, in the URL within the app, we would use /post/:rkey or /lists/:rkey
+    // but the collection name would be fully qualified name with . separator
+    // so, we want to make sure we can match the collection name with the URL
+    const isFullCollectionName = collections.includes(part)
+    const partialCollectionName = collections.find((col) =>
+      col.includes(`.${part}`),
+    )
+    if (part && (isFullCollectionName || partialCollectionName)) {
+      collectionIndex = i
+      parts.collection = isFullCollectionName ? part : partialCollectionName
     }
   })
 
-  if (postIndex >= 0) {
-    parts.cid = identifiers[postIndex + 1]
+  if (collectionIndex >= 0) {
+    parts.rkey = identifiers[collectionIndex + 1]
   }
 
   return parts
+}
+
+export const buildAtUriFromFragments = (
+  fragments: BlueSkyAppUrlFragments | null,
+) => {
+  if (fragments?.did || fragments?.handle) {
+    const uri = AtUri.make(
+      `${fragments?.did || fragments?.handle}`,
+      fragments.collection,
+      fragments.rkey,
+    )
+    return uri.toString()
+  }
+
+  return ''
 }
 
 export const isValidDid = (did?: string | null) => did?.startsWith('did:')


### PR DESCRIPTION
This PR fixes 

1. order of items in cmd palette. Prioritize action panel opener for record when available, account (through did or handle) otherwise.
2. matcher for did, handle, bsky url and at-uri
3. handle -> did replaces when navigating to record url 
4. spacing in the moderation queue table so that notes column does not take up too much space
5. On mobile safari, the botton address bar hiding content at the bottom of the quick action panel