### PR TITLE
:sparkles: Add modal image viewer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 'use client' // @TODO Totally circumventing SSC
 import '../styles/globals.css'
 import 'react-toastify/dist/ReactToastify.css'
+import 'yet-another-react-lightbox/styles.css'
+import 'yet-another-react-lightbox/plugins/thumbnails.css'
+import 'yet-another-react-lightbox/plugins/captions.css'
 import { ToastContainer } from 'react-toastify'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Shell } from '@/shell/Shell'

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -303,14 +303,12 @@ export function RepoCard(props: { did: string }) {
           <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
             <Link
               href={`/repositories/${repo.did}`}
-              className="hover:underline"
+              className="hover:underline text-gray-500 dark:text-gray-50"
             >
               {profile?.displayName ? (
                 <>
                   <span className="font-bold">{profile.displayName}</span>
-                  <span className="ml-1 text-gray-500 dark:text-gray-50">
-                    @{repo.handle}
-                  </span>
+                  <span className="ml-1">@{repo.handle}</span>
                 </>
               ) : (
                 <span className="font-bold">@{repo.handle}</span>

--- a/components/common/feeds/RecordCard.tsx
+++ b/components/common/feeds/RecordCard.tsx
@@ -63,7 +63,7 @@ export const FeedGeneratorRecordCard = ({ uri }: { uri: string }) => {
           />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
             <>
               <Link
                 href={`/repositories/${uri?.replace('at://', '')}`}
@@ -73,7 +73,9 @@ export const FeedGeneratorRecordCard = ({ uri }: { uri: string }) => {
               </Link>
               <span className="ml-1">by</span>
               <Link href={`/repositories/${creator.did}`}>
-                <span className="ml-1 text-gray-500">@{creator.handle}</span>
+                <span className="ml-1 text-gray-500 dark:text-gray-50">
+                  @{creator.handle}
+                </span>
               </Link>
             </>{' '}
             &nbsp;&middot;&nbsp;
@@ -87,10 +89,10 @@ export const FeedGeneratorRecordCard = ({ uri }: { uri: string }) => {
           </p>
         </div>
       </div>
-      <div className="pb-2 pl-10">
-        {description && <p className="text-sm text-gray-500">{description}</p>}
+      <div className="pb-2 pl-10 text-gray-500 dark:text-gray-50">
+        {description && <p className="text-sm">{description}</p>}
         {!!meta.length && (
-          <p className="text-sm text-gray-500">{meta.join(' - ')}</p>
+          <p className="text-sm">{meta.join(' - ')}</p>
         )}
       </div>
     </div>

--- a/components/common/posts/ImageList.tsx
+++ b/components/common/posts/ImageList.tsx
@@ -1,0 +1,53 @@
+import { AppBskyEmbedImages } from '@atproto/api'
+import { useState } from 'react'
+import { InformationCircleIcon } from '@heroicons/react/24/outline'
+import Lightbox from 'yet-another-react-lightbox'
+import Captions from 'yet-another-react-lightbox/plugins/captions'
+import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails'
+import 'yet-another-react-lightbox/styles.css'
+import 'yet-another-react-lightbox/plugins/thumbnails.css'
+import 'yet-another-react-lightbox/plugins/captions.css'
+
+function ImageAltText({ alt }: { alt: string }) {
+  if (!alt) return null
+  return (
+    <p className="leading-2 text-gray-400 text-xs leading-3 mt-1">
+      <InformationCircleIcon className="w-4 h-4 inline mr-1" />
+      {alt}
+    </p>
+  )
+}
+
+export const ImageList = ({
+  images,
+  imageClassName,
+}: {
+  imageClassName?: string
+  images: AppBskyEmbedImages.ViewImage[]
+}) => {
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
+  return (
+    <>
+      <Lightbox
+        open={isImageViewerOpen}
+        plugins={[Thumbnails, Captions]}
+        carousel={{ finite: true }}
+        close={() => setIsImageViewerOpen(false)}
+        slides={images.map((img) => ({
+          src: img.fullsize,
+          description: img.alt,
+        }))}
+      />
+      {images.map((image, i) => (
+        <figure key={`img-${i}`}>
+          <button type="button" onClick={() => setIsImageViewerOpen(true)}>
+            <img className={imageClassName} src={image.thumb} alt={image.alt} />
+          </button>
+          <figcaption>
+            <ImageAltText alt={image.alt} />
+          </figcaption>
+        </figure>
+      ))}
+    </>
+  )
+}

--- a/components/common/posts/ImageList.tsx
+++ b/components/common/posts/ImageList.tsx
@@ -4,9 +4,6 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline'
 import Lightbox from 'yet-another-react-lightbox'
 import Captions from 'yet-another-react-lightbox/plugins/captions'
 import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails'
-import 'yet-another-react-lightbox/styles.css'
-import 'yet-another-react-lightbox/plugins/thumbnails.css'
-import 'yet-another-react-lightbox/plugins/captions.css'
 
 function ImageAltText({ alt }: { alt: string }) {
   if (!alt) return null
@@ -39,7 +36,7 @@ export const ImageList = ({
         }))}
       />
       {images.map((image, i) => (
-        <figure key={`img-${i}`}>
+        <figure key={image.thumb}>
           <button type="button" onClick={() => setIsImageViewerOpen(true)}>
             <img className={imageClassName} src={image.thumb} alt={image.alt} />
           </button>

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -9,6 +9,10 @@ import {
   AppBskyEmbedRecord,
 } from '@atproto/api'
 import Link from 'next/link'
+import Lightbox from 'yet-another-react-lightbox'
+import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails'
+import 'yet-another-react-lightbox/styles.css'
+import 'yet-another-react-lightbox/plugins/thumbnails.css'
 import {
   DocumentMagnifyingGlassIcon,
   ExclamationCircleIcon,
@@ -27,6 +31,7 @@ import { getTranslatorLink, isPostInLanguage } from '@/lib/locale/helpers'
 import { MOD_EVENTS } from '@/mod-event/constants'
 import { SOCIAL_APP_URL } from '@/lib/constants'
 import { ReplyParent } from './ReplyParent'
+import { ImageList } from './ImageList'
 
 export function PostsFeed({
   items,
@@ -217,6 +222,7 @@ function ImageAltText({ alt }: { alt: string }) {
 }
 
 export function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
   const embed = AppBskyEmbedRecordWithMedia.isView(item.post.embed)
     ? item.post.embed.media
     : item.post.embed
@@ -237,21 +243,10 @@ export function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
     )
     return (
       <div className="flex gap-2 pb-2 pl-14">
-        {embed.images.map((image, i) => (
-          <a
-            key={`img-${i}`}
-            href={image.fullsize}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <img
-              className={embeddedImageClassName}
-              src={image.thumb}
-              alt={image.alt}
-            />
-            <ImageAltText alt={image.alt} />
-          </a>
-        ))}
+        <ImageList
+          images={embed.images}
+          imageClassName={embeddedImageClassName}
+        />
       </div>
     )
   }

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -9,10 +9,6 @@ import {
   AppBskyEmbedRecord,
 } from '@atproto/api'
 import Link from 'next/link'
-import Lightbox from 'yet-another-react-lightbox'
-import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails'
-import 'yet-another-react-lightbox/styles.css'
-import 'yet-another-react-lightbox/plugins/thumbnails.css'
 import {
   DocumentMagnifyingGlassIcon,
   ExclamationCircleIcon,
@@ -211,18 +207,7 @@ function PostContent({
 const getImageSizeClass = (imageCount: number) =>
   imageCount < 3 ? 'w-32 h-32' : 'w-20 h-20'
 
-function ImageAltText({ alt }: { alt: string }) {
-  if (!alt) return null
-  return (
-    <p className="leading-2 text-gray-400 text-xs leading-3 mt-1">
-      <InformationCircleIcon className="w-4 h-4 inline mr-1" />
-      {alt}
-    </p>
-  )
-}
-
 export function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
-  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
   const embed = AppBskyEmbedRecordWithMedia.isView(item.post.embed)
     ? item.post.embed.media
     : item.post.embed

--- a/components/common/posts/PostsTable.tsx
+++ b/components/common/posts/PostsTable.tsx
@@ -12,6 +12,7 @@ import { isRepost } from '@/lib/types'
 import { doesLabelNeedBlur } from '../labels'
 import { classNames } from '@/lib/util'
 import { ReplyParent } from './ReplyParent'
+import { ImageList } from './ImageList'
 
 export function PostsTable({
   items,
@@ -155,16 +156,10 @@ function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
     )
     return (
       <span className="flex gap-2 pt-2">
-        {embed.images.map((image, i) => (
-          <a
-            key={`img-${i}`}
-            href={image.fullsize}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <img className={embeddedImageClassName} src={image.thumb} />
-          </a>
-        ))}
+        <ImageList
+          images={embed.images}
+          imageClassName={embeddedImageClassName}
+        />
       </span>
     )
   }

--- a/components/list/RecordCard.tsx
+++ b/components/list/RecordCard.tsx
@@ -53,7 +53,7 @@ export const ListRecordCard = ({ uri }: { uri: string }) => {
           />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
             <>
               <Link
                 href={`/repositories/${uri?.replace('at://', '')}`}
@@ -63,7 +63,9 @@ export const ListRecordCard = ({ uri }: { uri: string }) => {
               </Link>
               <span className="ml-1">by</span>
               <Link href={`/repositories/${creator.did}`}>
-                <span className="ml-1 text-gray-500">@{creator.handle}</span>
+                <span className="ml-1 text-gray-500 dark:text-gray-50">
+                  @{creator.handle}
+                </span>
               </Link>
             </>{' '}
             &nbsp;&middot;&nbsp;
@@ -81,10 +83,10 @@ export const ListRecordCard = ({ uri }: { uri: string }) => {
           </p>
         </div>
       </div>
-      <div className="pb-2 pl-10">
-        {description && <p className="text-sm text-gray-500">{description}</p>}
+      <div className="pb-2 pl-10 text-gray-500 dark:text-gray-50">
+        {description && <p className="text-sm">{description}</p>}
         {!!meta.length && (
-          <p className="text-sm text-gray-500">{meta.join(' - ')}</p>
+          <p className="text-sm">{meta.join(' - ')}</p>
         )}
       </div>
     </div>

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -49,8 +49,11 @@ export function takesKeyboardEvt(el?: EventTarget | null) {
   if (!el) return false
   const htmlEl = el as HTMLElement
   return (
-    ['TEXTAREA', 'INPUT', 'SELECT'].includes(htmlEl.tagName) &&
-    !htmlEl.getAttribute('disabled')
+    (['TEXTAREA', 'INPUT', 'SELECT'].includes(htmlEl.tagName) &&
+      !htmlEl.getAttribute('disabled')) ||
+    // We open images from posts in modal windows and the modals are wrapped in this class
+    // so we want to make sure users can navigate within the image modal without navigating within the queue
+    htmlEl.classList.contains('yarl__container')
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-use": "^17.4.0",
     "remark": "^14.0.3",
     "remark-html": "^15.0.2",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "yet-another-react-lightbox": "^3.20.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4888,6 +4888,11 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
+yet-another-react-lightbox@^3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/yet-another-react-lightbox/-/yet-another-react-lightbox-3.20.0.tgz#cb7ecb7372fbdfbb3a55d12e81f2131b265134c3"
+  integrity sha512-Ty0yrqfVJ5XVq0gr1EmN31Ng5gkjC79RePrtzqGi/Xn+erwiuzEDTmKqbO9pDqrfb05xfow2NwWcp3auk4RVuQ==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"


### PR DESCRIPTION
This PR introduces a lightbox plugin to open images within a modal instead of opening them in a new tab. This allows moderators to view and navigate images in full size.
The plugin being used is https://yet-another-react-lightbox.com/

While testing, I also found a few UI issues with text color being off in some places so those were fixed too.

<img width="1342" alt="Screenshot 2024-06-14 at 21 52 55" src="https://github.com/bluesky-social/ozone/assets/1919066/33d35d24-c4c9-43d7-8f58-5679d43687bb">

> Screenshot from a post's image being opened in lightbox showing thumbnails and alt text as caption