### PR TITLE
:sparkles: Allow taking subjects from event stream to workspace

### DIFF
--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -272,7 +272,7 @@ export const useModEventList = (
       }
     })
 
-    addItemsToWorkspace([...items])
+    return addItemsToWorkspace([...items])
   }
 
   return {

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -1,4 +1,5 @@
 import {
+  ChatBskyConvoDefs,
   ComAtprotoAdminDefs,
   ComAtprotoRepoStrongRef,
   ToolsOzoneModerationQueryEvents,
@@ -263,6 +264,8 @@ export const useModEventList = (
           items.add(event.subject.did)
         } else if (ComAtprotoRepoStrongRef.isMain(event.subject)) {
           items.add(event.subject.uri)
+        } else if (ChatBskyConvoDefs.isMessageRef(event.subject)) {
+          items.add(event.subject.did)
         }
       } else if (showWorkspaceConfirmation === 'creators') {
         items.add(event.createdBy)


### PR DESCRIPTION
This PR adds a `Add to workspace` workflow in the event stream. This helps moderator do bulk action/investigation using data from the event stream.


https://github.com/user-attachments/assets/55dc7dd9-04c3-4b40-95f1-dee2976a2a9f

