### PR TITLE
:lipstick: Show links to post and author action panel for replies

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -576,6 +576,7 @@ function Form(
                   <ModEventSelectorButton
                     subjectStatus={subjectStatus}
                     selectedAction={modEventType}
+                    isSubjectDid={isSubjectDid}
                     hasBlobs={!!record?.blobs?.length}
                     setSelectedAction={(action) => setModEventType(action)}
                   />

--- a/components/common/posts/ReplyParent.tsx
+++ b/components/common/posts/ReplyParent.tsx
@@ -25,18 +25,21 @@ export const ReplyParent = ({
     [searchParams, pathname],
   )
 
+  const linkToParentPost = (text: string = 'Reply') => (
+    <Link
+      className="underline"
+      href={createLinkToActionPanel('quickOpen', `${parent.uri}`)}
+    >
+      {text}
+    </Link>
+  )
+
   if (!parent) return null
 
   if (parent.notFound) {
     return (
       <Wrapper className="text-gray-500 dark:text-gray-50 text-sm">
-        Reply to{' '}
-        <Link
-          className="underline"
-          href={createLinkToActionPanel('quickOpen', `${parent.uri}`)}
-        >
-          a deleted post
-        </Link>
+        {linkToParentPost()} to a deleted post
       </Wrapper>
     )
   }
@@ -44,27 +47,27 @@ export const ReplyParent = ({
   const parentAuthor = parent.author as AppBskyActorDefs.ProfileViewBasic
 
   if (!parentAuthor) {
+    const userText = parent.blocked
+      ? 'a user who blocked the author'
+      : 'an anonymous user'
     return (
       <Wrapper className="text-gray-500 dark:text-gray-50 text-sm">
-        Reply to{' '}
-        <Link
-          className="underline"
-          href={createLinkToActionPanel('quickOpen', `${parent.uri}`)}
-        >
-          an anonymous post
-        </Link>
+        {linkToParentPost()} to {userText}
       </Wrapper>
     )
   }
 
+  const userText = parent.blocked
+    ? 'a user who blocked the author'
+    : `@${parentAuthor.handle}`
   return (
     <Wrapper className="text-gray-500 dark:text-gray-50 text-sm">
-      Reply to{' '}
+      {linkToParentPost()} to{' '}
       <Link
-        href={`/repositories/${parentAuthor.did}`}
-        className="hover:underline"
+        href={createLinkToActionPanel('quickOpen', parentAuthor.did)}
+        className="underline"
       >
-        @{parentAuthor.handle}
+        {userText}
       </Link>
     </Wrapper>
   )

--- a/components/mod-event/SelectorButton.tsx
+++ b/components/mod-event/SelectorButton.tsx
@@ -49,11 +49,13 @@ export const ModEventSelectorButton = ({
   selectedAction,
   setSelectedAction,
   hasBlobs,
+  isSubjectDid,
 }: {
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
   selectedAction: string
   setSelectedAction: (action: string) => void
   hasBlobs: boolean
+  isSubjectDid: boolean
 }) => {
   const availableActions = useMemo(() => {
     return actions.filter(({ key, text }) => {
@@ -93,13 +95,17 @@ export const ModEventSelectorButton = ({
         return false
       }
       // Don't show mute reporter action if reporter is already muted
-      if (key === MOD_EVENTS.MUTE_REPORTER && isReporterMuted(subjectStatus)) {
+      if (
+        (key === MOD_EVENTS.MUTE_REPORTER && isReporterMuted(subjectStatus)) ||
+        !isSubjectDid
+      ) {
         return false
       }
       // Don't show unmute reporter action if reporter is not muted
       if (
-        key === MOD_EVENTS.UNMUTE_REPORTER &&
-        !isReporterMuted(subjectStatus)
+        (key === MOD_EVENTS.UNMUTE_REPORTER &&
+          !isReporterMuted(subjectStatus)) ||
+        !isSubjectDid
       ) {
         return false
       }


### PR DESCRIPTION
Addresses https://github.com/bluesky-social/ozone/issues/101

This PR improves linking around reply posts. In ozone, when a reply post is shown, mods may want to review the parent post or the author account of the parent post. With this PR, both are available inline and the special case where the author of the parent post blocked the reply author is also handled.

Sneaking in an unrelated fix with this to hide reporter muting actions on non-repo subjects.