### PR TITLE
:bug: Build correct event filter for appeal and tags

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -664,7 +664,7 @@ function Form(
                     <LabelSelector
                       id="labels"
                       name="labels"
-                      formId={FORM_ID}
+                      form={FORM_ID}
                       defaultLabels={currentLabels.filter((label) => {
                         // If there's a label where the source is the current labeler, it's editable
                         const isEditableLabel = allLabels.some((l) => {

--- a/components/common/labels/Selector.tsx
+++ b/components/common/labels/Selector.tsx
@@ -10,7 +10,7 @@ const EMPTY_ARR = []
 export const LabelSelector = (props: LabelsProps) => {
   const {
     id,
-    formId,
+    form,
     name,
     defaultLabels = EMPTY_ARR,
     disabled,
@@ -57,7 +57,7 @@ export const LabelSelector = (props: LabelsProps) => {
       <input
         type="hidden"
         name={name}
-        {...{ id, formId, disabled }}
+        {...{ id, form, disabled }}
         value={Array.isArray(selectedLabels) ? selectedLabels.join(',') : ''}
       />
       <Input
@@ -114,7 +114,7 @@ export const LabelSelector = (props: LabelsProps) => {
 
 type LabelsProps = {
   id: string
-  formId: string
+  form: string
   name: string
   disabled?: boolean
   defaultLabels?: string[]

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -288,7 +288,7 @@ export const EventFilterPanel = ({
               <LabelSelector
                 id="addedLabels"
                 name="addedLabels"
-                formId=""
+                form=""
                 defaultLabels={[]}
                 onChange={(value) =>
                   changeListFilter({ field: 'addedLabels', value })
@@ -300,7 +300,7 @@ export const EventFilterPanel = ({
               <LabelSelector
                 id="removedLabels"
                 name="removedLabels"
-                formId=""
+                form=""
                 defaultLabels={[]}
                 onChange={(value) =>
                   changeListFilter({ field: 'removedLabels', value })

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -228,9 +228,7 @@ export const useModEventList = (
           // There is a no appeal type, it's a placeholder and behind the scene
           // we use type as report and reportTypes as appeal
           if (type === MOD_EVENTS.APPEAL) {
-            if (!queryParams.reportTypes) {
-              queryParams.reportTypes = []
-            }
+            queryParams.reportTypes ||= []
             queryParams.reportTypes.push(ComAtprotoModerationDefs.REASONAPPEAL)
             return MOD_EVENTS.REPORT
           }
@@ -373,20 +371,15 @@ const buildTagFilter = (type: string) => {
   const remove: string[] = []
   const tagTypes = Object.keys(TagBasedTypeFilters)
 
-  if (!tagTypes.includes(type)) {
+  if (!(type in tagTypes) || !Object.hasOwn(tagTypes, type)) {
     return { add, remove }
   }
-
-  tagTypes.forEach((key) => {
-    if (type === key) {
-      if (TagBasedTypeFilters[key].add) {
-        add.push(TagBasedTypeFilters[key].add)
-      }
-      if (TagBasedTypeFilters[key].remove) {
-        remove.push(TagBasedTypeFilters[key].remove)
-      }
-    }
-  })
+  if (TagBasedTypeFilters[type].add) {
+    add.push(TagBasedTypeFilters[type].add)
+  }
+  if (TagBasedTypeFilters[type].remove) {
+    remove.push(TagBasedTypeFilters[type].remove)
+  }
 
   return { add, remove }
 }

--- a/components/repositories/Blocks.tsx
+++ b/components/repositories/Blocks.tsx
@@ -4,9 +4,18 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { AccountsGrid } from './AccountView'
 import { listRecords } from './api'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
+import { useEffect, useRef, useState } from 'react'
+import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
+import { toast } from 'react-toastify'
+import { ActionButton } from '@/common/buttons'
+import { ConfirmationModal } from '@/common/modals/confirmation'
 
 export function Blocks({ did }: { did: string }) {
   const labelerAgent = useLabelerAgent()
+  const abortController = useRef<AbortController | null>(null)
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
+  const [isAdding, setIsAdding] = useState(false)
+  const { mutateAsync: addItemsToWorkspace } = useWorkspaceAddItemsMutation()
 
   const { data, error, fetchNextPage, hasNextPage, isInitialLoading } =
     useInfiniteQuery({
@@ -15,21 +24,6 @@ export function Blocks({ did }: { did: string }) {
         const data = await listRecords(did, 'app.bsky.graph.block', {
           cursor: pageParam,
         })
-        console.log(async (did) => {
-          let cursor: string | undefined
-          let results = []
-          do {
-            const data = await listRecords(did, 'app.bsky.graph.block', {
-              cursor,
-            })
-            if (data.records.length !== 0) {
-              // @ts-ignore
-              results.push(...data.records)
-            }
-            cursor = data.cursor
-          } while (cursor)
-          return results
-        })
         const actors = data.records.map(
           (record) => record.value['subject'] as string,
         )
@@ -37,7 +31,7 @@ export function Blocks({ did }: { did: string }) {
           return { accounts: [], cursor: null }
         }
         const { data: profileData } =
-          await labelerAgent.api.app.bsky.actor.getProfiles({
+          await labelerAgent.app.bsky.actor.getProfiles({
             actors,
           })
 
@@ -57,8 +51,94 @@ export function Blocks({ did }: { did: string }) {
       getNextPageParam: (lastPage) => lastPage.cursor,
     })
   const blockedAccounts = data?.pages.flatMap((page) => page.accounts) ?? []
+
+  const confirmAddToWorkspace = async () => {
+    // add items that are already loaded
+    await addItemsToWorkspace(blockedAccounts.map((f) => f.did))
+    if (!data?.pageParams) {
+      setIsConfirmationOpen(false)
+      return
+    }
+    setIsAdding(true)
+    const newAbortController = new AbortController()
+    abortController.current = newAbortController
+
+    try {
+      let cursor = data.pageParams[0] as string | undefined
+      do {
+        const data = await listRecords(
+          did,
+          'app.bsky.graph.block',
+          { cursor },
+          { signal: abortController.current?.signal },
+        )
+
+        await addItemsToWorkspace(
+          data.records.map((record) => record.value['subject'] as string),
+        )
+        cursor = data.cursor
+        //   if the modal is closed, that means the user decided not to add any more user to workspace
+      } while (cursor && isConfirmationOpen)
+    } catch (e) {
+      if (abortController.current?.signal.reason === 'user-cancelled') {
+        toast.info('Stopped adding blocked accounts to workspace')
+      } else {
+        toast.error(`Something went wrong: ${(e as Error).message}`)
+      }
+    }
+    setIsAdding(false)
+    setIsConfirmationOpen(false)
+  }
+
+  useEffect(() => {
+    if (!isConfirmationOpen) {
+      abortController.current?.abort('user-cancelled')
+    }
+  }, [isConfirmationOpen])
+
+  useEffect(() => {
+    // User cancelled by closing this view (navigation, other?)
+    return () => abortController.current?.abort('user-cancelled')
+  }, [])
+
   return (
     <div>
+      {!!blockedAccounts?.length && (
+        <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
+          <ActionButton
+            appearance="primary"
+            size="sm"
+            onClick={() => setIsConfirmationOpen(true)}
+          >
+            Add to workspace
+          </ActionButton>
+
+          <ConfirmationModal
+            onConfirm={() => {
+              if (isAdding) {
+                setIsAdding(false)
+                setIsConfirmationOpen(false)
+                return
+              }
+
+              confirmAddToWorkspace()
+            }}
+            isOpen={isConfirmationOpen}
+            setIsOpen={setIsConfirmationOpen}
+            confirmButtonText={isAdding ? 'Stop adding' : 'Yes, add all'}
+            title={`Add all blocked accounts to workspace?`}
+            description={
+              <>
+                Once confirmed, all the accounts blocked by this user will be
+                added to the workspace. For users with a lot of blocks, this may
+                take quite some time but you can always stop the process and
+                already added follows will remain in the workspace.
+              </>
+            }
+          />
+        </div>
+      )}
+
       <AccountsGrid
         isLoading={isInitialLoading}
         error={String(error ?? '')}

--- a/components/repositories/Blocks.tsx
+++ b/components/repositories/Blocks.tsx
@@ -15,6 +15,21 @@ export function Blocks({ did }: { did: string }) {
         const data = await listRecords(did, 'app.bsky.graph.block', {
           cursor: pageParam,
         })
+        console.log(async (did) => {
+          let cursor: string | undefined
+          let results = []
+          do {
+            const data = await listRecords(did, 'app.bsky.graph.block', {
+              cursor,
+            })
+            if (data.records.length !== 0) {
+              // @ts-ignore
+              results.push(...data.records)
+            }
+            cursor = data.cursor
+          } while (cursor)
+          return results
+        })
         const actors = data.records.map(
           (record) => record.value['subject'] as string,
         )

--- a/components/repositories/api.ts
+++ b/components/repositories/api.ts
@@ -5,6 +5,7 @@ export async function listRecords(
   did: string,
   collection: string,
   { cursor, limit = 25 }: { cursor?: string; limit?: number },
+  options?: { signal?: AbortSignal },
 ) {
   const doc = await resolveDidDocData(did)
   if (!doc) {
@@ -21,6 +22,6 @@ export async function listRecords(
   if (cursor) {
     url.searchParams.set('cursor', `${cursor}`)
   }
-  const res = await fetch(url)
+  const res = await fetch(url, options)
   return res.json()
 }

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -50,7 +50,7 @@ export const WorkspacePanelActionForm = ({
           <LabelSelector
             id="labels"
             name="labels"
-            formId={WORKSPACE_FORM_ID}
+            form={WORKSPACE_FORM_ID}
             defaultLabels={[]}
           />
 


### PR DESCRIPTION
This PR fixed event filters so that tag based events and appeal event filter work correctly. These are pseudo event types so there's no 1-to-1 mapping for these and the actual filter need to be built manually. 