### PR TITLE
Change colors to for ReviewStateMarker so ReviewNone is visible on dark theme

### DIFF
--- a/components/subject/ReviewStateMarker.tsx
+++ b/components/subject/ReviewStateMarker.tsx
@@ -38,6 +38,10 @@ const reviewStateToColor = {
     bg: 'bg-green-200 dark:bg-green-200',
     text: 'text-green-800 dark:text-green-500',
   },
+  [ToolsOzoneModerationDefs.REVIEWNONE]: {
+    bg: 'bg-gray-200 dark:bg-gray-200',
+    text: 'text-gray-800 dark:text-gray-600',
+  },
 }
 
 const reviewStateToIcon = {


### PR DESCRIPTION
**Issue:**

Currently, REVIEWNONE icons are not visible on the dark theme. 

<img width="536" alt="Invisible icon" src="https://github.com/bluesky-social/ozone/assets/1154273/64894290-7a26-4309-b135-9042a60572b0">

**Change:**

I added a `reviewStateToColor` for `ToolsOzoneModerationDefs.REVIEWNONE` so help make it visible on the dark theme.

<img width="168" alt="dark mode" src="https://github.com/bluesky-social/ozone/assets/1154273/526c423c-64b6-4969-b994-8a4c08192fed">
<br />
<img width="152" alt="light mode" src="https://github.com/bluesky-social/ozone/assets/1154273/8ad91762-0e24-41b7-9efb-c6638848c2c1">



