### PR TITLE
:sparkles: Close image viewer lightbox when backdrop is clicked

### DIFF
--- a/components/common/posts/ImageList.tsx
+++ b/components/common/posts/ImageList.tsx
@@ -36,6 +36,7 @@ export const ImageList = ({
         open={isImageViewerOpen}
         plugins={[Thumbnails, Captions]}
         carousel={{ finite: true }}
+        controller={{ closeOnBackdropClick: true }}
         close={() => setIsImageViewerOpen(false)}
         slides={images.map((img) => ({
           src: img.fullsize,


### PR DESCRIPTION
This was requested by the mod team and I think it also aligns with current behavior of headless ui Dialogs.