### PR TITLE
Update queue sharding so that it can be rebalanced using a seed

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,6 +14,8 @@ export const PLC_DIRECTORY_URL =
 
 export const QUEUE_CONFIG = process.env.NEXT_PUBLIC_QUEUE_CONFIG || '{}'
 
+export const QUEUE_SEED = process.env.NEXT_PUBLIC_QUEUE_SEED || ''
+
 export const SOCIAL_APP_URL =
   process.env.NEXT_PUBLIC_SOCIAL_APP_URL ||
   (process.env.NODE_ENV === 'development'

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -171,3 +171,13 @@ export function chunkArray<T>(arr: T[], chunkSize: number) {
   }
   return chunks
 }
+
+// @NOTE hash function is insecure, though suitable for basic purposes such as bucketing.
+export function simpleHash(str: string) {
+  let hash = 0
+  for (let i = 0; i < str.length; ++i) {
+    const chr = str.charCodeAt(i)
+    hash = ((hash << 5) - hash + chr) | 0
+  }
+  return hash
+}


### PR DESCRIPTION
This should allow us to rebalance queues if they get lopsided by adjusting the seed via `NEXT_PUBLIC_QUEUE_SEED`.  This will reshuffle content that appears in each queue.