### PR TITLE
:bug: Only use recognized values for appealed query param

### DIFF
--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -330,10 +330,10 @@ function useModerationQueueQuery() {
         queryParams.onlyMuted = onlyMuted
       }
 
-      if (appealed) {
-        // If not specifically set to true but there is a value, we can default to false
-        // No value will pass undefined which will be ignored
-        queryParams.appealed = appealed === 'true'
+      if (appealed === 'true') {
+        queryParams.appealed = true
+      } else if (appealed === 'false') {
+        queryParams.appealed = false
       }
 
       if (tags) {


### PR DESCRIPTION
Addressing this scenario https://github.com/bluesky-social/ozone/pull/170#discussion_r1742276536