### PR TITLE
:sparkles: Add typeahead search in cmd palette

### DIFF
--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -360,9 +360,7 @@ export function RecordEmbedView({
               className="hover:underline"
             >
               {embed.record.name ? (
-                <>
-                  <span className="font-bold">{embed.record.name}</span>
-                </>
+                <span className="font-bold">{embed.record.name}</span>
               ) : (
                 <span className="font-bold">
                   @{embed.record.creator.handle}

--- a/components/repositories/useSearchActorsTypeahead.tsx
+++ b/components/repositories/useSearchActorsTypeahead.tsx
@@ -1,0 +1,17 @@
+import client from '@/lib/client'
+import { useQuery } from '@tanstack/react-query'
+
+export const useSearchActorsTypeahead = (query: string) => {
+  const q = query.startsWith('@') ? query.slice(1) : query
+  return useQuery({
+    queryKey: ['searchActorsTypeahead', { q }],
+    cacheTime: 1000 * 60 * 5,
+    queryFn: async () => {
+      const { data } = await client.api.app.bsky.actor.searchActorsTypeahead(
+        { q },
+        { headers: client.proxyHeaders() },
+      )
+      return data.actors
+    },
+  })
+}


### PR DESCRIPTION
Backend PR needs to be merged first https://github.com/bluesky-social/atproto/pull/2612

This PR triggers a user typeahead search from command palette when the search query starts with @ allowing moderators to look at a list of users and pick one to action on.

https://github.com/bluesky-social/ozone/assets/1919066/704e5c7b-6bda-4346-9900-39a34b32fd79

