### PR TITLE
:lipstick: Make graphic media less visible

### DIFF
--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -237,7 +237,7 @@ export const ReportsPageContent = () => {
         </div>
       </SectionHeader>
       <div className="md:flex mt-2 mb-2 flex-row justify-between px-4 sm:px-6 lg:px-8">
-        <div className='flex flex-row items-center gap-2'>
+        <div className="flex flex-row items-center gap-2">
           <LanguagePicker />
           <EmbedTypePickerForModerationQueue />
         </div>
@@ -382,7 +382,7 @@ const getQueueItems = async (
   queueName: string | null,
   attempt = 0,
 ) => {
-  const pageSize = 50
+  const pageSize = 100
   const { data } = await labelerAgent.tools.ozone.moderation.queryStatuses({
     limit: pageSize,
     includeMuted: true,

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -382,7 +382,7 @@ const getQueueItems = async (
   queueName: string | null,
   attempt = 0,
 ) => {
-  const pageSize = 100
+  const pageSize = 50
   const { data } = await labelerAgent.tools.ozone.moderation.queryStatuses({
     limit: pageSize,
     includeMuted: true,

--- a/components/common/labels/util.ts
+++ b/components/common/labels/util.ts
@@ -72,6 +72,11 @@ export const labelsRequiringMediaFilter = [
 ]
 
 export type GraphicMediaFilter = 'blur' | 'grayscale' | 'translucent'
+export const GraphicMediaFilterOptions = [
+  'blur',
+  'grayscale',
+  'translucent',
+] as const
 
 export const buildGraphicPreferenceKeyForLabel = (
   label: string,

--- a/components/common/labels/util.ts
+++ b/components/common/labels/util.ts
@@ -64,7 +64,7 @@ export const LabelGroupInfo: Record<string, { color: string }> = {
   },
 }
 
-export const labelsRequiringBlur = [
+export const labelsRequiringMediaFilter = [
   LABELS['graphic-media'].identifier,
   LABELS.porn.identifier,
   LABELS.nudity.identifier,

--- a/components/common/labels/util.ts
+++ b/components/common/labels/util.ts
@@ -64,17 +64,21 @@ export const LabelGroupInfo: Record<string, { color: string }> = {
   },
 }
 
-const labelsRequiringBlur = [
+export const labelsRequiringBlur = [
   LABELS['graphic-media'].identifier,
   LABELS.porn.identifier,
   LABELS.nudity.identifier,
   LABELS.sexual.identifier,
 ]
 
-export const doesLabelNeedBlur = (labels?: string[]): boolean =>
-  !!labels?.find((label) => labelsRequiringBlur.includes(label))
+export type GraphicMediaFilter = 'blur' | 'grayscale' | 'translucent'
 
-export const doesProfileNeedBlur = ({
+export const buildGraphicPreferenceKeyForLabel = (
+  label: string,
+  filter: GraphicMediaFilter,
+) => `graphic-pref-${filter}-${label}`
+
+export const getProfileAndRepoLabels = ({
   profile,
   repo,
 }: {
@@ -88,7 +92,7 @@ export const doesProfileNeedBlur = ({
   if (repo?.labels && Array.isArray(repo?.labels)) {
     labels.push(...repo.labels?.map(({ val }) => val))
   }
-  return doesLabelNeedBlur(labels)
+  return labels
 }
 
 export const getLabelsForSubject = ({

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -229,7 +229,7 @@ export function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
   )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
-    mediaRequiresBlur ? 'blur-sm hover:blur-none' : '',
+    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-40' : '',
   )
 
   if (AppBskyEmbedVideo.isView(embed)) {

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -229,7 +229,7 @@ export function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
   )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
-    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-40' : '',
+    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-50 grayscale' : '',
   )
 
   if (AppBskyEmbedVideo.isView(embed)) {

--- a/components/common/posts/PostsTable.tsx
+++ b/components/common/posts/PostsTable.tsx
@@ -146,7 +146,7 @@ function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
   )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
-    mediaRequiresBlur ? 'blur-sm hover:blur-none' : '',
+    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-40' : '',
   )
 
   if (AppBskyEmbedImages.isView(embed)) {

--- a/components/common/posts/PostsTable.tsx
+++ b/components/common/posts/PostsTable.tsx
@@ -9,10 +9,10 @@ import {
 import Link from 'next/link'
 import { LoadMore } from '../LoadMore'
 import { isRepost } from '@/lib/types'
-import { doesLabelNeedBlur } from '../labels'
 import { classNames } from '@/lib/util'
 import { ReplyParent } from './ReplyParent'
 import { ImageList } from './ImageList'
+import { useGraphicMediaPreferences } from '@/config/useLocalPreferences'
 
 export function PostsTable({
   items,
@@ -138,15 +138,19 @@ const getImageSizeClass = (imageCount: number) =>
 
 // @TODO record embeds
 function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
+  const { getMediaFiltersForLabels } = useGraphicMediaPreferences()
+
   const embed = AppBskyEmbedRecordWithMedia.isView(item.post.embed)
     ? item.post.embed.media
     : item.post.embed
-  const mediaRequiresBlur = doesLabelNeedBlur(
+  const mediaFilters = getMediaFiltersForLabels(
     item.post.labels?.map(({ val }) => val),
   )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
-    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-50 grayscale' : '',
+    mediaFilters.blur ? 'blur-sm hover:blur-none' : '',
+    mediaFilters.grayscale ? 'grayscale' : '',
+    mediaFilters.translucent ? 'opacity-50 ' : '',
   )
 
   if (AppBskyEmbedImages.isView(embed)) {

--- a/components/common/posts/PostsTable.tsx
+++ b/components/common/posts/PostsTable.tsx
@@ -146,7 +146,7 @@ function PostEmbeds({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
   )
   const imageClassName = classNames(
     `border border-gray-200 rounded`,
-    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-40' : '',
+    mediaRequiresBlur ? 'blur-sm hover:blur-none opacity-50 grayscale' : '',
   )
 
   if (AppBskyEmbedImages.isView(embed)) {

--- a/components/common/video/player.tsx
+++ b/components/common/video/player.tsx
@@ -2,19 +2,21 @@ import { getLanguageName } from '@/lib/locale/helpers'
 import { AppBskyEmbedVideo } from '@atproto/api'
 import Hls from 'hls.js/dist/hls.light' // Use light build of hls.
 import { useEffect, useId, useRef, useState } from 'react'
+import { GraphicMediaFilterPreference } from '@/config/useLocalPreferences'
+import { classNames } from '@/lib/util'
 
 export default function VideoPlayer({
   source,
   alt,
   thumbnail,
   captions,
-  shouldBlur = false,
+  mediaFilters,
 }: {
   source: string
   alt?: string
   thumbnail?: string
   captions: AppBskyEmbedVideo.Caption[]
-  shouldBlur?: boolean
+  mediaFilters: GraphicMediaFilterPreference
 }) {
   const [hls] = useState(() => new Hls())
   const [isUnsupported, setIsUnsupported] = useState(false)
@@ -58,12 +60,15 @@ export default function VideoPlayer({
         loop
         muted
         crossOrigin="anonymous"
-        className={`w-full flex-1 transition-all duration-300 ease-in-out ${
-          isHovered || !shouldBlur ? 'blur-none' : 'blur-md'
-        } ${shouldBlur ? 'grayscale opacity-50' : ''}`}
+        className={classNames(
+          `w-full flex-1 transition-all duration-300 ease-in-out`,
+          isHovered || !mediaFilters.blur ? 'blur-none' : 'blur-md',
+          mediaFilters.grayscale ? 'grayscale' : '',
+          mediaFilters.translucent ? 'opacity-50' : '',
+        )}
         aria-labelledby={alt ? figId : undefined}
       >
-        {!isHovered && shouldBlur && (
+        {!isHovered && mediaFilters.blur && (
           <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 text-white text-xl font-bold"></div>
         )}
         {isUnsupported && (

--- a/components/common/video/player.tsx
+++ b/components/common/video/player.tsx
@@ -60,7 +60,7 @@ export default function VideoPlayer({
         crossOrigin="anonymous"
         className={`w-full flex-1 transition-all duration-300 ease-in-out ${
           isHovered || !shouldBlur ? 'blur-none' : 'blur-md'
-        }`}
+        } ${shouldBlur ? 'grayscale opacity-50' : ''}`}
         aria-labelledby={alt ? figId : undefined}
       >
         {!isHovered && shouldBlur && (

--- a/components/config/Labeler.tsx
+++ b/components/config/Labeler.tsx
@@ -13,6 +13,7 @@ import { ExternalLabelerConfig } from './external-labeler'
 import { ServerConfig } from './server-config'
 import { useConfigurationContext } from '@/shell/ConfigurationContext'
 import { usePdsAgent } from '@/shell/AuthContext'
+import { LocalPreferences } from './LocalPreferences'
 
 const BrowserReactJsonView = dynamic(() => import('react-json-view'), {
   ssr: false,
@@ -39,6 +40,7 @@ export function LabelerConfig() {
       )}
 
       <ServerConfig />
+      <LocalPreferences />
       <ExternalLabelerConfig />
     </div>
   )

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -1,0 +1,91 @@
+import { ActionButton } from '@/common/buttons'
+import { Card } from '@/common/Card'
+import { Checkbox } from '@/common/forms'
+import {
+  buildGraphicPreferenceKeyForLabel,
+  GraphicMediaFilter,
+  LabelChip,
+  labelsRequiringBlur,
+} from '@/common/labels'
+import { useGraphicMediaPreferences } from './useLocalPreferences'
+import { toast } from 'react-toastify'
+
+const GraphicMediaPreferenceSelectorForLabel = ({
+  label,
+}: {
+  label: string
+}) => {
+  const { getPreference } = useGraphicMediaPreferences()
+
+  return (
+    <div className="my-2">
+      <LabelChip className="ml-0 mb-2">{label}</LabelChip>
+      {(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).map(
+        (filter) => {
+          const key = buildGraphicPreferenceKeyForLabel(label, filter)
+          return (
+            <Checkbox
+              defaultChecked={getPreference(key)}
+              label={filter}
+              className="capitalize"
+              name={key}
+              key={key}
+              value="on"
+            />
+          )
+        },
+      )}
+    </div>
+  )
+}
+
+export const LocalPreferences = () => {
+  const { getPreference, setPreferences } = useGraphicMediaPreferences()
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const preferences: Record<string, boolean> = {}
+    Array.from(formData.entries()).forEach(([key, value]) => {
+      preferences[key] = value === 'on'
+    })
+
+    setPreferences(preferences)
+    toast.success('Preferences saved successfully!')
+  }
+
+  return (
+    <>
+      <div className="flex flex-row justify-between my-4">
+        <h4 className="font-medium text-gray-700 dark:text-gray-100">
+          Preferences
+        </h4>
+      </div>
+      <Card className="mb-4 pb-4">
+        <p className="mb-1">Graphic media display</p>
+        <p className="text-sm mb-2">
+          You can choose to make media content with certain labels appear on
+          your screen with different filters.
+        </p>
+
+        <form onSubmit={handleSubmit}>
+          <div className="flex flex-row w-full gap-4 justify-between flex-wrap">
+            {labelsRequiringBlur.map((label) => {
+              return (
+                <GraphicMediaPreferenceSelectorForLabel
+                  key={label}
+                  label={label}
+                />
+              )
+            })}
+          </div>
+          <div className="mt-3 mb-2 flex flex-row justify-end">
+            <ActionButton appearance="primary" size="sm" type="submit">
+              Save Preferences
+            </ActionButton>
+          </div>
+        </form>
+      </Card>
+    </>
+  )
+}

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -5,7 +5,7 @@ import {
   buildGraphicPreferenceKeyForLabel,
   GraphicMediaFilter,
   LabelChip,
-  labelsRequiringBlur,
+  labelsRequiringMediaFilter,
 } from '@/common/labels'
 import { useGraphicMediaPreferences } from './useLocalPreferences'
 import { toast } from 'react-toastify'
@@ -64,13 +64,13 @@ export const LocalPreferences = () => {
       <Card className="mb-4 pb-4">
         <p className="mb-1">Graphic media display</p>
         <p className="text-sm mb-2">
-          You can choose to make media content with certain labels appear on
-          your screen with different filters.
+          You can choose to make media content (video and image) with the
+          following labels appear on your screen with your preferred filter.
         </p>
 
         <form onSubmit={handleSubmit}>
           <div className="flex flex-row w-full gap-4 justify-between flex-wrap">
-            {labelsRequiringBlur.map((label) => {
+            {labelsRequiringMediaFilter.map((label) => {
               return (
                 <GraphicMediaPreferenceSelectorForLabel
                   key={label}

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -39,7 +39,7 @@ const GraphicMediaPreferenceSelectorForLabel = ({
 }
 
 export const LocalPreferences = () => {
-  const { getPreference, setPreferences } = useGraphicMediaPreferences()
+  const { setPreferences } = useGraphicMediaPreferences()
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from '@/common/forms'
 import {
   buildGraphicPreferenceKeyForLabel,
   GraphicMediaFilter,
+  GraphicMediaFilterOptions,
   LabelChip,
   labelsRequiringMediaFilter,
 } from '@/common/labels'
@@ -20,21 +21,19 @@ const GraphicMediaPreferenceSelectorForLabel = ({
   return (
     <div className="my-2">
       <LabelChip className="ml-0 mb-2">{label}</LabelChip>
-      {(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).map(
-        (filter) => {
-          const key = buildGraphicPreferenceKeyForLabel(label, filter)
-          return (
-            <Checkbox
-              defaultChecked={getPreference(key)}
-              label={filter}
-              className="capitalize"
-              name={key}
-              key={key}
-              value="on"
-            />
-          )
-        },
-      )}
+      {GraphicMediaFilterOptions.map((filter) => {
+        const key = buildGraphicPreferenceKeyForLabel(label, filter)
+        return (
+          <Checkbox
+            defaultChecked={getPreference(key)}
+            label={filter}
+            className="capitalize"
+            name={key}
+            key={key}
+            value="on"
+          />
+        )
+      })}
     </div>
   )
 }

--- a/components/config/useLocalPreferences.tsx
+++ b/components/config/useLocalPreferences.tsx
@@ -1,0 +1,81 @@
+import {
+  buildGraphicPreferenceKeyForLabel,
+  labelsRequiringBlur,
+  GraphicMediaFilter,
+} from '@/common/labels'
+import { useLocalStorage } from 'react-use'
+
+export type GraphicMediaFilterPreference = Record<GraphicMediaFilter, boolean>
+
+// This is the container hook for interfacing on top of localstorage and storing device level preferences
+// There may be various types of preferences that can be stored here and ideally each preference category
+// will have its own hook that will utilize this
+export const useLocalPreferences = () => {
+  const initialValue: Record<string, Record<string, boolean>> = {
+    graphicMediaPrefs: {},
+  }
+
+  labelsRequiringBlur.forEach((label) => {
+    ;(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).forEach(
+      (filter) => {
+        initialValue.graphicMediaPrefs[
+          buildGraphicPreferenceKeyForLabel(label, filter)
+        ] = true
+      },
+    )
+  })
+
+  const [localPreferences, setLocalPreferences] = useLocalStorage(
+    'ozoneLocalPreferences',
+    initialValue,
+    {
+      raw: false,
+      serializer: JSON.stringify,
+      deserializer: (value) => {
+        try {
+          return JSON.parse(value)
+        } catch {
+          return {}
+        }
+      },
+    },
+  )
+
+  return { localPreferences, setLocalPreferences }
+}
+
+export const useGraphicMediaPreferences = () => {
+  const { localPreferences, setLocalPreferences } = useLocalPreferences()
+  return {
+    setPreferences: (graphicMediaPrefs: Record<string, boolean>) => {
+      setLocalPreferences({ ...localPreferences, graphicMediaPrefs })
+    },
+    getPreference: (key: string): boolean =>
+      !!localPreferences.graphicMediaPrefs?.[key],
+    getMediaFiltersForLabels: (
+      labels?: string[],
+    ): GraphicMediaFilterPreference => {
+      const filters = { blur: false, grayscale: false, translucent: false }
+
+      if (!labels?.length) {
+        return filters
+      }
+
+      labels.forEach((label) => {
+        ;(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).forEach(
+          (filter) => {
+            if (
+              !!localPreferences.graphicMediaPrefs?.[
+                buildGraphicPreferenceKeyForLabel(label, filter)
+              ]
+            ) {
+              filters[filter] = true
+            }
+          },
+        )
+      })
+
+      return filters
+    },
+  }
+}

--- a/components/config/useLocalPreferences.tsx
+++ b/components/config/useLocalPreferences.tsx
@@ -2,6 +2,7 @@ import {
   buildGraphicPreferenceKeyForLabel,
   labelsRequiringMediaFilter,
   GraphicMediaFilter,
+  GraphicMediaFilterOptions,
 } from '@/common/labels'
 import { useLocalStorage } from 'react-use'
 
@@ -16,13 +17,11 @@ export const useLocalPreferences = () => {
   }
 
   labelsRequiringMediaFilter.forEach((label) => {
-    ;(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).forEach(
-      (filter) => {
-        initialValue.graphicMediaPrefs[
-          buildGraphicPreferenceKeyForLabel(label, filter)
-        ] = true
-      },
-    )
+    GraphicMediaFilterOptions.forEach((filter) => {
+      initialValue.graphicMediaPrefs[
+        buildGraphicPreferenceKeyForLabel(label, filter)
+      ] = true
+    })
   })
 
   const [localPreferences, setLocalPreferences] = useLocalStorage(
@@ -71,17 +70,15 @@ export const useGraphicMediaPreferences = () => {
       }
 
       labels.forEach((label) => {
-        ;(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).forEach(
-          (filter) => {
-            if (
-              !!localPreferences.graphicMediaPrefs?.[
-                buildGraphicPreferenceKeyForLabel(label, filter)
-              ]
-            ) {
-              filters[filter] = true
-            }
-          },
-        )
+        GraphicMediaFilterOptions.forEach((filter) => {
+          if (
+            !!localPreferences.graphicMediaPrefs?.[
+              buildGraphicPreferenceKeyForLabel(label, filter)
+            ]
+          ) {
+            filters[filter] = true
+          }
+        })
       })
 
       return filters

--- a/components/config/useLocalPreferences.tsx
+++ b/components/config/useLocalPreferences.tsx
@@ -1,6 +1,6 @@
 import {
   buildGraphicPreferenceKeyForLabel,
-  labelsRequiringBlur,
+  labelsRequiringMediaFilter,
   GraphicMediaFilter,
 } from '@/common/labels'
 import { useLocalStorage } from 'react-use'
@@ -15,7 +15,7 @@ export const useLocalPreferences = () => {
     graphicMediaPrefs: {},
   }
 
-  labelsRequiringBlur.forEach((label) => {
+  labelsRequiringMediaFilter.forEach((label) => {
     ;(['blur', 'grayscale', 'translucent'] as GraphicMediaFilter[]).forEach(
       (filter) => {
         initialValue.graphicMediaPrefs[
@@ -58,6 +58,15 @@ export const useGraphicMediaPreferences = () => {
       const filters = { blur: false, grayscale: false, translucent: false }
 
       if (!labels?.length) {
+        return filters
+      }
+
+      // In case the preference key is not found, meaning something went wrong with storing/fetching the preferences from localstorage
+      // we want to make sure we apply the blur effect by default for labels that require media filter
+      if (!localPreferences?.graphicMediaPrefs) {
+        filters.blur = labels.some((label) =>
+          labelsRequiringMediaFilter.includes(label),
+        )
         return filters
       }
 

--- a/components/repositories/AccountView.tsx
+++ b/components/repositories/AccountView.tsx
@@ -56,6 +56,7 @@ import { useEmailRecipientStatus } from 'components/email/useEmailRecipientStatu
 import { Alert } from '@/common/Alert'
 import { Follows } from 'components/graph/Follows'
 import { Followers } from 'components/graph/Followers'
+import Lightbox from 'yet-another-react-lightbox'
 
 enum Views {
   Details,
@@ -256,6 +257,69 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   timeStyle: 'short',
 })
 
+function ProfileHeaderImage({
+  profile,
+}: {
+  profile?: GetProfile.OutputSchema
+}) {
+  const alt = `Banner image for ${
+    profile?.displayName || profile?.handle || 'user'
+  }`
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+    }
+  }
+  const image = (
+    <img
+      className="h-32 w-full object-cover lg:h-48"
+      src={profile?.banner || '/img/default-banner.jpg'}
+      alt={alt}
+    />
+  )
+
+  if (!profile?.banner) {
+    return <div>{image}</div>
+  }
+
+  return (
+    <div>
+      <Lightbox
+        open={isImageViewerOpen}
+        carousel={{ finite: true }}
+        controller={{ closeOnBackdropClick: true }}
+        close={() => setIsImageViewerOpen(false)}
+        slides={[
+          {
+            src: profile.banner,
+            description: alt,
+          },
+        ]}
+        on={{
+          // The lightbox may open from other Dialog/modal components
+          // in that case, we want to make sure that esc button presses
+          // only close the lightbox and not the parent Dialog/modal underneath
+          entered: () => {
+            document.addEventListener('keydown', handleKeyDown)
+          },
+          exited: () => {
+            document.removeEventListener('keydown', handleKeyDown)
+          },
+        }}
+      />
+      <button
+        type="button"
+        className="w-full active:outline-none"
+        onClick={() => setIsImageViewerOpen(true)}
+      >
+        {image}
+      </button>
+    </div>
+  )
+}
+
 function Header({
   id,
   repo,
@@ -340,13 +404,7 @@ function Header({
           did={`${repo?.did || profile?.did}`}
         />
       )}
-      <div>
-        <img
-          className="h-32 w-full object-cover lg:h-48"
-          src={profile?.banner || '/img/default-banner.jpg'}
-          alt=""
-        />
-      </div>
+      <ProfileHeaderImage profile={profile} />
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
         <div className="-mt-12 sm:-mt-16 sm:flex sm:items-end sm:space-x-5">
           <div className="flex">

--- a/components/repositories/ProfileAvatar.tsx
+++ b/components/repositories/ProfileAvatar.tsx
@@ -10,7 +10,10 @@ export const avatarClassNames = (
   additionalClassnames?: string,
 ) => {
   if (doesProfileNeedBlur(profileAndRepo)) {
-    return classNames(additionalClassnames, 'blur-sm hover:blur-none')
+    return classNames(
+      additionalClassnames,
+      'blur-sm hover:blur-none opacity-40',
+    )
   }
 
   return additionalClassnames


### PR DESCRIPTION
This PR adds a localstorage based preference that allows users to choose 3 possible filters on media content with certain labels. Previously, we were only applying a blur filter for all these labels and now, along with blur, media can be black and white and translucent, according to user's preference. 

**By Default we will apply all 3 filters for those labels**

<img width="579" alt="Screenshot 2024-09-20 at 23 21 46" src="https://github.com/user-attachments/assets/ba0416c9-1fb0-4db0-ae7f-f72f8a41c301">

> Dark mode

<img width="585" alt="Screenshot 2024-09-20 at 23 21 38" src="https://github.com/user-attachments/assets/537acbdc-b7d4-48ea-8609-6425c2604fca">

> Light mode

Additionally, this PR adds modal image viewer for profile avatar and profile banner image.