### PR TITLE
Prevent use of another user's server-config

### DIFF
--- a/components/shell/ConfigContext.tsx
+++ b/components/shell/ConfigContext.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
-import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react'
-import { useLocalStorage } from 'react-use'
+import { createContext, ReactNode, useContext, useMemo } from 'react'
 
 import { Loading } from '@/common/Loader'
 import { SetupModal } from '@/common/SetupModal'
 import { getConfig, OzoneConfig } from '@/lib/client-config'
+import { useStoredQuery } from '@/lib/useStoredQuery'
 import { GLOBAL_QUERY_CONTEXT } from './QueryClient'
 
 export type ConfigContextData = {
@@ -18,36 +17,42 @@ export type ConfigContextData = {
 const ConfigContext = createContext<ConfigContextData | null>(null)
 
 export const ConfigProvider = ({ children }: { children: ReactNode }) => {
-  const [cachedConfig, setCachedConfig] =
-    useLocalStorage<OzoneConfig>('labeler-config')
-
-  const { data, error, refetch } = useQuery<OzoneConfig, Error>({
+  const { data, error, refetch } = useStoredQuery({
     // Use the global query client to avoid clearing the cache when the user
     // changes.
     context: GLOBAL_QUERY_CONTEXT,
-    retry: (failureCount: number, error: Error): boolean => {
-      // TODO: change getConfig() to throw a specific error when a network
-      // error occurs, so we can distinguish between network errors and
-      // configuration errors.
-      return false
-    },
+    // TODO: change getConfig() to throw a specific error when a network
+    // error occurs, so we can distinguish between network errors and
+    // configuration errors.
+    retry: false,
     queryKey: ['labeler-config'],
     queryFn: getConfig,
-    initialData: cachedConfig,
     // Refetching will be handled manually
     refetchOnWindowFocus: false,
+    // Initialize with data from the legacy key (can be removed in the future)
+    initialData: ((legacyKey: string) => {
+      try {
+        const data = localStorage.getItem(legacyKey)
+        if (data) return JSON.parse(data)
+      } catch {
+        // Ignore
+      } finally {
+        localStorage.removeItem(legacyKey)
+      }
+    })('labeler-config'),
   })
 
-  useEffect(() => {
-    if (data) setCachedConfig(data)
-  }, [data, setCachedConfig])
-
-  const value = useMemo(
+  const value = useMemo<ConfigContextData | null>(
     () =>
       data
         ? {
             config: data,
-            configError: error,
+            configError:
+              error == null
+                ? null
+                : error instanceof Error
+                ? error
+                : new Error('Unknown error', { cause: error }),
             refetchConfig: refetch,
           }
         : null,

--- a/components/shell/ConfigContext.tsx
+++ b/components/shell/ConfigContext.tsx
@@ -30,16 +30,19 @@ export const ConfigProvider = ({ children }: { children: ReactNode }) => {
     // Refetching will be handled manually
     refetchOnWindowFocus: false,
     // Initialize with data from the legacy key (can be removed in the future)
-    initialData: ((legacyKey: string) => {
-      try {
-        const data = localStorage.getItem(legacyKey)
-        if (data) return JSON.parse(data)
-      } catch {
-        // Ignore
-      } finally {
-        localStorage.removeItem(legacyKey)
-      }
-    })('labeler-config'),
+    initialData:
+      typeof window === 'undefined'
+        ? undefined
+        : ((legacyKey: string) => {
+            try {
+              const data = localStorage.getItem(legacyKey)
+              if (data) return JSON.parse(data)
+            } catch {
+              // Ignore
+            } finally {
+              localStorage.removeItem(legacyKey)
+            }
+          })('labeler-config'),
   })
 
   const value = useMemo<ConfigContextData | null>(

--- a/components/shell/ConfigurationContext.tsx
+++ b/components/shell/ConfigurationContext.tsx
@@ -69,14 +69,14 @@ export const ConfigurationProvider = ({
   // Reset "skipRecord" on credential change
   useEffect(() => setSkipRecord(false), [labelerAgent])
 
-  const accountDid = labelerAgent?.did
+  const isServiceAccount = labelerAgent.did === config.did
 
   const state =
     serverConfigError?.['status'] === 401
       ? ConfigurationState.Unauthorized
       : config.needs.key ||
         config.needs.service ||
-        (config.needs.record && config.did === accountDid && !skipRecord)
+        (config.needs.record && isServiceAccount && !skipRecord)
       ? ConfigurationState.Unconfigured
       : !serverConfig
       ? isServerConfigLoading
@@ -100,13 +100,13 @@ export const ConfigurationProvider = ({
       labelerAgent
         ? {
             config,
-            isServiceAccount: accountDid === config.did,
+            isServiceAccount,
             serverConfig,
             labelerAgent,
             reconfigure,
           }
         : null,
-    [state, accountDid, config, serverConfig, labelerAgent, reconfigure],
+    [state, config, isServiceAccount, serverConfig, labelerAgent, reconfigure],
   )
 
   if (!configurationContextData) {
@@ -144,7 +144,7 @@ export const ConfigurationProvider = ({
   )
 }
 
-export const useConfigurationContext = () => {
+export function useConfigurationContext() {
   const value = useContext(ConfigurationContext)
   if (value) return value
 
@@ -166,12 +166,9 @@ export function usePermission(name: PermissionName) {
 }
 
 export function useAppviewAgent() {
-  const { appview } = useConfigurationContext().serverConfig
-
+  const { appview } = useServerConfig()
   return useMemo<Agent | null>(() => {
-    if (appview) {
-      return new Agent(new CredentialSession(new URL(appview)))
-    }
+    if (appview) return new Agent(appview)
     return null
   }, [appview])
 }

--- a/components/shell/ConfigurationContext/useServerConfigQuery.ts
+++ b/components/shell/ConfigurationContext/useServerConfigQuery.ts
@@ -1,71 +1,74 @@
 import { Agent } from '@atproto/api'
 import { ResponseType, XRPCError } from '@atproto/xrpc'
-import { useQuery } from '@tanstack/react-query'
-import { useEffect } from 'react'
-import { useLocalStorage } from 'react-use'
 
-import { parseServerConfig, ServerConfig } from '@/lib/server-config'
+import { parseServerConfig } from '@/lib/server-config'
+import { useStoredQuery } from '@/lib/useStoredQuery'
 
 export function useServerConfigQuery(agent: Agent) {
-  const [cachedServerConfig, setCachedServerConfig] =
-    useLocalStorage<ServerConfig>('labeler-server-config')
-
-  const response = useQuery({
-    retry: (failureCount, error): boolean => {
-      if (error instanceof XRPCError) {
-        if (error.status === ResponseType.InternalServerError) {
-          // The server is misconfigured
-          return false
-        }
-
-        if (
-          error.status === ResponseType.InvalidRequest &&
-          error.message === 'could not resolve proxy did service url'
-        ) {
-          // Labeler service not configured in the user's DID document (yet)
-          return false
-        }
-
-        if (error.status === ResponseType.AuthRequired) {
-          // User is logged in with a user that is not member of the labeler's
-          // group.
-          return false
-        }
-      }
-
-      return failureCount < 3
-    },
-    retryDelay: (attempt, error) => {
-      if (
-        error instanceof XRPCError &&
-        error.status === ResponseType.RateLimitExceeded &&
-        error.headers?.['ratelimit-remaining'] === '0' &&
-        error.headers?.['ratelimit-reset']
-      ) {
-        // ratelimit-limit: 3000
-        // ratelimit-policy: 3000;w=300
-        // ratelimit-remaining: 2977
-        // ratelimit-reset: 1724927309
-
-        const reset = Number(error.headers['ratelimit-reset']) * 1e3
-        return reset - Date.now()
-      }
-
-      // Exponential backoff with a maximum of 30 seconds
-      return Math.min(1000 * 2 ** attempt, 30000)
-    },
-    queryKey: ['server-config', agent.assertDid, agent.proxy],
+  return useStoredQuery({
+    queryKey: ['server-config', agent.assertDid, agent.proxy ?? null],
     queryFn: async ({ signal }) => {
       const { data } = await agent.tools.ozone.server.getConfig({}, { signal })
       return parseServerConfig(data)
     },
-    initialData: cachedServerConfig,
+    retry,
+    retryDelay,
     refetchOnWindowFocus: false,
+    // Initialize with data from the legacy key (can be removed in the future)
+    initialData: ((legacyKey: string) => {
+      try {
+        const data = localStorage.getItem(legacyKey)
+        if (data) return JSON.parse(data)
+      } catch {
+        // Ignore
+      } finally {
+        localStorage.removeItem(legacyKey)
+      }
+    })('labeler-server-config'),
   })
+}
 
-  useEffect(() => {
-    if (response.data) setCachedServerConfig(response.data)
-  }, [response.data, setCachedServerConfig])
+const retry = (failureCount: number, error: unknown): boolean => {
+  if (error instanceof XRPCError) {
+    if (error.status === ResponseType.InternalServerError) {
+      // The server is misconfigured
+      return false
+    }
 
-  return response
+    if (
+      error.status === ResponseType.InvalidRequest &&
+      error.message === 'could not resolve proxy did service url'
+    ) {
+      // Labeler service not configured in the user's DID document (yet)
+      return false
+    }
+
+    if (error.status === ResponseType.AuthRequired) {
+      // User is logged in with a user that is not member of the labeler's
+      // group.
+      return false
+    }
+  }
+
+  return failureCount < 3
+}
+
+const retryDelay = (attempt: number, error: unknown): number => {
+  if (
+    error instanceof XRPCError &&
+    error.status === ResponseType.RateLimitExceeded &&
+    error.headers?.['ratelimit-remaining'] === '0' &&
+    error.headers?.['ratelimit-reset']
+  ) {
+    // ratelimit-limit: 3000
+    // ratelimit-policy: 3000;w=300
+    // ratelimit-remaining: 2977
+    // ratelimit-reset: 1724927309
+
+    const reset = Number(error.headers['ratelimit-reset']) * 1e3
+    return reset - Date.now()
+  }
+
+  // Exponential backoff with a maximum of 30 seconds
+  return Math.min(1000 * 2 ** attempt, 30000)
 }

--- a/components/shell/ConfigurationContext/useServerConfigQuery.ts
+++ b/components/shell/ConfigurationContext/useServerConfigQuery.ts
@@ -15,16 +15,19 @@ export function useServerConfigQuery(agent: Agent) {
     retryDelay,
     refetchOnWindowFocus: false,
     // Initialize with data from the legacy key (can be removed in the future)
-    initialData: ((legacyKey: string) => {
-      try {
-        const data = localStorage.getItem(legacyKey)
-        if (data) return JSON.parse(data)
-      } catch {
-        // Ignore
-      } finally {
-        localStorage.removeItem(legacyKey)
-      }
-    })('labeler-server-config'),
+    initialData:
+      typeof window === 'undefined'
+        ? undefined
+        : ((legacyKey: string) => {
+            try {
+              const data = localStorage.getItem(legacyKey)
+              if (data) return JSON.parse(data)
+            } catch {
+              // Ignore
+            } finally {
+              localStorage.removeItem(legacyKey)
+            }
+          })('labeler-server-config'),
   })
 }
 

--- a/lib/useStoredQuery.ts
+++ b/lib/useStoredQuery.ts
@@ -1,0 +1,34 @@
+import {
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { useLocalStorage } from 'react-use'
+
+export function useStoredQuery<
+  TData extends NonNullable<unknown> | null,
+  TError,
+  TQueryKey extends (string | number | boolean | null)[],
+>({
+  initialData,
+  ...options
+}: Omit<
+  UseQueryOptions<TData, TError, TData, TQueryKey>,
+  'queryKey' | 'initialData'
+> & {
+  queryKey: TQueryKey
+  initialData?: TData
+}): UseQueryResult<TData, TError> {
+  const key = `storedQuery:${JSON.stringify(options.queryKey).slice(1, -1)}`
+
+  const [storedData, setStoredData] = useLocalStorage<TData>(key, initialData)
+
+  const response = useQuery({ ...options, initialData: storedData })
+
+  useEffect(() => {
+    setStoredData(response.data)
+  }, [response.data, setStoredData])
+
+  return response
+}


### PR DESCRIPTION
The server config is stored in the local storage to allow cached access when loading the app. However, the cache key is the same for every user.

This PR adds a `useCachedQuery` that combines the `useQuery` and `useLocalStorage` hooks using a consistent cache key mechanism for both the cache and query key.