### PR TITLE
✨ Takedown policy association

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -267,8 +267,8 @@ function Form(
         coreEvent.durationInHours = Number(formData.get('durationInHours'))
       }
 
-      if (formData.get('policy')) {
-        coreEvent.policy = String(formData.get('policy'))
+      if (isTakedownEvent && formData.get('policies')) {
+        coreEvent.policies = [String(formData.get('policies'))]
       }
 
       if (
@@ -336,6 +336,10 @@ function Form(
 
       if (isDivertEvent && !subjectBlobCids.length) {
         throw new Error('blob-selection-required')
+      }
+
+      if (isTakedownEvent && !coreEvent.policies) {
+        throw new Error('policy-selection-required')
       }
 
       // This block handles an edge case where a label may be applied to profile record and then the profile record is updated by the user.
@@ -696,7 +700,7 @@ function Form(
                       </FormLabel>
                       {isTakedownEvent && (
                         <div className="mt-2 w-full">
-                          <ActionPolicySelector name="policy" />
+                          <ActionPolicySelector name="policies" />
                         </div>
                       )}
                     </div>

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -59,6 +59,7 @@ import {
 import { SubjectTag } from 'components/tags/SubjectTag'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { EmailComposer } from 'components/email/Composer'
+import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
 
 const FORM_ID = 'mod-action-panel'
 const useBreakpoint = createBreakpoint({ xs: 340, sm: 640 })
@@ -264,6 +265,10 @@ function Form(
 
       if (formData.get('durationInHours')) {
         coreEvent.durationInHours = Number(formData.get('durationInHours'))
+      }
+
+      if (formData.get('policy')) {
+        coreEvent.policy = String(formData.get('policy'))
       }
 
       if (
@@ -666,16 +671,35 @@ function Form(
                     <ModEventDetailsPopover modEventType={modEventType} />
                   </div>
                   {shouldShowDurationInHoursField && (
-                    <FormLabel
-                      label=""
-                      htmlFor="durationInHours"
-                      className={`mb-3 mt-2`}
-                    >
-                      <ActionDurationSelector
-                        action={modEventType}
-                        labelText={isMuteEvent ? 'Mute duration' : ''}
-                      />
-                    </FormLabel>
+                    <div className="flex flex-row gap-2">
+                      <FormLabel
+                        label=""
+                        htmlFor="durationInHours"
+                        className={`mb-3 mt-2`}
+                      >
+                        <ActionDurationSelector
+                          action={modEventType}
+                          onChange={(e) => {
+                            if (e.target.value === '0') {
+                              // When permanent takedown is selected, auto check ack all checkbox
+                              const ackAllCheckbox =
+                                document.querySelector<HTMLInputElement>(
+                                  'input[name="acknowledgeAccountSubjects"]',
+                                )
+                              if (ackAllCheckbox && !ackAllCheckbox.checked) {
+                                ackAllCheckbox.checked = true
+                              }
+                            }
+                          }}
+                          labelText={isMuteEvent ? 'Mute duration' : ''}
+                        />
+                      </FormLabel>
+                      {isTakedownEvent && (
+                        <div className="mt-2 w-full">
+                          <ActionPolicySelector name="policy" />
+                        </div>
+                      )}
+                    </div>
                   )}
 
                   {isMuteReporterEvent && (

--- a/app/configure/page-content.tsx
+++ b/app/configure/page-content.tsx
@@ -12,12 +12,14 @@ import { WorkspacePanel } from '@/workspace/Panel'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { SetsConfig } from '@/config/Sets'
 import { ProtectedTagsConfig } from '@/config/ProtectedTags'
+import { PoliciesConfig } from '@/config/Policies'
 
 enum Views {
   Configure,
   Members,
   Sets,
   ProtectedTags,
+  Policies,
 }
 
 const TabKeys = {
@@ -25,6 +27,7 @@ const TabKeys = {
   members: Views.Members,
   sets: Views.Sets,
   protectedTags: Views.ProtectedTags,
+  policies: Views.Policies,
 }
 
 export default function ConfigurePageContent() {
@@ -74,6 +77,10 @@ export default function ConfigurePageContent() {
       label: 'Sets',
     },
     {
+      view: Views.Policies,
+      label: 'Policies',
+    },
+    {
       view: Views.ProtectedTags,
       label: 'Protected Tags',
     },
@@ -90,8 +97,8 @@ export default function ConfigurePageContent() {
       {currentView === Views.Configure && <LabelerConfig />}
       {currentView === Views.Members && <MemberConfig />}
       {currentView === Views.Sets && <SetsConfig />}
-      {currentView === Views.Sets && <SetsConfig />}
       {currentView === Views.ProtectedTags && <ProtectedTagsConfig />}
+      {currentView === Views.Policies && <PoliciesConfig />}
 
       <ModActionPanelQuick
         open={!!quickOpenParam}

--- a/components/config/Policies.tsx
+++ b/components/config/Policies.tsx
@@ -1,0 +1,101 @@
+import { ActionButton, LinkButton } from '@/common/buttons'
+import { Input } from '@/common/forms'
+import { PolicyEditor } from '@/setting/policy/Editor'
+import { PolicyList } from '@/setting/policy/List'
+import { usePolicyListSetting } from '@/setting/policy/usePolicyList'
+import { createPolicyPageLink } from '@/setting/policy/utils'
+import { useServerConfig } from '@/shell/ConfigurationContext'
+import { ToolsOzoneTeamDefs } from '@atproto/api'
+import { PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+export function PoliciesConfig() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const searchQuery = searchParams.get('search')
+  const { role } = useServerConfig()
+  const canManagePolicies = role === ToolsOzoneTeamDefs.ROLEADMIN
+  const showPoliciesCreateForm = searchParams.has('create')
+
+  return (
+    <div className="pt-4">
+      <div className="flex flex-row justify-between mb-4">
+        {typeof searchQuery === 'string' ? (
+          <>
+            <Input
+              type="text"
+              autoFocus
+              className="w-3/4"
+              placeholder="Search policies..."
+              value={searchQuery}
+              onChange={(e) => {
+                const url = createPolicyPageLink({ search: e.target.value })
+                router.push(url)
+              }}
+            />{' '}
+            <LinkButton
+              size="sm"
+              className="ml-1"
+              appearance="outlined"
+              href={createPolicyPageLink({})}
+            >
+              Cancel
+            </LinkButton>
+          </>
+        ) : (
+          <>
+            <div className="flex flex-row items-center">
+              <h4 className="font-medium text-gray-700 dark:text-gray-100">
+                Manage Policies
+              </h4>
+            </div>
+            {!showPoliciesCreateForm && (
+              <div className="flex flex-row items-center">
+                {canManagePolicies && (
+                  <LinkButton
+                    size="sm"
+                    appearance="primary"
+                    href={createPolicyPageLink({ create: 'true' })}
+                  >
+                    <PlusIcon className="h-3 w-3 mr-1" />
+                    <span className="text-xs">Add New Policy</span>
+                  </LinkButton>
+                )}
+
+                <LinkButton
+                  size="sm"
+                  className="ml-1"
+                  appearance="outlined"
+                  href={createPolicyPageLink({ search: '' })}
+                >
+                  <MagnifyingGlassIcon className="h-4 w-4" />
+                </LinkButton>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      {showPoliciesCreateForm && (
+        <div className="mb-4">
+          <PolicyEditor
+            onCancel={() => {
+              const url = createPolicyPageLink({})
+              router.push(url)
+            }}
+            onSuccess={() => {
+              const url = createPolicyPageLink({})
+              router.push(url)
+            }}
+          />
+        </div>
+      )}
+
+      <PolicyList
+        {...{
+          searchQuery,
+          canEdit: canManagePolicies,
+        }}
+      />
+    </div>
+  )
+}

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -13,6 +13,7 @@ import { ItemTitle } from './ItemTitle'
 import { PreviewCard } from '@/common/PreviewCard'
 import { ModEventViewWithDetails } from './useModEventList'
 import { ClockIcon, DocumentTextIcon } from '@heroicons/react/24/solid'
+import Link from 'next/link'
 
 const LinkToAuthor = ({
   creatorHandle,
@@ -195,7 +196,14 @@ const TakedownOrMute = ({
         <p className="pb-1 flex flex-row items-center">
           <DocumentTextIcon className="h-3 w-3 inline-block mr-1" />
           <i>
-            Under <u>{`${modEvent.event.policy}`}</u> policy
+            Under{' '}
+            <Link
+              prefetch={false}
+              href={`/configure?tab=policies&search=${modEvent.event.policy}`}
+            >
+              <u>{`${modEvent.event.policy}`}</u>
+            </Link>{' '}
+            policy
           </i>
         </p>
       ) : null}

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -14,6 +14,7 @@ import { PreviewCard } from '@/common/PreviewCard'
 import { ModEventViewWithDetails } from './useModEventList'
 import { ClockIcon, DocumentTextIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
+import { pluralize } from '@/lib/util'
 
 const LinkToAuthor = ({
   creatorHandle,
@@ -226,18 +227,26 @@ const TakedownOrMute = ({
           Until {dateFormatter.format(expiresAt)}
         </p>
       )}
-      {modEvent.event.policy ? (
+      {ToolsOzoneModerationDefs.isModEventTakedown(modEvent.event) &&
+      modEvent.event.policies?.length ? (
         <p className="pb-1 flex flex-row items-center">
           <DocumentTextIcon className="h-3 w-3 inline-block mr-1" />
           <i>
             Under{' '}
-            <Link
-              prefetch={false}
-              href={`/configure?tab=policies&search=${modEvent.event.policy}`}
-            >
-              <u>{`${modEvent.event.policy}`}</u>
-            </Link>{' '}
-            policy
+            {modEvent.event.policies.map((policy) => {
+              return (
+                <Link
+                  key={policy}
+                  prefetch={false}
+                  href={`/configure?tab=policies&search=${policy}`}
+                >
+                  <u>{`${policy}`}</u>{' '}
+                </Link>
+              )
+            })}
+            {pluralize(modEvent.event.policies.length, 'policy', {
+              plural: 'policies',
+            })}
           </i>
         </p>
       ) : null}

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -12,6 +12,7 @@ import { useConfigurationContext } from '@/shell/ConfigurationContext'
 import { ItemTitle } from './ItemTitle'
 import { PreviewCard } from '@/common/PreviewCard'
 import { ModEventViewWithDetails } from './useModEventList'
+import { ClockIcon, DocumentTextIcon } from '@heroicons/react/24/solid'
 
 const LinkToAuthor = ({
   creatorHandle,
@@ -185,8 +186,19 @@ const TakedownOrMute = ({
         </div>
       </div>
       {expiresAt && (
-        <p className="mt-1">Until {dateFormatter.format(expiresAt)}</p>
+        <p className="mt-1 flex flex-row items-center">
+          <ClockIcon className="h-3 w-3 inline-block mr-1" />
+          Until {dateFormatter.format(expiresAt)}
+        </p>
       )}
+      {modEvent.event.policy ? (
+        <p className="pb-1 flex flex-row items-center">
+          <DocumentTextIcon className="h-3 w-3 inline-block mr-1" />
+          <i>
+            Under <u>{`${modEvent.event.policy}`}</u> policy
+          </i>
+        </p>
+      ) : null}
       {modEvent.event.comment ? (
         <p className="pb-1">{`${modEvent.event.comment}`}</p>
       ) : null}

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -143,6 +143,7 @@ export const ModEventList = (
     isInitialLoadingModEvents,
     hasFilter,
     commentFilter,
+    policies,
     toggleCommentFilter,
     setCommentFilterKeyword,
     createdBy,
@@ -285,6 +286,7 @@ export const ModEventList = (
             removedTags,
             applyFilterMacro,
             changeListFilter,
+            policies,
           }}
         />
       )}

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react'
 import { RepoFinder } from '@/repositories/Finder'
 import { Dropdown } from '@/common/Dropdown'
 import { ChevronDownIcon } from '@heroicons/react/24/solid'
+import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
 
 export const EventFilterPanel = ({
   limit,
@@ -271,6 +272,17 @@ export const EventFilterPanel = ({
           </FormLabel>
         </div>
       </div>
+      {types.includes(MOD_EVENTS.TAKEDOWN) && (
+        <div className="flex flex-row gap-2 mt-2">
+          <FormLabel label="Policy" className="flex-1">
+            <ActionPolicySelector
+              onSelect={(policy) => {
+                changeListFilter({ field: 'policy', value: policy })
+              }}
+            />
+          </FormLabel>
+        </div>
+      )}
       {types.includes(MOD_EVENTS.TAG) && (
         <div className="flex flex-row gap-2 mt-2">
           <FormLabel label="Added Tags" className="flex-1 max-w-sm">

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -17,7 +17,10 @@ import { useState } from 'react'
 import { RepoFinder } from '@/repositories/Finder'
 import { Dropdown } from '@/common/Dropdown'
 import { ChevronDownIcon } from '@heroicons/react/24/solid'
-import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
+import {
+  ActionPoliciesSelector,
+  ActionPolicySelector,
+} from '@/reports/ModerationForm/ActionPolicySelector'
 
 export const EventFilterPanel = ({
   limit,
@@ -275,9 +278,9 @@ export const EventFilterPanel = ({
       {types.includes(MOD_EVENTS.TAKEDOWN) && (
         <div className="flex flex-row gap-2 mt-2">
           <FormLabel label="Policy" className="flex-1">
-            <ActionPolicySelector
-              onSelect={(policy) => {
-                changeListFilter({ field: 'policy', value: policy })
+            <ActionPoliciesSelector
+              onSelect={(policies) => {
+                changeListFilter({ field: 'policies', value: policies })
               }}
             />
           </FormLabel>

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -62,6 +62,7 @@ const initialListState = {
   removedLabels: [],
   addedTags: '',
   removedTags: '',
+  policy: '',
   showContentPreview: false,
   limit: 25,
 }
@@ -157,6 +158,7 @@ type EventListFilterPayload =
   | { field: 'removedLabels'; value: string[] }
   | { field: 'addedTags'; value: string }
   | { field: 'removedTags'; value: string }
+  | { field: 'policy'; value: string }
   | { field: 'limit'; value: number }
 
 type EventListAction =
@@ -246,6 +248,7 @@ export const useModEventList = (
         addedTags,
         removedTags,
         reportTypes,
+        policy,
         limit,
       } = listState
       const queryParams: ToolsOzoneModerationQueryEvents.QueryParams = {
@@ -335,6 +338,10 @@ export const useModEventList = (
         })
       }
 
+      if (filterTypes.includes(MOD_EVENTS.TAKEDOWN) && policy) {
+        queryParams.policy = policy
+      }
+
       const { data } = await labelerAgent.tools.ozone.moderation.queryEvents({
         ...queryParams,
       })
@@ -372,6 +379,7 @@ export const useModEventList = (
     listState.createdBy ||
     listState.subject ||
     listState.oldestFirst ||
+    listState.policy ||
     listState.reportTypes.length > 0 ||
     listState.addedLabels.length > 0 ||
     listState.removedLabels.length > 0 ||

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -62,7 +62,7 @@ const initialListState = {
   removedLabels: [],
   addedTags: '',
   removedTags: '',
-  policy: '',
+  policies: [],
   showContentPreview: false,
   limit: 25,
 }
@@ -158,7 +158,7 @@ type EventListFilterPayload =
   | { field: 'removedLabels'; value: string[] }
   | { field: 'addedTags'; value: string }
   | { field: 'removedTags'; value: string }
-  | { field: 'policy'; value: string }
+  | { field: 'policies'; value: string[] }
   | { field: 'limit'; value: number }
 
 type EventListAction =
@@ -248,7 +248,7 @@ export const useModEventList = (
         addedTags,
         removedTags,
         reportTypes,
-        policy,
+        policies,
         limit,
       } = listState
       const queryParams: ToolsOzoneModerationQueryEvents.QueryParams = {
@@ -338,8 +338,8 @@ export const useModEventList = (
         })
       }
 
-      if (filterTypes.includes(MOD_EVENTS.TAKEDOWN) && policy) {
-        queryParams.policy = policy
+      if (filterTypes.includes(MOD_EVENTS.TAKEDOWN) && policies) {
+        queryParams.policies = policies
       }
 
       const { data } = await labelerAgent.tools.ozone.moderation.queryEvents({
@@ -379,7 +379,7 @@ export const useModEventList = (
     listState.createdBy ||
     listState.subject ||
     listState.oldestFirst ||
-    listState.policy ||
+    listState.policies.length > 0 ||
     listState.reportTypes.length > 0 ||
     listState.addedLabels.length > 0 ||
     listState.removedLabels.length > 0 ||

--- a/components/reports/ModerationForm/ActionError.tsx
+++ b/components/reports/ModerationForm/ActionError.tsx
@@ -5,6 +5,10 @@ const ActionErrors = {
     title: 'No blobs selected',
     description: 'You must select at least one blob to be diverted',
   },
+  'policy-selection-required': {
+    title: 'No takedown policy selected',
+    description: 'You must select the policy used for the takedown',
+  },
 }
 
 export type ActionErrorKey = keyof typeof ActionErrors | string
@@ -13,7 +17,7 @@ export const ActionError = ({ error }: { error: ActionErrorKey }) => {
   if (ActionErrors[error]) {
     return (
       <Card variation="error">
-        <h4 className='font-bold'>{ActionErrors[error].title}</h4>
+        <h4 className="font-bold">{ActionErrors[error].title}</h4>
         <p>{ActionErrors[error].description}</p>
       </Card>
     )

--- a/components/reports/ModerationForm/ActionPolicySelector.tsx
+++ b/components/reports/ModerationForm/ActionPolicySelector.tsx
@@ -1,0 +1,147 @@
+import { Dropdown } from '@/common/Dropdown'
+import { Combobox, Transition } from '@headlessui/react'
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpDownIcon,
+} from '@heroicons/react/24/solid'
+import { Fragment, useState } from 'react'
+
+const availablePolicies = {
+  trolling: {
+    name: 'Trolling',
+    description: 'Content that is intended to provoke or upset others',
+  },
+  spam: {
+    name: 'Spam',
+    description: 'Content that is irrelevant or repetitive',
+  },
+  hate: {
+    name: 'Hate Speech',
+    description: 'Content that promotes hate or violence against a group',
+  },
+}
+const policyList = Object.values(availablePolicies)
+
+export const ActionPolicySelector = ({
+  defaultPolicy,
+  onSelect,
+  name,
+}: {
+  name?: string
+  defaultPolicy?: string
+  onSelect?: (name: string) => void
+}) => {
+  const [selected, setSelected] = useState('')
+  const [query, setQuery] = useState('')
+  const [selectedPolicy, setSelectedPolicy] = useState<string | undefined>(
+    defaultPolicy,
+  )
+  const matchingPolicies = policyList
+    ?.filter((tpl) => {
+      if (selectedPolicy && tpl.name !== selectedPolicy) {
+        return false
+      }
+
+      if (query.length) {
+        return tpl.name.toLowerCase().includes(query.toLowerCase())
+      }
+
+      return true
+    })
+    .sort((prev, next) => prev.name.localeCompare(next.name))
+
+  return (
+    <>
+      <Combobox
+        value={selected}
+        onChange={(selectedPolicy) => {
+          setSelected(selectedPolicy)
+          onSelect?.(selectedPolicy)
+        }}
+        name="policy"
+      >
+        <div className="relative mt-1 w-full">
+          <div className="relative w-full cursor-default overflow-hidden rounded-md bg-white dark:bg-slate-700 text-left shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
+            <Combobox.Input
+              className="w-full rounded-md border-gray-300 dark:border-teal-500 dark:bg-slate-700 shadow-sm dark:shadow-slate-700 focus:border-indigo-500 focus:ring-indigo-500 dark:focus:ring-teal-500 sm:text-sm dark:text-gray-100"
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Type keyword or click the arrows on the right to see all policies"
+            />
+            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+              <ChevronUpDownIcon
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              />
+            </Combobox.Button>
+          </div>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            afterLeave={() => setQuery('')}
+          >
+            <Combobox.Options className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-slate-700 py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+              {!matchingPolicies?.length ? (
+                <NoPolicyOption {...{ selectedPolicy, query }} />
+              ) : (
+                matchingPolicies?.map((tpl) => (
+                  <Combobox.Option
+                    key={tpl.name}
+                    className={({ active }) =>
+                      `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                        active
+                          ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
+                          : 'text-gray-900 dark:text-gray-200'
+                      }`
+                    }
+                    value={tpl.name}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        {selected ? (
+                          <span
+                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                              active ? 'text-indigo-900' : 'text-indigo-600'
+                            }`}
+                          >
+                            <CheckIcon
+                              className="h-5 w-5 dark:text-gray-50"
+                              aria-hidden="true"
+                            />
+                          </span>
+                        ) : null}
+                        <div className="flex flex-row">
+                          <div>
+                            <p
+                              className={`block truncate ${
+                                selected ? 'font-medium' : 'font-normal'
+                              }`}
+                            >
+                              {tpl.name}
+                            </p>
+                            <p className="text-xs">{tpl.description}</p>
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))
+              )}
+            </Combobox.Options>
+          </Transition>
+        </div>
+      </Combobox>
+      {name && <input type="hidden" name={name} value={selected} />}
+    </>
+  )
+}
+
+const NoPolicyOption = ({ query = '' }: { query?: string }) => {
+  return (
+    <div className="relative cursor-default select-none px-4 py-2 text-gray-700 dark:text-gray-100">
+      No policy found {query.length ? `matching "${query}"` : ''}
+    </div>
+  )
+}

--- a/components/reports/ModerationForm/ActionPolicySelector.tsx
+++ b/components/reports/ModerationForm/ActionPolicySelector.tsx
@@ -1,12 +1,18 @@
 import { usePolicyListSetting } from '@/setting/policy/usePolicyList'
+import { useServerConfig } from '@/shell/ConfigurationContext'
+import { ToolsOzoneTeamDefs } from '@atproto/api'
 import { Combobox, Transition } from '@headlessui/react'
-import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/solid'
-import { Fragment, useState } from 'react'
+import {
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  ChevronUpDownIcon,
+} from '@heroicons/react/24/solid'
+import { Fragment, useRef, useState } from 'react'
 
 export const ActionPolicySelector = ({
   defaultPolicy,
   onSelect,
-  name = 'policy',
+  name = 'policies',
 }: {
   name?: string
   defaultPolicy?: string
@@ -14,17 +20,7 @@ export const ActionPolicySelector = ({
 }) => {
   const { data, isLoading } = usePolicyListSetting()
   const [selected, setSelected] = useState(defaultPolicy)
-  const [query, setQuery] = useState('')
   const policyList = Object.values(data?.value || {})
-  const matchingPolicies = policyList
-    ?.filter((tpl) => {
-      if (query.length) {
-        return tpl.name.toLowerCase().includes(query.toLowerCase())
-      }
-
-      return true
-    })
-    .sort((prev, next) => prev.name.localeCompare(next.name))
 
   return (
     <>
@@ -37,86 +33,158 @@ export const ActionPolicySelector = ({
         }}
         name={name}
       >
-        <div className="relative mt-1 w-full">
-          <div className="relative w-full cursor-default overflow-hidden rounded-md bg-white dark:bg-slate-700 text-left shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
-            <Combobox.Input
-              className="w-full rounded-md border-gray-300 dark:border-teal-500 dark:bg-slate-700 shadow-sm dark:shadow-slate-700 focus:border-indigo-500 focus:ring-indigo-500 dark:focus:ring-teal-500 sm:text-sm dark:text-gray-100"
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Type keyword or click the arrows on the right to see all policies"
-            />
-            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-              <ChevronUpDownIcon
-                className="h-5 w-5 text-gray-400"
-                aria-hidden="true"
-              />
-            </Combobox.Button>
-          </div>
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-            afterLeave={() => setQuery('')}
-          >
-            <Combobox.Options className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-slate-700 py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
-              {!matchingPolicies?.length ? (
-                <NoPolicyOption query={query} />
-              ) : (
-                matchingPolicies?.map((tpl) => (
-                  <Combobox.Option
-                    key={tpl.name}
-                    className={({ active }) =>
-                      `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                        active
-                          ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
-                          : 'text-gray-900 dark:text-gray-200'
-                      }`
-                    }
-                    value={tpl.name}
-                  >
-                    {({ selected, active }) => (
-                      <>
-                        {selected ? (
-                          <span
-                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                              active ? 'text-indigo-900' : 'text-indigo-600'
-                            }`}
-                          >
-                            <CheckIcon
-                              className="h-5 w-5 dark:text-gray-50"
-                              aria-hidden="true"
-                            />
-                          </span>
-                        ) : null}
-                        <div className="flex flex-row">
-                          <div>
-                            <p
-                              className={`block truncate ${
-                                selected ? 'font-medium' : 'font-normal'
-                              }`}
-                            >
-                              {tpl.name}
-                            </p>
-                            <p className="text-xs">{tpl.description}</p>
-                          </div>
-                        </div>
-                      </>
-                    )}
-                  </Combobox.Option>
-                ))
-              )}
-            </Combobox.Options>
-          </Transition>
-        </div>
+        <ActionPolicyList policyList={policyList} />
       </Combobox>
     </>
   )
 }
 
+export const ActionPoliciesSelector = ({
+  defaultPolicies,
+  onSelect,
+  name = 'policies',
+}: {
+  name?: string
+  defaultPolicies?: string[]
+  onSelect?: (names: string[]) => void
+}) => {
+  const { data, isLoading } = usePolicyListSetting()
+  const [selected, setSelected] = useState(defaultPolicies)
+  const policyList = Object.values(data?.value || {})
+
+  return (
+    <>
+      <Combobox
+        multiple
+        value={selected}
+        disabled={isLoading}
+        onChange={(selectedPolicies) => {
+          setSelected(selectedPolicies)
+          onSelect?.(selectedPolicies)
+        }}
+        name={name}
+      >
+        <ActionPolicyList policyList={policyList} />
+      </Combobox>
+    </>
+  )
+}
+
+const ActionPolicyList = ({ policyList }: { policyList: any[] }) => {
+  const [query, setQuery] = useState('')
+  const [isFocused, setIsFocused] = useState(false)
+  const matchingPolicies = policyList
+    ?.filter((tpl) => {
+      if (query.length) {
+        return tpl.name.toLowerCase().includes(query.toLowerCase())
+      }
+
+      return true
+    })
+    .sort((prev, next) => prev.name.localeCompare(next.name))
+
+  return (
+    <div className="relative mt-1 w-full">
+      <div className="relative w-full cursor-default overflow-hidden rounded-md bg-white dark:bg-slate-700 text-left shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
+        <Combobox.Input
+          className="w-full rounded-md border-gray-300 dark:border-teal-500 dark:bg-slate-700 shadow-sm dark:shadow-slate-700 focus:border-indigo-500 focus:ring-indigo-500 dark:focus:ring-teal-500 sm:text-sm dark:text-gray-100"
+          onChange={(event) => setQuery(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          displayValue={(values) => {
+            // When focused from blur, display empty value allowing user to input their search query
+            return isFocused
+              ? ''
+              : // when blurred, selected values may be an array of strings or just a string
+              // when array, we apply the OR condition between multiple policies so show that
+              Array.isArray(values)
+              ? values.join(' OR ')
+              : values || ''
+          }}
+          placeholder="Type or click arrows to see all policies"
+        />
+        <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+          <ChevronUpDownIcon
+            className="h-5 w-5 text-gray-400"
+            aria-hidden="true"
+          />
+        </Combobox.Button>
+      </div>
+      <Transition
+        as={Fragment}
+        leave="transition ease-in duration-100"
+        leaveFrom="opacity-100"
+        leaveTo="opacity-0"
+        afterLeave={() => setQuery('')}
+      >
+        <Combobox.Options className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-slate-700 py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+          {!matchingPolicies?.length ? (
+            <NoPolicyOption query={query} />
+          ) : (
+            matchingPolicies?.map((tpl) => (
+              <Combobox.Option
+                key={tpl.name}
+                className={({ active }) =>
+                  `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                    active
+                      ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
+                      : 'text-gray-900 dark:text-gray-200'
+                  }`
+                }
+                value={tpl.name}
+              >
+                {({ selected, active }) => (
+                  <>
+                    {selected ? (
+                      <span
+                        className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                          active ? 'text-indigo-900' : 'text-indigo-600'
+                        }`}
+                      >
+                        <CheckIcon
+                          className="h-5 w-5 dark:text-gray-50"
+                          aria-hidden="true"
+                        />
+                      </span>
+                    ) : null}
+                    <div className="flex flex-row">
+                      <div>
+                        <p
+                          className={`block truncate ${
+                            selected ? 'font-medium' : 'font-normal'
+                          }`}
+                        >
+                          {tpl.name}
+                        </p>
+                        <p className="text-xs">{tpl.description}</p>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </Combobox.Option>
+            ))
+          )}
+        </Combobox.Options>
+      </Transition>
+    </div>
+  )
+}
+
 const NoPolicyOption = ({ query = '' }: { query?: string }) => {
+  const isAdmin = useServerConfig().role === ToolsOzoneTeamDefs.ROLEADMIN
   return (
     <div className="relative cursor-default select-none px-4 py-2 text-gray-700 dark:text-gray-100">
-      No policy found {query.length ? `matching "${query}"` : ''}
+      No policy found {query.length ? `matching "${query}"` : ''}.
+      {isAdmin && (
+        <a
+          target="_blank"
+          className="underline mx-1"
+          href="/configure?tab=policies"
+        >
+          Add policy
+        </a>
+      )}
+      <ArrowTopRightOnSquareIcon className="h-3 w-3 inline" />
     </div>
   )
 }

--- a/components/reports/ModerationForm/ActionPolicySelector.tsx
+++ b/components/reports/ModerationForm/ActionPolicySelector.tsx
@@ -1,45 +1,24 @@
-import { Dropdown } from '@/common/Dropdown'
+import { usePolicyListSetting } from '@/setting/policy/usePolicyList'
 import { Combobox, Transition } from '@headlessui/react'
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpDownIcon,
-} from '@heroicons/react/24/solid'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/solid'
 import { Fragment, useState } from 'react'
-
-const availablePolicies = {
-  trolling: {
-    name: 'Trolling',
-    description: 'Content that is intended to provoke or upset others',
-  },
-  spam: {
-    name: 'Spam',
-    description: 'Content that is irrelevant or repetitive',
-  },
-  hate: {
-    name: 'Hate Speech',
-    description: 'Content that promotes hate or violence against a group',
-  },
-}
-const policyList = Object.values(availablePolicies)
 
 export const ActionPolicySelector = ({
   defaultPolicy,
   onSelect,
-  name,
+  name = 'policy',
 }: {
   name?: string
   defaultPolicy?: string
   onSelect?: (name: string) => void
 }) => {
-  const [selected, setSelected] = useState('')
+  const { data, isLoading } = usePolicyListSetting()
+  const [selected, setSelected] = useState(defaultPolicy)
   const [query, setQuery] = useState('')
-  const [selectedPolicy, setSelectedPolicy] = useState<string | undefined>(
-    defaultPolicy,
-  )
+  const policyList = Object.values(data?.value || {})
   const matchingPolicies = policyList
     ?.filter((tpl) => {
-      if (selectedPolicy && tpl.name !== selectedPolicy) {
+      if (selected && tpl.name !== selected) {
         return false
       }
 
@@ -55,11 +34,12 @@ export const ActionPolicySelector = ({
     <>
       <Combobox
         value={selected}
+        disabled={isLoading}
         onChange={(selectedPolicy) => {
           setSelected(selectedPolicy)
           onSelect?.(selectedPolicy)
         }}
-        name="policy"
+        name={name}
       >
         <div className="relative mt-1 w-full">
           <div className="relative w-full cursor-default overflow-hidden rounded-md bg-white dark:bg-slate-700 text-left shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
@@ -84,7 +64,7 @@ export const ActionPolicySelector = ({
           >
             <Combobox.Options className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-slate-700 py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
               {!matchingPolicies?.length ? (
-                <NoPolicyOption {...{ selectedPolicy, query }} />
+                <NoPolicyOption query={query} />
               ) : (
                 matchingPolicies?.map((tpl) => (
                   <Combobox.Option
@@ -133,7 +113,6 @@ export const ActionPolicySelector = ({
           </Transition>
         </div>
       </Combobox>
-      {name && <input type="hidden" name={name} value={selected} />}
     </>
   )
 }

--- a/components/reports/ModerationForm/ActionPolicySelector.tsx
+++ b/components/reports/ModerationForm/ActionPolicySelector.tsx
@@ -101,7 +101,7 @@ const ActionPolicyList = ({ policyList }: { policyList: any[] }) => {
               ? values.join(' OR ')
               : values || ''
           }}
-          placeholder="Type or click arrows to see all policies"
+          placeholder="Select policy. Type or click arrows to see all policies"
         />
         <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
           <ChevronUpDownIcon

--- a/components/reports/ModerationForm/ActionPolicySelector.tsx
+++ b/components/reports/ModerationForm/ActionPolicySelector.tsx
@@ -18,10 +18,6 @@ export const ActionPolicySelector = ({
   const policyList = Object.values(data?.value || {})
   const matchingPolicies = policyList
     ?.filter((tpl) => {
-      if (selected && tpl.name !== selected) {
-        return false
-      }
-
       if (query.length) {
         return tpl.name.toLowerCase().includes(query.toLowerCase())
       }

--- a/components/setting/policy/Editor.tsx
+++ b/components/setting/policy/Editor.tsx
@@ -24,12 +24,16 @@ export const PolicyEditor = ({
           id="name"
           name="name"
           required
-          placeholder="Name of the policy. Only alphabets are allowed."
+          placeholder="Name of the policy. Only alphabetic characters are allowed."
           className="block w-full"
           pattern="[A-Za-z ]+"
         />
       </FormLabel>
-      <FormLabel label="Name" htmlFor="name" className="flex-1 mb-3">
+      <FormLabel
+        label="Description"
+        htmlFor="description"
+        className="flex-1 mb-3"
+      >
         <Textarea
           required
           id="description"

--- a/components/setting/policy/Editor.tsx
+++ b/components/setting/policy/Editor.tsx
@@ -30,6 +30,7 @@ export const PolicyEditor = ({
         />
       </FormLabel>
       <FormLabel
+        required
         label="Description"
         htmlFor="description"
         className="flex-1 mb-3"

--- a/components/setting/policy/Editor.tsx
+++ b/components/setting/policy/Editor.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { usePolicyListEditor } from './usePolicyList'
+import { FormLabel, Input, Textarea } from '@/common/forms'
+import { ActionButton } from '@/common/buttons'
+import { DocumentCheckIcon } from '@heroicons/react/24/solid'
+
+export const PolicyEditor = ({
+  onCancel,
+  onSuccess,
+}: {
+  onSuccess: () => void
+  onCancel: () => void
+}) => {
+  const { onSubmit, mutation } = usePolicyListEditor()
+  return (
+    <form
+      onSubmit={(e) => {
+        onSubmit(e).then(onSuccess).catch(onCancel)
+      }}
+    >
+      <FormLabel label="Name" htmlFor="name" className="flex-1 mb-3">
+        <Input
+          type="text"
+          id="name"
+          name="name"
+          required
+          placeholder="Name of the policy. Only alphabets are allowed."
+          className="block w-full"
+          pattern="[A-Za-z ]+"
+        />
+      </FormLabel>
+      <FormLabel label="Name" htmlFor="name" className="flex-1 mb-3">
+        <Textarea
+          required
+          id="description"
+          name="description"
+          className="block w-full"
+          placeholder="Additional details about the policy"
+        />
+      </FormLabel>
+
+      <div className="flex flex-row items-center gap-2">
+        <ActionButton
+          size="sm"
+          appearance="primary"
+          type="submit"
+          disabled={mutation.isLoading}
+        >
+          <DocumentCheckIcon className="h-4 w-4 mr-2" />
+          Save Policy
+        </ActionButton>
+        <ActionButton
+          size="sm"
+          appearance="outlined"
+          type="button"
+          disabled={mutation.isLoading}
+          onClick={onCancel}
+        >
+          Cancel
+        </ActionButton>
+      </div>
+    </form>
+  )
+}

--- a/components/setting/policy/List.tsx
+++ b/components/setting/policy/List.tsx
@@ -1,0 +1,95 @@
+import { ActionButton } from '@/common/buttons'
+import { Card } from '@/common/Card'
+import { TrashIcon } from '@heroicons/react/24/solid'
+import { ConfirmationModal } from '@/common/modals/confirmation'
+import { usePolicyListEditor, usePolicyListSetting } from './usePolicyList'
+
+export function PolicyList({
+  canEdit = false,
+  searchQuery,
+}: {
+  searchQuery: string | null
+  canEdit: boolean
+}) {
+  const { data, isLoading } = usePolicyListSetting()
+  const { onRemove, mutation, removingPolicy, setRemovingPolicy } =
+    usePolicyListEditor()
+  let policyList = Object.values(data?.value || {}).sort((prev, next) =>
+    prev.name.localeCompare(next.name),
+  )
+  if (searchQuery) {
+    policyList = policyList.filter((policy) =>
+      policy.name.toLowerCase().includes(searchQuery.toLowerCase()),
+    )
+  }
+
+  return (
+    <>
+      <Card className="mb-3 py-3">
+        {isLoading ? (
+          <p>Hang tight, we{"'"}re loading all policies...</p>
+        ) : (
+          <div>
+            {!policyList?.length && (
+              <p>
+                {!searchQuery
+                  ? 'No policies found.'
+                  : `No policy matches the prefix "${searchQuery}". Please clear your search to see all policies`}
+              </p>
+            )}
+            {policyList?.map((policy, i) => {
+              const lastItem = i === policyList.length - 1
+              return (
+                <div
+                  key={policy.name}
+                  className={`flex flex-row justify-between px-2 ${
+                    !lastItem
+                      ? 'mb-2 border-b dark:border-gray-700 border-gray-100 pb-3'
+                      : ''
+                  }`}
+                >
+                  <div>
+                    <p>{policy.name}</p>
+                    <p className="text-sm">{policy.description}</p>
+                  </div>
+                  {canEdit && (
+                    <div className="flex flex-row items-center gap-2">
+                      <ActionButton
+                        size="xs"
+                        appearance="outlined"
+                        onClick={() => {
+                          setRemovingPolicy(policy.name)
+                        }}
+                      >
+                        <TrashIcon className="h-3 w-3 mx-1" />
+                      </ActionButton>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+
+            <ConfirmationModal
+              onConfirm={() => {
+                onRemove(removingPolicy)
+              }}
+              isOpen={!!removingPolicy}
+              setIsOpen={() => setRemovingPolicy('')}
+              confirmButtonText="Yes, Remove Policy"
+              confirmButtonDisabled={mutation.isLoading}
+              error={mutation.error?.['message']}
+              title={`Remove Policy?`}
+              description={
+                <>
+                  You{"'"}re about to remove the filter policy{' '}
+                  {`"${removingPolicy}"`}. You can always recreate your policy
+                  from the event filter panel.
+                </>
+              }
+            />
+          </div>
+        )}
+      </Card>
+    </>
+  )
+}

--- a/components/setting/policy/types.ts
+++ b/components/setting/policy/types.ts
@@ -1,0 +1,6 @@
+export type PolicyDetail = {
+  name: string
+  description: string
+}
+
+export type PolicyListSetting = Record<string, PolicyDetail>

--- a/components/setting/policy/usePolicyList.tsx
+++ b/components/setting/policy/usePolicyList.tsx
@@ -1,0 +1,96 @@
+import { useLabelerAgent, useServerConfig } from '@/shell/ConfigurationContext'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { PolicyListSetting } from './types'
+import { ToolsOzoneTeamDefs } from '@atproto/api'
+import { toast } from 'react-toastify'
+import { useState } from 'react'
+
+const PolicyListSettingKey = 'tools.ozone.setting.policyList'
+const nameToKey = (name: string) => name.toLowerCase().replace(/\s/g, '-')
+
+export const usePolicyListSetting = () => {
+  const labelerAgent = useLabelerAgent()
+  return useQuery({
+    queryKey: ['policy-list'],
+    queryFn: async () => {
+      const { data } = await labelerAgent.tools.ozone.setting.listOptions({
+        scope: 'instance',
+        keys: [PolicyListSettingKey],
+      })
+
+      const policyListSetting = data.options.find(
+        (option) => option.key === PolicyListSettingKey,
+      )
+
+      return policyListSetting
+        ? {
+            ...policyListSetting,
+            value: policyListSetting.value as PolicyListSetting,
+          }
+        : null
+    },
+  })
+}
+
+export const usePolicyListEditor = () => {
+  const queryClient = useQueryClient()
+  const labelerAgent = useLabelerAgent()
+  const { data: initialSetting } = usePolicyListSetting()
+  const { role } = useServerConfig()
+  const [removingPolicy, setRemovingPolicy] = useState('')
+
+  const mutation = useMutation({
+    mutationKey: ['policy-list-setting', 'upsert'],
+    mutationFn: async (value: PolicyListSetting) => {
+      await labelerAgent.tools.ozone.setting.upsertOption({
+        value,
+        scope: 'instance',
+        key: PolicyListSettingKey,
+        managerRole: ToolsOzoneTeamDefs.ROLEADMIN,
+      })
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries(['policy-list'])
+      toast.success('Policy list updated')
+    },
+
+    onError: (error) => {
+      toast.error(`Failed to update policy list: ${error?.['message']}`)
+    },
+  })
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const name = formData.get('name')?.toString().trim() ?? ''
+    const description = formData.get('description')?.toString().trim() ?? ''
+    const newSetting = {
+      ...(initialSetting?.value ?? {}),
+      [nameToKey(name)]: {
+        name,
+        description,
+      },
+    }
+    await mutation.mutateAsync(newSetting)
+    e.currentTarget.reset()
+  }
+
+  const onRemove = async (name: string) => {
+    const newSetting = {
+      ...(initialSetting?.value ?? {}),
+    }
+    delete newSetting[nameToKey(name)]
+    await mutation.mutateAsync(newSetting)
+    setRemovingPolicy('')
+  }
+
+  return {
+    mutation,
+    onSubmit,
+    removingPolicy,
+    setRemovingPolicy,
+    onRemove,
+    canManagePolicies: role === ToolsOzoneTeamDefs.ROLEADMIN,
+  }
+}

--- a/components/setting/policy/utils.ts
+++ b/components/setting/policy/utils.ts
@@ -1,0 +1,9 @@
+export const createPolicyPageLink = (queryParams: Record<string, string>) => {
+  const url = new URL(window.location.href.replace(window.location.search, ''))
+
+  Object.entries({ tab: 'policies', ...queryParams }).forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+
+  return url.toString()
+}

--- a/components/setting/useQueueSetting.ts
+++ b/components/setting/useQueueSetting.ts
@@ -1,4 +1,4 @@
-import { useLabelerAgent, useServerConfig } from '@/shell/ConfigurationContext'
+import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { QUEUE_CONFIG } from '@/lib/constants'
 import { toast } from 'react-toastify'

--- a/components/shell/CommandPalette/Root.tsx
+++ b/components/shell/CommandPalette/Root.tsx
@@ -46,9 +46,7 @@ export const CommandPaletteRoot = ({
   children: React.ReactNode
 }) => {
   const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
-  const staticActions = getStaticActions({ router, pathname, searchParams })
+  const staticActions = getStaticActions({ router })
   return (
     <KBarProvider actions={staticActions}>
       <KBarPortal>

--- a/components/shell/CommandPalette/actions.ts
+++ b/components/shell/CommandPalette/actions.ts
@@ -1,15 +1,6 @@
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
-import { ReadonlyURLSearchParams } from 'next/navigation'
 
-export const getStaticActions = ({
-  router,
-  pathname,
-  searchParams,
-}: {
-  router: AppRouterInstance
-  pathname: string
-  searchParams: ReadonlyURLSearchParams
-}) => [
+export const getStaticActions = ({ router }: { router: AppRouterInstance }) => [
   {
     id: 'quick-action-modal',
     name: 'Open Quick Action Panel',
@@ -25,9 +16,10 @@ export const getStaticActions = ({
     shortcut: ['w'],
     keywords: 'workspace,panel',
     perform: () => {
-      const newParams = new URLSearchParams(searchParams)
+      const pathname = window.location.pathname
+      const newParams = new URLSearchParams(window.location.search)
       newParams.set('workspaceOpen', 'true')
-      router.push((pathname ?? '') + '?' + newParams.toString())
+      router.push(`${pathname}?${newParams.toString()}`)
     },
   },
   {

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -35,6 +35,7 @@ import { WorkspacePanelActions } from './PanelActions'
 import { useWorkspaceListData } from './useWorkspaceListData'
 import { isNonNullable, isValidDid } from '@/lib/util'
 import { EmailComposerData } from 'components/email/helpers'
+import { Alert } from '@/common/Alert'
 
 export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
   const { onClose, ...others } = props
@@ -223,6 +224,18 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
         coreEvent.sticky = true
       }
 
+      if (coreEvent.$type === MOD_EVENTS.TAKEDOWN) {
+        if (formData.get('policies')) {
+          coreEvent.policies = [String(formData.get('policies'))]
+        } else {
+          setSubmission({
+            isSubmitting: false,
+            error: 'Please select a policy for the takedown.',
+          })
+          return
+        }
+      }
+
       // @TODO: Limitation that we only allow adding tags/labels in bulk but not removal
       if (formData.get('tags')) {
         const isRemovingTags = formData.get('removeTags')
@@ -302,6 +315,7 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
       setSubmission({ error: (err as Error).message, isSubmitting: false })
     }
   }
+
   return (
     <FullScreenActionPanel
       title={
@@ -366,12 +380,23 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                   />
                 )}
                 {showActionForm && (
-                  <WorkspacePanelActionForm
-                    modEventType={modEventType}
-                    setModEventType={setModEventType}
-                    handleEmailSubmit={handleEmailSubmit}
-                    onCancel={() => setShowActionForm((current) => !current)}
-                  />
+                  <>
+                    <WorkspacePanelActionForm
+                      modEventType={modEventType}
+                      setModEventType={setModEventType}
+                      handleEmailSubmit={handleEmailSubmit}
+                      onCancel={() => setShowActionForm((current) => !current)}
+                    />
+                    {submission.error && (
+                      <div className="mb-3">
+                        <Alert
+                          type="error"
+                          body={submission.error}
+                          title="Error submitting bulk action"
+                        />
+                      </div>
+                    )}
+                  </>
                 )}
                 {/* The form component can't wrap the panel action form above because we may render the email composer */}
                 {/* inside the panel action form which is it's own form so we use form ids to avoid nesting forms */}

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -8,6 +8,7 @@ import { ModEventDetailsPopover } from '@/mod-event/DetailsPopover'
 import { WORKSPACE_FORM_ID } from './constants'
 import { EmailComposer } from 'components/email/Composer'
 import { EmailComposerData } from 'components/email/helpers'
+import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
 
 export const WorkspacePanelActionForm = ({
   handleEmailSubmit,
@@ -27,8 +28,7 @@ export const WorkspacePanelActionForm = ({
   const isMuteEvent = modEventType === MOD_EVENTS.MUTE
   const isTagEvent = modEventType === MOD_EVENTS.TAG
   const isLabelEvent = modEventType === MOD_EVENTS.LABEL
-  const shouldShowDurationInHoursField =
-    modEventType === MOD_EVENTS.TAKEDOWN || isMuteEvent
+  const shouldShowDurationInHoursField = isTakedownEvent || isMuteEvent
 
   return (
     <div className="mb-4 w-1/2">
@@ -57,17 +57,25 @@ export const WorkspacePanelActionForm = ({
       ) : (
         <div>
           {shouldShowDurationInHoursField && (
-            <FormLabel
-              label=""
-              htmlFor="durationInHours"
-              className={`mb-3 mt-2`}
-            >
-              <ActionDurationSelector
-                action={modEventType}
-                form={WORKSPACE_FORM_ID}
-                labelText={isMuteEvent ? 'Mute duration' : ''}
-              />
-            </FormLabel>
+            <div className="flex flex-row gap-2">
+              <FormLabel
+                label=""
+                htmlFor="durationInHours"
+                className={`mb-3 mt-2`}
+              >
+                <ActionDurationSelector
+                  action={modEventType}
+                  form={WORKSPACE_FORM_ID}
+                  labelText={isMuteEvent ? 'Mute duration' : ''}
+                />
+              </FormLabel>
+
+              {isTakedownEvent && (
+                <div className="mt-2 w-full">
+                  <ActionPolicySelector name="policies" />
+                </div>
+              )}
+            </div>
           )}
 
           {isLabelEvent && (

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.23",
+    "@atproto/api": "^0.13.25",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/service/package.json
+++ b/service/package.json
@@ -3,7 +3,7 @@
   "description": "Ozone service entrypoint",
   "main": "index.js",
   "dependencies": {
-    "@atproto/ozone": "0.1.63",
+    "@atproto/ozone": "0.1.64",
     "next": "14.2.5"
   }
 }

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@atproto/api@^0.13.24":
-  version "0.13.24"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.24.tgz#3fff2421a9d1db0e416155e378022a328d477b62"
-  integrity sha512-q9GHjaypnEyeag4plsWzP2eWaUfJWy9PHviBsJu5GauwMrGSU/4ijIqWwbFYzyXeWg85ErQxx6FqIne7HDbaVQ==
+"@atproto/api@^0.13.25":
+  version "0.13.25"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.25.tgz#917d6ae75e0c176166f67b7c340944c84a7c6413"
+  integrity sha512-5tz2NvYO7W9+0PV7x4k4KIAIazQI6Km+q4/+O6VUoNSqHsF3ry9/9mjcZKBoJLdmcVtZdcKSlPUTtxthan6iKw==
   dependencies:
     "@atproto/common-web" "^0.3.1"
     "@atproto/lexicon" "^0.4.4"
@@ -88,12 +88,12 @@
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/ozone@0.1.63":
-  version "0.1.63"
-  resolved "https://registry.yarnpkg.com/@atproto/ozone/-/ozone-0.1.63.tgz#0952519a310fd2071879ea72b5a67b5c891bc881"
-  integrity sha512-/YTunTH5Z8r5nNHCg10je6l0FI3hGxSmsmEfZ+gRdiNt9eU8Wtm8CVVB37PhRYRzJ9FyTRvLhA/WXlokcgOw+Q==
+"@atproto/ozone@0.1.64":
+  version "0.1.64"
+  resolved "https://registry.yarnpkg.com/@atproto/ozone/-/ozone-0.1.64.tgz#babd67fdfaef1a21423e49033a02c82a54ec09e3"
+  integrity sha512-1eJFx29eG+HW0jFGCsQM/DYI5Yy3PxDuCJk7nDj+s35IcgadV3Hv0d6QzsnL+IRygJetzfS7PewyZTbnh41x4Q==
   dependencies:
-    "@atproto/api" "^0.13.24"
+    "@atproto/api" "^0.13.25"
     "@atproto/common" "^0.4.5"
     "@atproto/crypto" "^0.4.2"
     "@atproto/identity" "^0.4.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
       "@/dms/*": ["components/dms/*"],
       "@/workspace/*": ["components/workspace/*"],
       "@/sets/*": ["components/sets/*"],
+      "@/setting/*": ["components/setting/*"],
     }
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@^0.13.23":
-  version "0.13.23"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.23.tgz#f65d0d7946afa4ca467b7763b056f0824432bcf6"
-  integrity sha512-V1Z5kgfSsqlFaC14sjnZL1Psv/9Lq/YKW1w7TIBq948Rtq8l+c6BpGrOH2Ssdcphpqi4OSeSYRsmJJlD6GGJ5w==
+"@atproto/api@^0.13.25":
+  version "0.13.25"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.25.tgz#917d6ae75e0c176166f67b7c340944c84a7c6413"
+  integrity sha512-5tz2NvYO7W9+0PV7x4k4KIAIazQI6Km+q4/+O6VUoNSqHsF3ry9/9mjcZKBoJLdmcVtZdcKSlPUTtxthan6iKw==
   dependencies:
     "@atproto/common-web" "^0.3.1"
     "@atproto/lexicon" "^0.4.4"


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/3271

This PR adds a new setting panel for managing a list of policies for takedown action. When taking a subject down moderators can *optionally* chose a policy from the list to associate with the takedown. 

https://github.com/user-attachments/assets/7ac61b69-c7a4-451a-99ed-907ec78e126b


