### PR TITLE
Invert role order when adding new member

### DIFF
--- a/components/team/Role.tsx
+++ b/components/team/Role.tsx
@@ -2,9 +2,9 @@ import { LabelChip } from '@/common/labels'
 import { ToolsOzoneTeamDefs } from '@atproto/api'
 
 export const MemberRoleNames = {
-  [ToolsOzoneTeamDefs.ROLEADMIN]: 'Admin',
-  [ToolsOzoneTeamDefs.ROLEMODERATOR]: 'Moderator',
   [ToolsOzoneTeamDefs.ROLETRIAGE]: 'Triage',
+  [ToolsOzoneTeamDefs.ROLEMODERATOR]: 'Moderator',
+  [ToolsOzoneTeamDefs.ROLEADMIN]: 'Admin',
 }
 
 const getRoleText = (role: ToolsOzoneTeamDefs.Member['role']) => {


### PR DESCRIPTION
New members are normally added as "triage". The current ordering of the role dropdown uses "admin" is a default. This just inverts the order so that the default is to onboard someone with the least permissions