### PR TITLE
:bug: Don't show external label in label selector

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -670,8 +670,8 @@ function Form(
                       name="labels"
                       formId={FORM_ID}
                       defaultLabels={currentLabels.filter((label) => {
-                        const serviceDid = client.getServiceDid()
-                        const isExternalLabel = allLabels.find((l) => {
+                        const serviceDid = client.getServiceDid()?.split('#')[0]
+                        const isExternalLabel = allLabels.some((l) => {
                           return l.val === label && l.src !== serviceDid
                         })
                         return !isSelfLabel(label) && !isExternalLabel

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -669,9 +669,13 @@ function Form(
                       id="labels"
                       name="labels"
                       formId={FORM_ID}
-                      defaultLabels={currentLabels.filter(
-                        (label) => !isSelfLabel(label),
-                      )}
+                      defaultLabels={currentLabels.filter((label) => {
+                        const serviceDid = client.getServiceDid()
+                        const isExternalLabel = allLabels.find((l) => {
+                          return l.val === label && l.src !== serviceDid
+                        })
+                        return !isSelfLabel(label) && !isExternalLabel
+                      })}
                     />
                   </div>
                 )}

--- a/cypress/fixtures/seed.json
+++ b/cypress/fixtures/seed.json
@@ -37,7 +37,7 @@
                   "labels":[
                       {
                           "ver":1,
-                          "src":"did:plc:4wke3qtisoohr7tf6vfhe5r2",
+                          "src":"did:plc:ozone",
                           "uri":"did:plc:jttgywq7eusytkmurmjbum6h",
                           "val":"impersonation",
                           "cts":"2024-05-13T14:35:09.154Z",
@@ -148,7 +148,7 @@
               "labels": [
                 {
                   "ver": 1,
-                  "src": "did:plc:ar7c4by46qjdydhdevvrndac",
+                  "src": "did:plc:ozone",
                   "uri": "at://did:plc:jttgywq7eusytkmurmjbum6h/app.bsky.actor.profile/self",
                   "cid": "bafyreifar3ib273ksyfwp4faluaj32aahuc6u2pdnxaygzbkqdhrjejhhi",
                   "val": "porn",
@@ -160,7 +160,7 @@
       
                 {
                   "ver": 1,
-                  "src": "did:plc:ar7c4by46qjdydhdevvrndac",
+                  "src": "did:plc:ozone",
                   "uri": "at://did:plc:jttgywq7eusytkmurmjbum6h/app.bsky.actor.profile/self",
                   "cid": "bafyreifar3ib273xczfwp4faluaj32aahuc6u2pdnxaygzbkqdhrjejhhi",
                   "val": "porn",


### PR DESCRIPTION
When taking label action, the label selector shows all labels that are currently applied on the subject and as a result, any label applied by an external labeler can be `unselected`. However, in reality, this doesn't do anything since one can not remove a label applied by an external labeler. 

To reduce confusion around this, this PR removes external labelers from label selector.