### PR TITLE
:sparkles: Pass queue config to the server query when fetching statuses

### DIFF
--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -398,7 +398,6 @@ function useModerationQueueQuery() {
         labelerAgent,
         queryParams,
         queueName,
-        0,
         queueSetting.data
           ? {
               queueNames: queueSetting.data.queueNames,
@@ -415,51 +414,22 @@ const getQueueItems = async (
   labelerAgent: Agent,
   queryParams: ToolsOzoneModerationQueryStatuses.QueryParams,
   queueName: string | null,
-  attempt = 0,
   queueSetting?: { queueNames: string[]; queueSeed: string },
 ) => {
   const pageSize = 100
+
+  if (queueName && queueSetting?.queueNames.length) {
+    queryParams.queueCount = queueSetting.queueNames.length
+    queryParams.queueIndex = queueSetting.queueNames.indexOf(queueName)
+    if (queueSetting.queueSeed) {
+      queryParams.queueSeed = queueSetting.queueSeed
+    }
+  }
   const { data } = await labelerAgent.tools.ozone.moderation.queryStatuses({
     limit: pageSize,
     includeMuted: true,
     ...queryParams,
   })
 
-  const queueIndex = queueSetting?.queueNames.indexOf(queueName ?? '')
-  const statusesInQueue = queueName
-    ? data.subjectStatuses.filter((status) => {
-        const subjectDid = ComAtprotoAdminDefs.isRepoRef(status.subject)
-          ? status.subject.did
-          : new AtUri(`${status.subject.uri}`).host
-        return (
-          getQueueIndex(
-            subjectDid,
-            queueSetting?.queueNames || [],
-            queueSetting?.queueSeed || '',
-          ) === queueIndex
-        )
-      })
-    : data.subjectStatuses
-
-  // This is a recursive call to get items in queue if the current page
-  // gives us less than full page size and there are more items to fetch
-  // also, use a circuit breaker to make sure we never accidentally call this more than 10 times
-  if (statusesInQueue.length === 0 && data.cursor && attempt < 10) {
-    return getQueueItems(
-      labelerAgent,
-      {
-        ...queryParams,
-        cursor: data.cursor,
-      },
-      queueName,
-      ++attempt,
-      queueSetting,
-    )
-  }
-
-  return { cursor: data.cursor, subjectStatuses: statusesInQueue }
-}
-
-function getQueueIndex(did: string, queueNames: string[], queueSeed: string) {
-  return simpleHash(`${queueSeed}:${did}`) % queueNames.length
+  return data
 }

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -419,10 +419,14 @@ const getQueueItems = async (
   const pageSize = 100
 
   if (queueName && queueSetting?.queueNames.length) {
-    queryParams.queueCount = queueSetting.queueNames.length
-    queryParams.queueIndex = queueSetting.queueNames.indexOf(queueName)
-    if (queueSetting.queueSeed) {
-      queryParams.queueSeed = queueSetting.queueSeed
+    const queueIndex = queueSetting.queueNames.indexOf(queueName)
+    // Only apply queue filters if the user is looking at a queue that exists in the list of queues
+    if (queueIndex >= 0) {
+      queryParams.queueIndex = queueIndex
+      queryParams.queueCount = queueSetting.queueNames.length
+      if (queueSetting.queueSeed) {
+        queryParams.queueSeed = queueSetting.queueSeed
+      }
     }
   }
   const { data } = await labelerAgent.tools.ozone.moderation.queryStatuses({

--- a/components/config/Labeler.tsx
+++ b/components/config/Labeler.tsx
@@ -41,8 +41,8 @@ export function LabelerConfig() {
       )}
 
       <ServerConfig />
-      <LocalPreferences />
       <QueueSetting />
+      <LocalPreferences />
       <ExternalLabelerConfig />
     </div>
   )

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -66,7 +66,7 @@ export const LocalPreferences = () => {
           You can choose to make media content (video and image) with the
           following labels appear on your screen with your preferred filter.
           <br />
-          This is your personal configuration and won't be shared with other
+          This is your personal configuration and won{"'"}t be shared with other
           moderators.
         </p>
 

--- a/components/config/LocalPreferences.tsx
+++ b/components/config/LocalPreferences.tsx
@@ -65,6 +65,9 @@ export const LocalPreferences = () => {
         <p className="text-sm mb-2">
           You can choose to make media content (video and image) with the
           following labels appear on your screen with your preferred filter.
+          <br />
+          This is your personal configuration and won't be shared with other
+          moderators.
         </p>
 
         <form onSubmit={handleSubmit}>

--- a/components/config/external-labeler.tsx
+++ b/components/config/external-labeler.tsx
@@ -46,7 +46,9 @@ export const ExternalLabelerConfig = () => {
             subscriptions there.
           </p>
           <p className="mt-1 text-sm text-gray-900 dark:text-gray-200">
-            You can unsubscribe from any external labeler at any time.
+            You can unsubscribe from any external labeler at any time. This is
+            your personal configuration and won't be shared with other
+            moderators.
           </p>
 
           <div className="flex flex-row justify-end items-end my-3 gap-2">

--- a/components/config/external-labeler.tsx
+++ b/components/config/external-labeler.tsx
@@ -47,7 +47,7 @@ export const ExternalLabelerConfig = () => {
           </p>
           <p className="mt-1 text-sm text-gray-900 dark:text-gray-200">
             You can unsubscribe from any external labeler at any time. This is
-            your personal configuration and won't be shared with other
+            your personal configuration and won{"'"}t be shared with other
             moderators.
           </p>
 

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -31,6 +31,38 @@ const LinkToAuthor = ({
   )
 }
 
+// Utility function to detect and replace links with <a> tags
+const wrapLinksInText = (text: string): JSX.Element[] => {
+  // Regular expression to match URLs
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+
+  // Split text into parts, with URLs as matches
+  const parts = text.split(urlRegex)
+
+  return parts.map((part, index) => {
+    if (urlRegex.test(part)) {
+      // If part matches a URL, return it as a link
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all underline"
+        >
+          {part}
+        </a>
+      )
+    }
+    // Otherwise, return it as plain text
+    return <span key={index}>{part}</span>
+  })
+}
+
+const TextWithLinks: React.FC<{ text: string }> = ({ text }) => {
+  return <p className="whitespace-pre-wrap">{wrapLinksInText(text)}</p>
+}
+
 const Comment = ({
   modEvent,
 }: {
@@ -60,7 +92,9 @@ const Comment = ({
           )}
         </div>
       </div>
-      {modEvent.event.comment && <p>{modEvent.event.comment}</p>}
+      {modEvent.event.comment && (
+        <TextWithLinks text={modEvent.event.comment} />
+      )}
       {/* This is only for legacy actions, new actions won't have these properties for these events */}
       <EventLabels
         header="Added: "
@@ -141,7 +175,7 @@ const Report = ({
         </div>
       </div>
       {modEvent.event.comment && (
-        <p className="mt-1">{modEvent.event.comment}</p>
+        <TextWithLinks text={modEvent.event.comment} />
       )}
 
       {isMessageSubject(modEvent.subject) && (

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.19",
+    "@atproto/api": "^0.13.23",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/service/package.json
+++ b/service/package.json
@@ -3,7 +3,7 @@
   "description": "Ozone service entrypoint",
   "main": "index.js",
   "dependencies": {
-    "@atproto/ozone": "0.1.58",
+    "@atproto/ozone": "0.1.62",
     "next": "14.2.5"
   }
 }

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@atproto/api@^0.13.19":
-  version "0.13.19"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.19.tgz#a3b47847bfe00d3f83da2bd3f6dc5566f43887b0"
-  integrity sha512-rLWQBZaOIk3ds1Fx9CwrdyX3X2GbdSEvVJ9mdSPNX40joiEaE1ljGMOcziFipbvZacXynozE4E0Sb1CgOhzfmA==
+"@atproto/api@^0.13.23":
+  version "0.13.23"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.23.tgz#f65d0d7946afa4ca467b7763b056f0824432bcf6"
+  integrity sha512-V1Z5kgfSsqlFaC14sjnZL1Psv/9Lq/YKW1w7TIBq948Rtq8l+c6BpGrOH2Ssdcphpqi4OSeSYRsmJJlD6GGJ5w==
   dependencies:
     "@atproto/common-web" "^0.3.1"
-    "@atproto/lexicon" "^0.4.3"
+    "@atproto/lexicon" "^0.4.4"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.4"
+    "@atproto/xrpc" "^0.6.5"
     await-lock "^2.2.2"
     multiformats "^9.9.0"
     tlds "^1.234.0"
@@ -36,10 +36,10 @@
     pino "^8.6.1"
     zod "^3.14.2"
 
-"@atproto/common@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@atproto/common/-/common-0.4.4.tgz#79096aef920f5ad7cda5c682d7ed7416d0581e1a"
-  integrity sha512-58tMbn6A1Zu296s/l3uIj8z9d7IRHpZvLOfsFRikaQaYrzhJpL2aPY4uFQ8GJcxnsxeUnxBCrQz9we5jVVJI5Q==
+"@atproto/common@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@atproto/common/-/common-0.4.5.tgz#28fd176a9b5527c723828e725586bc0be9fa9516"
+  integrity sha512-LFAGqHcxCI5+b31Xgk+VQQtZU258iGPpHJzNeHVcdh6teIKZi4C2l6YV+m+3CEz+yYcfP7jjUmgqesx7l9Arsg==
   dependencies:
     "@atproto/common-web" "^0.3.1"
     "@ipld/dag-cbor" "^7.0.3"
@@ -77,10 +77,10 @@
     "@atproto/crypto" "^0.4.2"
     axios "^0.27.2"
 
-"@atproto/lexicon@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.3.tgz#d69f6bb363a6326df7766c48132bfa30e22622d9"
-  integrity sha512-lFVZXe1S1pJP0dcxvJuHP3r/a+EAIBwwU7jUK+r8iLhIja+ml6NmYv8KeFHmIJATh03spEQ9s02duDmFVdCoXg==
+"@atproto/lexicon@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.4.tgz#0d97314bb57b693b76f2495fa5e02872469dd93a"
+  integrity sha512-QFEmr3rpj/RoAmfX9ALU/asBG/rsVtQZnw+9nOB1/AuIwoxXd+ZyndR6lVUc2+DL4GEjl6W2yvBru5xbQIZWyA==
   dependencies:
     "@atproto/common-web" "^0.3.1"
     "@atproto/syntax" "^0.3.1"
@@ -88,19 +88,19 @@
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/ozone@0.1.58":
-  version "0.1.58"
-  resolved "https://registry.yarnpkg.com/@atproto/ozone/-/ozone-0.1.58.tgz#578d1cd2d0ce53648c633859f0ea5545971cf583"
-  integrity sha512-GdW/vZQGsPf3R+p/APPIdxKggfkiHl38+HVfykqxbCTvPKC0jheRXg8I93hsCPNWXg50A2Aei1YEQg15SOCNwQ==
+"@atproto/ozone@0.1.62":
+  version "0.1.62"
+  resolved "https://registry.yarnpkg.com/@atproto/ozone/-/ozone-0.1.62.tgz#53974547a89edfd2884c05343c2fe06b12c0888f"
+  integrity sha512-xM/y3elUsjXRWCoffNf5A9BNM2GsodsuvJgLzSTjm4vTsuGz/J821ZMq/09+bGAFq3swB/OCQwXx0h+SkY0CFQ==
   dependencies:
-    "@atproto/api" "^0.13.19"
-    "@atproto/common" "^0.4.4"
+    "@atproto/api" "^0.13.23"
+    "@atproto/common" "^0.4.5"
     "@atproto/crypto" "^0.4.2"
     "@atproto/identity" "^0.4.3"
-    "@atproto/lexicon" "^0.4.3"
+    "@atproto/lexicon" "^0.4.4"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.4"
-    "@atproto/xrpc-server" "^0.7.3"
+    "@atproto/xrpc" "^0.6.5"
+    "@atproto/xrpc-server" "^0.7.4"
     "@did-plc/lib" "^0.0.1"
     axios "^1.6.7"
     compression "^1.7.4"
@@ -122,15 +122,15 @@
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.1.tgz#4346418728f9643d783d2ffcf7c77e132e1f53d4"
   integrity sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==
 
-"@atproto/xrpc-server@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc-server/-/xrpc-server-0.7.3.tgz#d09b36d00edb7aacca48675d1ebb7fa796fa11bd"
-  integrity sha512-x0qegkN6snrbXJO3v9h2kuh9e90g6ZZkDXv3COiraGS3yRTzIm6i4bMvDSfCI50+0xCNtPKOkpn8taRoRgkyiw==
+"@atproto/xrpc-server@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@atproto/xrpc-server/-/xrpc-server-0.7.4.tgz#dfac8f7276c1c971a35eaba627eb6372088441c3"
+  integrity sha512-MrAwxfJBQm/kCol3D8qc+vpQzBMzLqvtUbauSSfVVJ10PlGtxg4LlXqcjkAuhrjyrqp3dQH9LHuhDpgVQK+G3w==
   dependencies:
-    "@atproto/common" "^0.4.4"
+    "@atproto/common" "^0.4.5"
     "@atproto/crypto" "^0.4.2"
-    "@atproto/lexicon" "^0.4.3"
-    "@atproto/xrpc" "^0.6.4"
+    "@atproto/lexicon" "^0.4.4"
+    "@atproto/xrpc" "^0.6.5"
     cbor-x "^1.5.1"
     express "^4.17.2"
     http-errors "^2.0.0"
@@ -140,12 +140,12 @@
     ws "^8.12.0"
     zod "^3.23.8"
 
-"@atproto/xrpc@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.4.tgz#4cf59774f7c72e5bc821bc5f1d57f0a6ae2014db"
-  integrity sha512-9ZAJ8nsXTqC4XFyS0E1Wlg7bAvonhXQNQ3Ocs1L1LIwFLXvsw/4fNpIHXxvXvqTCVeyHLbImOnE9UiO1c/qIYA==
+"@atproto/xrpc@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.5.tgz#8b180fc5f6b8374fd00c41b9e4cd7b24ead48e6b"
+  integrity sha512-t6u8iPEVbWge5RhzKZDahSzNDYIAxUtop6Q/X/apAZY1rgreVU0/1sSvvRoRFH19d3UIKjYdLuwFqMi9w8nY3Q==
   dependencies:
-    "@atproto/lexicon" "^0.4.3"
+    "@atproto/lexicon" "^0.4.4"
     zod "^3.23.8"
 
 "@cbor-extract/cbor-extract-darwin-arm64@2.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,15 +60,15 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@^0.13.19":
-  version "0.13.19"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.19.tgz#a3b47847bfe00d3f83da2bd3f6dc5566f43887b0"
-  integrity sha512-rLWQBZaOIk3ds1Fx9CwrdyX3X2GbdSEvVJ9mdSPNX40joiEaE1ljGMOcziFipbvZacXynozE4E0Sb1CgOhzfmA==
+"@atproto/api@^0.13.23":
+  version "0.13.23"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.23.tgz#f65d0d7946afa4ca467b7763b056f0824432bcf6"
+  integrity sha512-V1Z5kgfSsqlFaC14sjnZL1Psv/9Lq/YKW1w7TIBq948Rtq8l+c6BpGrOH2Ssdcphpqi4OSeSYRsmJJlD6GGJ5w==
   dependencies:
     "@atproto/common-web" "^0.3.1"
-    "@atproto/lexicon" "^0.4.3"
+    "@atproto/lexicon" "^0.4.4"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.4"
+    "@atproto/xrpc" "^0.6.5"
     await-lock "^2.2.2"
     multiformats "^9.9.0"
     tlds "^1.234.0"
@@ -136,10 +136,10 @@
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/lexicon@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.3.tgz#d69f6bb363a6326df7766c48132bfa30e22622d9"
-  integrity sha512-lFVZXe1S1pJP0dcxvJuHP3r/a+EAIBwwU7jUK+r8iLhIja+ml6NmYv8KeFHmIJATh03spEQ9s02duDmFVdCoXg==
+"@atproto/lexicon@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.4.tgz#0d97314bb57b693b76f2495fa5e02872469dd93a"
+  integrity sha512-QFEmr3rpj/RoAmfX9ALU/asBG/rsVtQZnw+9nOB1/AuIwoxXd+ZyndR6lVUc2+DL4GEjl6W2yvBru5xbQIZWyA==
   dependencies:
     "@atproto/common-web" "^0.3.1"
     "@atproto/syntax" "^0.3.1"
@@ -205,12 +205,12 @@
     "@atproto/lexicon" "^0.4.1"
     zod "^3.23.8"
 
-"@atproto/xrpc@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.4.tgz#4cf59774f7c72e5bc821bc5f1d57f0a6ae2014db"
-  integrity sha512-9ZAJ8nsXTqC4XFyS0E1Wlg7bAvonhXQNQ3Ocs1L1LIwFLXvsw/4fNpIHXxvXvqTCVeyHLbImOnE9UiO1c/qIYA==
+"@atproto/xrpc@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.5.tgz#8b180fc5f6b8374fd00c41b9e4cd7b24ead48e6b"
+  integrity sha512-t6u8iPEVbWge5RhzKZDahSzNDYIAxUtop6Q/X/apAZY1rgreVU0/1sSvvRoRFH19d3UIKjYdLuwFqMi9w8nY3Q==
   dependencies:
-    "@atproto/lexicon" "^0.4.3"
+    "@atproto/lexicon" "^0.4.4"
     zod "^3.23.8"
 
 "@babel/runtime@^7.1.2":


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/3280

This PR removes the client side queue splitting and passes the queue config to the request when calling `queryStatuses` so that the db query on the server can take care of the splitting.