### PR TITLE
:sparkles: Show post preview even when moderator is blocked by the author

### DIFF
--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -11,6 +11,7 @@ import { FeedGeneratorRecordCard } from './feeds/RecordCard'
 import { ProfileAvatar } from '@/repositories/ProfileAvatar'
 import { ShieldCheckIcon } from '@heroicons/react/24/solid'
 import { ProfileViewDetailed } from '@atproto/api/dist/client/types/app/bsky/actor/defs'
+import { isSelfLabels } from '@atproto/api/dist/client/types/com/atproto/label/defs'
 
 export function RecordCard(props: { uri: string; showLabels?: boolean }) {
   const { uri, showLabels = false } = props
@@ -84,10 +85,19 @@ function PostCard(props: { uri: string; showLabels?: boolean }) {
             controls={false}
             item={{
               post: {
+                uri: record.uri,
+                cid: record.cid,
                 author: record.repo,
                 record: record.value,
-                ...record,
-                ...record.value,
+                labels: isSelfLabels(record.value['labels'])
+                  ? record.value['labels'].values.map(({ val }) => ({
+                      val,
+                      uri: record.uri,
+                      src: record.repo.did,
+                      cts: new Date(0).toISOString(),
+                    }))
+                  : [],
+                indexedAt: new Date(0).toISOString(),
               },
             }}
           />

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -71,6 +71,31 @@ function PostCard(props: { uri: string; showLabels?: boolean }) {
       />
     )
   }
+
+  // When the author of the post blocks the viewer, getPostThread won't return the necessary properties
+  // to build the post view so we manually build the post view from the raw record data
+  if (data?.thread?.blocked) {
+    return (
+      <BaseRecordCard
+        uri={uri}
+        renderRecord={(record) => (
+          <PostAsCard
+            dense
+            controls={false}
+            item={{
+              post: {
+                author: record.repo,
+                record: record.value,
+                ...record,
+                ...record.value,
+              },
+            }}
+          />
+        )}
+      />
+    )
+  }
+
   if (!data || !AppBskyFeedDefs.isThreadViewPost(data.thread)) {
     return null
   }

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -222,9 +222,17 @@ function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
     ? item.post.embed.media
     : item.post.embed
 
-  const imageRequiresBlur = doesLabelNeedBlur(
-    item.post.labels?.map(({ val }) => val),
-  )
+  const labelVals: string[] = []
+  if (Array.isArray(item.post.labels)) {
+    item.post.labels.forEach(({ val }) => labelVals.push(val))
+  } else if (Array.isArray(item.post.labels?.['values'])) {
+    // This handles the case where the item may be built from raw record and in that case, labels value is not an array rather a self label object
+    const labels = item.post.labels?.['values'] as unknown as Array<{
+      val: string
+    }>
+    labels.forEach(({ val }) => labelVals.push(val))
+  }
+  const imageRequiresBlur = doesLabelNeedBlur(labelVals)
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
     imageRequiresBlur ? 'blur-sm hover:blur-none' : '',

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -222,17 +222,9 @@ function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
     ? item.post.embed.media
     : item.post.embed
 
-  const labelVals: string[] = []
-  if (Array.isArray(item.post.labels)) {
-    item.post.labels.forEach(({ val }) => labelVals.push(val))
-  } else if (Array.isArray(item.post.labels?.['values'])) {
-    // This handles the case where the item may be built from raw record and in that case, labels value is not an array rather a self label object
-    const labels = item.post.labels?.['values'] as unknown as Array<{
-      val: string
-    }>
-    labels.forEach(({ val }) => labelVals.push(val))
-  }
-  const imageRequiresBlur = doesLabelNeedBlur(labelVals)
+  const imageRequiresBlur = doesLabelNeedBlur(
+    item.post.labels?.map(({ val }) => val),
+  )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
     imageRequiresBlur ? 'blur-sm hover:blur-none' : '',


### PR DESCRIPTION
Since `getPostThread` does not return post record data when there's a block relationship between author and the moderator viewer, this PR builds the post data from `getRecord` so that post preview is displayed properly in the quick action panel.