### PR TITLE
add xxd dep to HOSTING doc

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -112,6 +112,8 @@ sudo apt-get install \
     ca-certificates \
     curl \
     jq \
+    openssl \
+    xxd \
     gnupg
 ```
 


### PR DESCRIPTION
closes: https://github.com/bluesky-social/ozone/issues/57

Also added `openssl`, though I think that is usually already installed, or a dep of one of the other tools.