### PR TITLE
:bug: Fix filter for mute reporter event display in selector button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Release 0.1.5
+- Fix event type selector button ([#112](https://github.com/bluesky-social/ozone/pull/112))
+
+
 ## Release 0.1.4
 
 ### Features

--- a/components/mod-event/SelectorButton.tsx
+++ b/components/mod-event/SelectorButton.tsx
@@ -96,16 +96,15 @@ export const ModEventSelectorButton = ({
       }
       // Don't show mute reporter action if reporter is already muted
       if (
-        (key === MOD_EVENTS.MUTE_REPORTER && isReporterMuted(subjectStatus)) ||
-        !isSubjectDid
+        key === MOD_EVENTS.MUTE_REPORTER &&
+        (isReporterMuted(subjectStatus) || !isSubjectDid)
       ) {
         return false
       }
       // Don't show unmute reporter action if reporter is not muted
       if (
-        (key === MOD_EVENTS.UNMUTE_REPORTER &&
-          !isReporterMuted(subjectStatus)) ||
-        !isSubjectDid
+        key === MOD_EVENTS.UNMUTE_REPORTER &&
+        (!isReporterMuted(subjectStatus) || !isSubjectDid)
       ) {
         return false
       }
@@ -126,7 +125,9 @@ export const ModEventSelectorButton = ({
     subjectStatus?.reviewState,
     subjectStatus?.appealed,
     hasBlobs,
+    isSubjectDid,
   ])
+  
   return (
     <Dropdown
       className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"


### PR DESCRIPTION
Mute/Unmute reporter event should only displayed when the subject is a DID. The previous implementation for that check was filtering out all event types when subject is not DID.