### PR TITLE
:bug: Fix permission fetching

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -629,7 +629,6 @@ function Form(
                     selectedAction={modEventType}
                     isSubjectDid={isSubjectDid}
                     hasBlobs={!!record?.blobs?.length}
-                    serverConfig={client.session.serverConfig}
                     setSelectedAction={(action) => setModEventType(action)}
                   />
                   <ModEventDetailsPopover modEventType={modEventType} />

--- a/app/communication-template/page.tsx
+++ b/app/communication-template/page.tsx
@@ -13,6 +13,7 @@ import { CommunicationTemplateDeleteConfirmationModal } from 'components/communi
 import { ActionButton, LinkButton } from '@/common/buttons'
 import client from '@/lib/client'
 import { ErrorInfo } from '@/common/ErrorInfo'
+import { checkPermission } from '@/lib/server-config'
 
 export default function CommunicationTemplatePage() {
   const { data, error, isLoading } = useCommunicationTemplateList({})
@@ -24,7 +25,7 @@ export default function CommunicationTemplatePage() {
     : []
   useTitle(`Communication Templates`)
 
-  if (!client.session.serverConfig?.permissions.canManageTemplates) {
+  if (!checkPermission('canManageTemplates')) {
     return (
       <ErrorInfo type="warn">
         Sorry, you don{"'"}t have permission to manage communication templates.

--- a/components/config/Member.tsx
+++ b/components/config/Member.tsx
@@ -19,7 +19,7 @@ export function MemberConfig() {
       setShowMemberCreateForm(false)
     }
   }
-  const canManageTeam = client.session?.serverConfig
+  const { canManageTeam } = client.session.serverConfig?.permissions || {}
 
   return (
     <div className="pt-4">

--- a/components/config/Member.tsx
+++ b/components/config/Member.tsx
@@ -1,5 +1,6 @@
 import { ActionButton } from '@/common/buttons'
 import client from '@/lib/client'
+import { checkPermission } from '@/lib/server-config'
 import { ToolsOzoneTeamDefs } from '@atproto/api'
 import { PlusIcon } from '@heroicons/react/24/outline'
 import { MemberEditor } from 'components/team/MemberEditor'
@@ -19,7 +20,7 @@ export function MemberConfig() {
       setShowMemberCreateForm(false)
     }
   }
-  const { canManageTeam } = client.session.serverConfig?.permissions || {}
+  const canManageTeam = checkPermission('canManageTeam')
 
   return (
     <div className="pt-4">

--- a/components/repositories/AccountView.tsx
+++ b/components/repositories/AccountView.tsx
@@ -44,6 +44,7 @@ import { EmptyDataset } from '@/common/feeds/EmptyFeed'
 import { MuteReporting } from './MuteReporting'
 import { Tabs, TabView } from '@/common/Tabs'
 import { Lists } from 'components/list/Lists'
+import { checkPermission } from '@/lib/server-config'
 
 enum Views {
   Details,
@@ -149,7 +150,7 @@ export function AccountView({
       { view: Views.Events, label: 'Events' },
     )
 
-    if (client.session.serverConfig?.permissions.canSendEmail) {
+    if (checkPermission('canSendEmail')) {
       views.push({ view: Views.Email, label: 'Email' })
     }
 

--- a/cypress/e2e/cmd-palette/main.cy.ts
+++ b/cypress/e2e/cmd-palette/main.cy.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />"
 
+import { mockServerConfigResponse } from '../../support/api'
+
 describe('Command Palette', () => {
   const SERVER_URL = 'https://bsky.social/xrpc'
   const PLC_URL = 'https://plc.directory'
@@ -62,6 +64,10 @@ describe('Command Palette', () => {
     mockOzoneDidDataResponse({
       statusCode: 200,
       body: authFixture.ozoneDidDataResponse,
+    })
+    mockServerConfigResponse({
+      statusCode: 200,
+      body: authFixture.ozoneServerConfigResponse,
     })
   }
 

--- a/cypress/fixtures/auth.json
+++ b/cypress/fixtures/auth.json
@@ -61,5 +61,22 @@
   },
   "createResolveHandleResponse": {
     "did":"did:plc:56ud7t6bqdkwblmzwmkcetst"
+  },
+  "ozoneServerConfigResponse": {
+      "appview": {
+          "url": "http://localhost:2581"
+      },
+      "blobDivert": {
+          "url": "http://localhost:2588"
+      },
+      "pds": {
+          "url": "http://localhost:2583"
+      },
+      "chat": {
+          "url": "http://localhost:2592"
+      },
+      "viewer": {
+          "role": "tools.ozone.team.defs#roleAdmin"
+      }
   }
 }

--- a/cypress/support/api.ts
+++ b/cypress/support/api.ts
@@ -44,6 +44,8 @@ export const mockOzoneMetaResponse = (response: Record<string, any>) =>
   cy.intercept('GET', '/.well-known/ozone-metadata.json', response)
 export const mockOzoneDidDataResponse = (response: Record<string, any>) =>
   cy.intercept('GET', `${PLC_URL}/*/data`, response)
+export const mockServerConfigResponse = (response: Record<string, any>) =>
+  cy.intercept('GET', `${SERVER_URL}/tools.ozone.server.getConfig*`, response)
 
 export const mockEmitEventResponse = (response: {
   statusCode: number

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -4,6 +4,7 @@ import {
   mockProfileResponse,
   mockOzoneMetaResponse,
   mockOzoneDidDataResponse,
+  mockServerConfigResponse,
   API_URL,
 } from './api'
 
@@ -15,11 +16,16 @@ Cypress.Commands.add(
     getProfileResponse: any
     ozoneMetaResponse: any
     ozoneDidDataResponse: any
+    ozoneServerConfigResponse: any
   }) => {
     // Setup the auth response
     mockAuthResponse({
       statusCode: 200,
       body: authFixture.createSessionResponse,
+    })
+    mockServerConfigResponse({
+      statusCode: 200,
+      body: authFixture.ozoneServerConfigResponse,
     })
     mockRepoResponse({
       statusCode: 200,

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -13,6 +13,7 @@ declare namespace Cypress {
       getProfileResponse: any
       ozoneMetaResponse: any
       ozoneDidDataResponse: any
+      ozoneServerConfigResponse: any
     }): Chainable<any>
   }
 }

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,4 +1,5 @@
 import { ToolsOzoneServerGetConfig, ToolsOzoneTeamDefs } from '@atproto/api'
+import client from './client'
 
 export type ServerConfig = {
   pds?: string
@@ -13,6 +14,7 @@ export type ServerConfig = {
     canSendEmail: boolean
     canManageTeam: boolean
     canTakedownFeedGenerators: boolean
+    canDivertBlob: boolean
   }
 }
 
@@ -36,6 +38,19 @@ export const parseServerConfig = (
       canSendEmail: !!config.pds?.url && isModerator,
       canManageTeam: isAdmin,
       canTakedownFeedGenerators: isAdmin,
+      canDivertBlob: !!config.blobDivert?.url && isModerator,
     },
+  }
+}
+
+export const checkPermission = (
+  permission: keyof ServerConfig['permissions'],
+) => {
+  try {
+    return client.session.serverConfig?.permissions[permission]
+  } catch (e) {
+    // Trying to access client.session while unauthenticated throws an error in which case,
+    // we can safely assume the user does not have the permission
+    return false
   }
 }


### PR DESCRIPTION
Since next.js generates static pages on build, attempting to access `client.session` in any of the paths that may get rendered in the static build triggers an auth error. So, this PR refactors the permission checks into a helper function that handles said error.