### PR TITLE
:sparkles: Add Repost, quote, media and no reply filters to author feed

### DIFF
--- a/components/common/feeds/AuthorFeed.tsx
+++ b/components/common/feeds/AuthorFeed.tsx
@@ -4,6 +4,66 @@ import { Posts } from '../posts/Posts'
 import client from '@/lib/client'
 import { useState } from 'react'
 import { useRepoAndProfile } from '@/repositories/useRepoAndProfile'
+import { AppBskyFeedDefs } from '@atproto/api'
+import { TypeFilterKey, TypeFiltersByKey } from '../posts/constants'
+
+const getAuthorFeed = async ({ id, pageParam, typeFilter, options }) => {
+  const limit = 30
+  let filteredFeed: AppBskyFeedDefs.FeedViewPost[] = []
+  let cursor = pageParam
+  const isPostFilter = [
+    TypeFiltersByKey.posts_no_replies.key,
+    TypeFiltersByKey.posts_with_media.key,
+  ].includes(typeFilter)
+  const isQuoteOrRepostFilter = [
+    TypeFiltersByKey.reposts.key,
+    TypeFiltersByKey.quotes.key,
+    TypeFiltersByKey.quotes_and_reposts.key,
+  ].includes(typeFilter)
+
+  while (filteredFeed.length < limit) {
+    const { data } = await client.api.app.bsky.feed.getAuthorFeed(
+      {
+        limit,
+        actor: id,
+        cursor,
+        ...(isPostFilter ? { filter: typeFilter } : {}),
+      },
+      options,
+    )
+
+    // Only repost/quote post filters are applied on the client side
+    if (!isQuoteOrRepostFilter) {
+      return data
+    }
+
+    const newFilteredItems = data.feed.filter((item) => {
+      const isRepost = item.reason?.$type === 'app.bsky.feed.defs#reasonRepost'
+      const isQuotePost =
+        item.post.embed?.$type === 'app.bsky.embed.record#view'
+      if (typeFilter === TypeFiltersByKey.reposts.key) {
+        return isRepost
+      }
+      if (typeFilter === TypeFiltersByKey.quotes.key) {
+        // When a quoted post is reposted, we don't want to consider that a quote post
+        return isQuotePost && !isRepost
+      }
+      return isRepost || isQuotePost
+    })
+
+    filteredFeed = [...filteredFeed, ...newFilteredItems]
+
+    // If no more items are available, break the loop to prevent infinite requests
+    if (!data.cursor) {
+      break
+    }
+
+    cursor = data.cursor
+  }
+
+  // Ensure the feed is exactly 30 items if there are more than 30
+  return { feed: filteredFeed, cursor }
+}
 
 export function AuthorFeed({
   id,
@@ -13,9 +73,10 @@ export function AuthorFeed({
   onReport: (uri: string) => void
 }) {
   const [query, setQuery] = useState('')
+  const [typeFilter, setTypeFilter] = useState<TypeFilterKey>('no_filter')
   const { data: repoData } = useRepoAndProfile({ id })
   const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
-    queryKey: ['authorFeed', { id, query }],
+    queryKey: ['authorFeed', { id, query, typeFilter }],
     queryFn: async ({ pageParam }) => {
       const options = { headers: client.proxyHeaders() }
       const searchPosts = query.length && repoData?.repo.handle
@@ -30,14 +91,12 @@ export function AuthorFeed({
         )
         return { ...data, feed: data.posts.map((post) => ({ post })) }
       } else {
-        const { data } = await client.api.app.bsky.feed.getAuthorFeed(
-          {
-            actor: id,
-            limit: 30,
-            cursor: pageParam,
-          },
+        const data = await getAuthorFeed({
+          id,
+          pageParam,
+          typeFilter,
           options,
-        )
+        })
         return data
       }
     },
@@ -48,10 +107,13 @@ export function AuthorFeed({
   return (
     <Posts
       items={items}
+      searchQuery={query}
       setSearchQuery={setQuery}
       onReport={onReport}
       isFetching={isFetching}
       onLoadMore={hasNextPage ? () => fetchNextPage() : undefined}
+      typeFilter={typeFilter}
+      setTypeFilter={setTypeFilter}
     />
   )
 }

--- a/components/common/posts/Filter.tsx
+++ b/components/common/posts/Filter.tsx
@@ -1,0 +1,34 @@
+import { ChevronDownIcon } from '@heroicons/react/24/solid'
+import { Dropdown } from '../Dropdown'
+import { TypeFilterKey, TypeFiltersByKey } from './constants'
+
+export const PostFilter = ({
+  selectedType = 'no_filter',
+  setSelectedType,
+}: {
+  selectedType: TypeFilterKey
+  setSelectedType: (type: TypeFilterKey) => void
+}) => {
+  const selectedText = TypeFiltersByKey[selectedType].text
+
+  return (
+    <div className="flex gap-1">
+      <Dropdown
+        className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+        items={Object.values(TypeFiltersByKey).map(({ key, text }) => ({
+          text,
+          id: key,
+          onClick: () => setSelectedType(key),
+        }))}
+        data-cy="post-type-selector"
+      >
+        {selectedText}
+
+        <ChevronDownIcon
+          className="ml-2 -mr-1 h-5 w-5 text-violet-200 hover:text-violet-100"
+          aria-hidden="true"
+        />
+      </Dropdown>
+    </div>
+  )
+}

--- a/components/common/posts/Posts.tsx
+++ b/components/common/posts/Posts.tsx
@@ -6,6 +6,9 @@ import { PostsTable } from './PostsTable'
 import { ButtonGroup } from '../buttons'
 import { EmptyFeed } from '../feeds/EmptyFeed'
 import { Input } from '../forms'
+import { PostFilter } from './Filter'
+import { TypeFilterKey } from './constants'
+import { Loading } from '../Loader'
 
 enum Mode {
   Feed,
@@ -17,29 +20,42 @@ export function Posts({
   onReport,
   onLoadMore,
   isFetching,
+  searchQuery,
   setSearchQuery,
+  typeFilter,
+  setTypeFilter,
 }: {
   items: AppBskyFeedDefs.FeedViewPost[]
   onReport: (uri: string) => void
   onLoadMore?: () => void
   isFetching: boolean
+  searchQuery: string
   setSearchQuery: (query: string) => void
+  typeFilter: TypeFilterKey
+  setTypeFilter: (type: TypeFilterKey) => void
 }) {
   const [mode, setMode] = useState<Mode>(Mode.Feed)
 
   return (
     <div>
       <div className="bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-slate-700 px-4 sticky top-0">
-        <div className="mx-auto max-w-3xl w-full sm:py-4 sm:px-6 lg:px-8 sm:flex sm:items-center sm:justify-between ">
-          <div className="w-2/3">
+        <div className="mx-auto max-w-3xl w-full py-4 sm:px-6 lg:px-8 sm:flex sm:items-start sm:justify-between ">
+          <div className="sm:w-2/3 flex gap-1">
             <Input
               name="search"
-              className="w-full p-2"
+              value={searchQuery}
+              className="sm:w-1/3 md:w-2/3 p-2"
               placeholder="Type keyword to search..."
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {!searchQuery && (
+              <PostFilter
+                selectedType={typeFilter}
+                setSelectedType={setTypeFilter}
+              />
+            )}
           </div>
-          <div className="sm:flex mt-3 sm:mt-0 sm:ml-4">
+          <div className="sm:flex mt-3 sm:mt-0">
             <ButtonGroup
               appearance="primary"
               items={[
@@ -85,6 +101,7 @@ export function Posts({
               onLoadMore={onLoadMore}
             />
           )}
+          {isFetching && <Loading />}
         </>
       )}
     </div>

--- a/components/common/posts/constants.ts
+++ b/components/common/posts/constants.ts
@@ -1,0 +1,22 @@
+export type TypeFilterKey =
+  | 'no_filter'
+  | 'posts_no_replies'
+  | 'posts_with_media'
+  | 'reposts'
+  | 'quotes'
+  | 'quotes_and_reposts'
+
+export const TypeFiltersByKey: Record<
+  TypeFilterKey,
+  { key: TypeFilterKey; text: string }
+> = {
+  no_filter: { key: 'no_filter', text: 'No Filter' },
+  posts_no_replies: { key: 'posts_no_replies', text: 'Exclude replies' },
+  posts_with_media: { key: 'posts_with_media', text: 'Media Only' },
+  reposts: { key: 'reposts', text: 'Reposts Only' },
+  quotes: { key: 'quotes', text: 'Quotes Only' },
+  quotes_and_reposts: {
+    key: 'quotes_and_reposts',
+    text: 'Quotes & Reposts Only',
+  },
+}


### PR DESCRIPTION
This PR adds new filters for moderators to view specific types of posts from a user, such as excluding replies, showing media only, reposts only, and quotes only posts. Some of the filtering happens client-side and mutually exclusive with the existing keyword search due to differing data sources.

https://github.com/bluesky-social/ozone/assets/1919066/1242e2a3-4951-4c6f-9dd7-b7d83cf3a7be

