### PR TITLE
:sparkles: Add search page

### DIFF
--- a/app/search/page-content.tsx
+++ b/app/search/page-content.tsx
@@ -1,0 +1,95 @@
+import { ActionButton } from '@/common/buttons'
+import { Dropdown } from '@/common/Dropdown'
+import { LoadMoreButton } from '@/common/LoadMoreButton'
+import { ConfirmationModal } from '@/common/modals/confirmation'
+import { PostAsCard } from '@/common/posts/PostsFeed'
+import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
+import { WorkspacePanel } from '@/workspace/Panel'
+import { useContentSearch } from 'components/search-content/useContentSearch'
+import { SectionHeader } from 'components/SectionHeader'
+import { useTitle } from 'react-use'
+
+const TABS = [
+  {
+    key: 'top',
+    name: 'Top',
+    href: `/search?section=top`,
+  },
+  {
+    key: 'latest',
+    name: 'Latest',
+    href: `/search?section=latest`,
+  },
+]
+
+export const SearchPageContent = ({
+  term,
+  section = 'top',
+}: {
+  term: string
+  section?: string
+}) => {
+  let pageTitle = `Search Content`
+  if (term) {
+    pageTitle += ` - ${term}`
+  }
+
+  useTitle(pageTitle)
+  const { posts, isLoading, fetchNextPage, hasNextPage, addToWorkspace } =
+    useContentSearch({
+      term,
+      section,
+    })
+  const { toggleWorkspacePanel, isWorkspaceOpen } = useWorkspaceOpener()
+
+  return (
+    <>
+      <SectionHeader title={'Search'} tabs={TABS} current={section}>
+        <div className="flex-1 lg:text-right lg:pr-2 pb-4 px-1 pt-5 lg:pt-0">
+          <Dropdown
+            containerClassName="inline-block"
+            rightAligned
+            className="inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-400 bg-white dark:bg-slate-800 dark:text-gray-100 dark px-4 py-2 text-sm text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+            items={[
+              {
+                id: 'add_users_to_workspace',
+                text: 'Add all posters',
+                onClick: () =>
+                  addToWorkspace(posts.map((post) => post.author.did)),
+              },
+              {
+                id: 'add_posts_to_workspace',
+                text: 'Add all posts',
+                onClick: () => addToWorkspace(posts.map((post) => post.uri)),
+              },
+            ]}
+          >
+            Add to workspace
+          </Dropdown>
+        </div>
+      </SectionHeader>
+
+      <div className="w-5/6 sm:w-3/4 md:w-2/3 lg:w-1/2 mx-auto my-4 dark:text-gray-100">
+        {posts.map((post) => (
+          <div className="mb-4" key={post.uri}>
+            <PostAsCard
+              className="bg-transparent px-3 py-2"
+              item={{ post }}
+              dense
+            />
+          </div>
+        ))}
+        {hasNextPage && (
+          <div className="flex justify-center mb-4">
+            <LoadMoreButton onClick={() => fetchNextPage()} />
+          </div>
+        )}
+      </div>
+
+      <WorkspacePanel
+        open={isWorkspaceOpen}
+        onClose={() => toggleWorkspacePanel()}
+      />
+    </>
+  )
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { Suspense } from 'react'
+import { SearchPageContent } from './page-content'
+
+export default function SearchHomePage({ searchParams }) {
+  return (
+    <Suspense fallback={<div></div>}>
+      <SearchPageContent
+        term={searchParams.term || ''}
+        section={searchParams.section}
+      />
+    </Suspense>
+  )
+}

--- a/components/common/feeds/AuthorFeed.tsx
+++ b/components/common/feeds/AuthorFeed.tsx
@@ -24,7 +24,7 @@ export const useAuthorFeedQuery = ({
     queryFn: async ({ pageParam }) => {
       const searchPosts = query.length && repoData?.repo.handle
       if (searchPosts) {
-        const { data } = await labelerAgent.api.app.bsky.feed.searchPosts({
+        const { data } = await labelerAgent.app.bsky.feed.searchPosts({
           q: `from:${repoData?.repo.handle} ${query}`,
           limit: 30,
           cursor: pageParam,

--- a/components/search-content/useContentSearch.tsx
+++ b/components/search-content/useContentSearch.tsx
@@ -1,0 +1,38 @@
+import { useLabelerAgent } from '@/shell/ConfigurationContext'
+import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+export const useContentSearch = ({
+  term,
+  section,
+}: {
+  term: string
+  section: string
+}) => {
+  const labelerAgent = useLabelerAgent()
+
+  const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
+
+  const searchInfo = useInfiniteQuery({
+    queryKey: ['searchContent', { term, section }],
+    enabled: !!term,
+    queryFn: async ({ pageParam }) => {
+      const { data } = await labelerAgent.app.bsky.feed.searchPosts({
+        q: term,
+        limit: 30,
+        sort: section,
+        cursor: pageParam,
+      })
+      return data
+    },
+    getNextPageParam: (lastPage) => lastPage.cursor,
+  })
+
+  const posts = searchInfo.data?.pages.flatMap((page) => page.posts) || []
+
+  return {
+    ...searchInfo,
+    posts,
+    addToWorkspace,
+  }
+}

--- a/components/shell/common.ts
+++ b/components/shell/common.ts
@@ -7,6 +7,7 @@ import {
   SunIcon,
   MoonIcon,
   WrenchScrewdriverIcon,
+  MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline'
 import { useKBar } from 'kbar'
 import { MouseEventHandler } from 'react'
@@ -20,6 +21,7 @@ export const ICONS = {
   sun: SunIcon,
   moon: MoonIcon,
   configure: WrenchScrewdriverIcon,
+  search: MagnifyingGlassIcon,
 }
 
 export type SidebarNavItem = {
@@ -50,14 +52,19 @@ export const NAV_ITEMS: SidebarNavItem[] = [
         kbar.query.toggle(),
   },
   {
-    name: 'Theme',
-    icon: 'sun',
-    onClick: ({ toggleTheme }) => toggleTheme,
+    name: 'Search',
+    href: '/search',
+    icon: 'search',
   },
   {
     name: 'Configure',
     href: '/configure',
     icon: 'configure',
+  },
+  {
+    name: 'Theme',
+    icon: 'sun',
+    onClick: ({ toggleTheme }) => toggleTheme,
   },
 ]
 


### PR DESCRIPTION
This PR adds a dedicated page to show top and latest posts for a search keyword which surfaces the same content as the app. This helps moderators to quickly find and proactively action content without having to go through the app.

<img width="1193" alt="Screenshot 2024-10-01 at 20 10 14" src="https://github.com/user-attachments/assets/2c161840-61b9-4d81-a2ad-5bc68d459213">

