### PR TITLE
:sparkles: Show subject stats/summary

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -60,7 +60,6 @@ import { SubjectTag } from 'components/tags/SubjectTag'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { EmailComposer } from 'components/email/Composer'
 import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
-import { SubjectSummary } from '@/subject/Summary'
 
 const FORM_ID = 'mod-action-panel'
 const useBreakpoint = createBreakpoint({ xs: 340, sm: 640 })

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -60,6 +60,7 @@ import { SubjectTag } from 'components/tags/SubjectTag'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { EmailComposer } from 'components/email/Composer'
 import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
+import { SubjectSummary } from '@/subject/Summary'
 
 const FORM_ID = 'mod-action-panel'
 const useBreakpoint = createBreakpoint({ xs: 340, sm: 640 })
@@ -670,7 +671,15 @@ function Form(
               {/* This is only meant to be switched on in mobile/small screen view */}
               {/* The parent component ensures to toggle this based on the screen size */}
               {replaceFormWithEvents ? (
-                <ModEventList subject={subject} />
+                <>
+                  <ModEventList
+                    subject={subject}
+                    stats={{
+                      accountStats: subjectStatus?.accountStats,
+                      recordsStats: subjectStatus?.recordsStats,
+                    }}
+                  />
+                </>
               ) : (
                 <div className="px-1">
                   {profile && (
@@ -886,7 +895,13 @@ function Form(
         </div>
         {!replaceFormWithEvents && (
           <div className="hidden sm:block sm:w-1/2 sm:pl-4">
-            <ModEventList subject={subject} />
+            <ModEventList
+              stats={{
+                accountStats: subjectStatus?.accountStats,
+                recordsStats: subjectStatus?.recordsStats,
+              }}
+              subject={subject}
+            />
           </div>
         )}
       </div>

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -184,7 +184,14 @@ const getSortParams = (params: ReadonlyURLSearchParams) => {
     sortDirection = 'desc'
   }
 
-  if (!['lastReportedAt', 'lastReviewedAt'].includes(sortField ?? '')) {
+  if (
+    ![
+      'lastReportedAt',
+      'lastReviewedAt',
+      'reportedRecordsCount',
+      'takendownRecordsCount',
+    ].includes(sortField ?? '')
+  ) {
     sortField = 'lastReportedAt'
   }
 

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -313,6 +313,9 @@ function useModerationQueueQuery() {
   const queueName = params.get('queueName')
   const subjectType = params.get('subjectType')
   const collections = params.get('collections')
+  const minAccountSuspendCount = params.get('minAccountSuspendCount')
+  const minReportedRecordsCount = params.get('minReportedRecordsCount')
+  const minTakendownRecordsCount = params.get('minTakendownRecordsCount')
   const { sortField, sortDirection } = getSortParams(params)
   const { lastReviewedBy, subject, reporters, includeAllUserRecords } =
     useFluentReportSearchParams()
@@ -337,6 +340,8 @@ function useModerationQueueQuery() {
         onlyMuted,
         subjectType,
         collections,
+        minAccountSuspendCount,
+        minReportedRecordsCount,
       },
     ],
     queryFn: async ({ pageParam }) => {
@@ -387,6 +392,18 @@ function useModerationQueueQuery() {
 
       if (excludeTags) {
         queryParams.excludeTags = excludeTags.split(',')
+      }
+
+      if (minAccountSuspendCount) {
+        queryParams.minAccountSuspendCount = Number(minAccountSuspendCount)
+      }
+
+      if (minReportedRecordsCount) {
+        queryParams.minReportedRecordsCount = Number(minReportedRecordsCount)
+      }
+
+      if (minTakendownRecordsCount) {
+        queryParams.minTakendownRecordsCount = Number(minTakendownRecordsCount)
       }
 
       // For these fields, we only want to add them to the filter if the values are set, otherwise, defaults will kick in

--- a/components/common/buttons.tsx
+++ b/components/common/buttons.tsx
@@ -96,7 +96,6 @@ const buttonSpaceMap = {
 }
 
 export const ButtonGroup = ({
-  appearance,
   size = 'sm',
   items,
   leftAligned = false,

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -21,6 +21,9 @@ import {
 } from '@heroicons/react/24/solid'
 import { EventFilterPanel } from './FilterPanel'
 import { ConfirmationModal } from '@/common/modals/confirmation'
+import { ToolsOzoneModerationDefs } from '@atproto/api'
+import { SubjectSummary } from '@/subject/Summary'
+import { MOD_EVENTS } from './constants'
 
 const getConfirmWorkspaceTitle = (
   showWorkspaceConfirmation: WorkspaceConfirmationOptions,
@@ -126,7 +129,14 @@ const Header = ({
 }
 
 export const ModEventList = (
-  props: { subject?: string; createdBy?: string } & ModEventListQueryOptions,
+  props: {
+    subject?: string
+    createdBy?: string
+    stats?: {
+      accountStats: ToolsOzoneModerationDefs.AccountStats
+      recordsStats: ToolsOzoneModerationDefs.RecordsStats
+    }
+  } & ModEventListQueryOptions,
 ) => {
   const {
     types,
@@ -203,6 +213,14 @@ export const ModEventList = (
 
   return (
     <div className="mr-1">
+      {!!props.stats && (
+        <SubjectSummary
+          onAccountTakedownClick={() => {
+            changeListFilter({ field: 'types', value: [MOD_EVENTS.TAKEDOWN] })
+          }}
+          stats={props.stats}
+        />
+      )}
       <div className="flex flex-row justify-between items-center">
         {!isEntireHistoryView ? (
           <Header

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -194,6 +194,13 @@ export const ModEventList = (
     },
   ]
 
+  if (hasFilter) {
+    eventActions.push({
+      text: 'Clear filters',
+      onClick: () => resetListFilters(),
+    })
+  }
+
   if (!noEvents) {
     eventActions.push(
       {

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -133,8 +133,8 @@ export const ModEventList = (
     subject?: string
     createdBy?: string
     stats?: {
-      accountStats: ToolsOzoneModerationDefs.AccountStats
-      recordsStats: ToolsOzoneModerationDefs.RecordsStats
+      accountStats?: ToolsOzoneModerationDefs.AccountStats
+      recordsStats?: ToolsOzoneModerationDefs.RecordsStats
     }
   } & ModEventListQueryOptions,
 ) => {

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -200,7 +200,11 @@ const eventListReducer = (state: EventListState, action: EventListAction) => {
 }
 
 export const useModEventList = (
-  props: { subject?: string; createdBy?: string } & ModEventListQueryOptions,
+  props: {
+    subject?: string
+    createdBy?: string
+    eventType?: string
+  } & ModEventListQueryOptions,
 ) => {
   const [showWorkspaceConfirmation, setShowWorkspaceConfirmation] =
     useState<WorkspaceConfirmationOptions>(null)
@@ -227,6 +231,15 @@ export const useModEventList = (
       })
     }
   }, [props.createdBy])
+
+  useEffect(() => {
+    if (props.eventType) {
+      dispatch({
+        type: 'SET_FILTER',
+        payload: { field: 'types', value: [props.eventType] },
+      })
+    }
+  }, [props.eventType])
 
   const results = useInfiniteQuery<{
     events: ModEventViewWithDetails[]

--- a/components/reports/QueueFilter/Panel.tsx
+++ b/components/reports/QueueFilter/Panel.tsx
@@ -8,6 +8,7 @@ import { getLanguageFlag } from 'components/tags/SubjectTag'
 import { getCollectionName } from '../helpers/subject'
 import { classNames } from '@/lib/util'
 import { QueueFilterTags } from './Tag'
+import { QueueFilterStats } from './Stats'
 
 const buildTagFilterSummary = (tags: string[]) => {
   const filtered = tags.filter(Boolean)
@@ -147,6 +148,8 @@ export const QueueFilterPanel = () => {
                 <div className="flex flex-row px-2 gap-6">
                   <QueueFilterSubjectType />
                 </div>
+
+                <QueueFilterStats />
 
                 <QueueFilterTags />
               </div>

--- a/components/reports/QueueFilter/Panel.tsx
+++ b/components/reports/QueueFilter/Panel.tsx
@@ -148,10 +148,8 @@ export const QueueFilterPanel = () => {
                 <div className="flex flex-row px-2 gap-6">
                   <QueueFilterSubjectType />
                 </div>
-
-                <QueueFilterStats />
-
                 <QueueFilterTags />
+                <QueueFilterStats />
               </div>
             </Popover.Panel>
           </Transition>

--- a/components/reports/QueueFilter/Stats.tsx
+++ b/components/reports/QueueFilter/Stats.tsx
@@ -24,7 +24,7 @@ export const QueueFilterStats = () => {
     <div className="flex flex-row gap-6">
       <div className="px-2 mt-4">
         <div className="flex flex-row gap-2">
-          <FormLabel label="Suspension count" className="mb-2">
+          <FormLabel label="Min. Suspension count" className="mb-2">
             <Input
               type="number"
               className="block w-full"
@@ -34,7 +34,7 @@ export const QueueFilterStats = () => {
               onChange={handleInputChange(setMinAccountSuspendCount)}
             />
           </FormLabel>
-          <FormLabel label="Reported records">
+          <FormLabel label="Min. Reported records">
             <Input
               type="number"
               className="block w-full"
@@ -45,7 +45,7 @@ export const QueueFilterStats = () => {
             />
           </FormLabel>
         </div>
-        <FormLabel label="Takendown records">
+        <FormLabel label="Min. Takendown records">
           <Input
             type="number"
             className="block w-full"

--- a/components/reports/QueueFilter/Stats.tsx
+++ b/components/reports/QueueFilter/Stats.tsx
@@ -1,0 +1,61 @@
+import { FormLabel, Input } from '@/common/forms'
+import { useQueueFilter } from '../useQueueFilter'
+
+export const QueueFilterStats = () => {
+  const {
+    queueFilters,
+    setMinAccountSuspendCount,
+    setMinReportedRecordsCount,
+    setMinTakendownRecordsCount,
+  } = useQueueFilter()
+
+  const handleInputChange =
+    (handler: (val?: number) => void) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const inputValue = e.target.value
+      if (inputValue === '') {
+        handler(undefined)
+      } else if (/^\d*$/.test(inputValue)) {
+        // Allow only digits by filtering non-numeric characters
+        handler(Number(inputValue))
+      }
+    }
+  return (
+    <div className="flex flex-row gap-6">
+      <div className="px-2 mt-4">
+        <div className="flex flex-row gap-2">
+          <FormLabel label="Suspension count" className="mb-2">
+            <Input
+              type="number"
+              className="block w-full"
+              id="minAccountSuspendCount"
+              name="minAccountSuspendCount"
+              value={queueFilters.minAccountSuspendCount || ''}
+              onChange={handleInputChange(setMinAccountSuspendCount)}
+            />
+          </FormLabel>
+          <FormLabel label="Reported records">
+            <Input
+              type="number"
+              className="block w-full"
+              id="minReportedRecordsCount"
+              name="minReportedRecordsCount"
+              value={queueFilters.minReportedRecordsCount || ''}
+              onChange={handleInputChange(setMinReportedRecordsCount)}
+            />
+          </FormLabel>
+        </div>
+        <FormLabel label="Takendown records">
+          <Input
+            type="number"
+            className="block w-full"
+            id="minTakendownRecordsCount"
+            name="minTakendownRecordsCount"
+            value={queueFilters.minTakendownRecordsCount || ''}
+            onChange={handleInputChange(setMinTakendownRecordsCount)}
+          />
+        </FormLabel>
+      </div>
+    </div>
+  )
+}

--- a/components/reports/useQueueFilter.tsx
+++ b/components/reports/useQueueFilter.tsx
@@ -123,6 +123,18 @@ export const useQueueFilter = () => {
     updateFilters({ tags: [] })
   }
 
+  const setMinAccountSuspendCount = (minAccountSuspendCount?: number) => {
+    updateFilters({ minAccountSuspendCount })
+  }
+
+  const setMinReportedRecordsCount = (minReportedRecordsCount?: number) => {
+    updateFilters({ minReportedRecordsCount })
+  }
+
+  const setMinTakendownRecordsCount = (minTakendownRecordsCount?: number) => {
+    updateFilters({ minTakendownRecordsCount })
+  }
+
   return {
     queueFilters,
     updateFilters,
@@ -132,5 +144,8 @@ export const useQueueFilter = () => {
     toggleSubjectType,
     clearSubjectType,
     clearTags,
+    setMinAccountSuspendCount,
+    setMinReportedRecordsCount,
+    setMinTakendownRecordsCount,
   }
 }

--- a/components/repositories/RepositoriesTable.tsx
+++ b/components/repositories/RepositoriesTable.tsx
@@ -89,6 +89,11 @@ function RepoRow(props: { repo: Repo; showEmail: boolean }) {
             />
           )}
         </div>
+        {subjectStatus?.comment && (
+          <p className="text-xs dark:text-gray-300 text-gray-700 max-w-xs">
+            <b>Note:</b> {subjectStatus.comment}
+          </p>
+        )}
         <dl className="font-normal lg:hidden">
           <dt className="sr-only">Name</dt>
           <dd className="mt-1 truncate text-gray-700 dark:text-gray-100">

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -142,8 +142,10 @@ export const AccountStats = ({
 export const RecordsStats = ({
   stats,
   showAll,
+  onlyNumbers,
 }: {
   showAll: boolean
+  onlyNumbers?: boolean
   stats: ToolsOzoneModerationDefs.RecordsStats
 }) => {
   const {
@@ -153,7 +155,7 @@ export const RecordsStats = ({
     appealedCount,
     pendingCount,
     processedCount,
-    takedownCount,
+    takendownCount,
   } = stats
 
   const hasStats =
@@ -163,23 +165,23 @@ export const RecordsStats = ({
     appealedCount ||
     pendingCount ||
     processedCount ||
-    takedownCount
+    takendownCount
 
   return (
     <>
       {hasStats && <PencilSquareIcon className="w-4 h-4 dark:text-gray-200" />}
-      {!!takedownCount && (
+      {!!takendownCount && (
         <StatView
           appearance="danger"
-          count={takedownCount}
+          count={takendownCount}
           Icon={ShieldExclamationIcon}
           text={
             showAll
-              ? pluralize(takedownCount, 'Takedown', { includeCount: false })
+              ? pluralize(takendownCount, 'Takedown', { includeCount: false })
               : ''
           }
           title={`${pluralize(
-            takedownCount,
+            takendownCount,
             'record',
           )} authored by this account has been taken down`}
         />
@@ -245,9 +247,11 @@ export const RecordsStats = ({
 
 export const SubjectSummary = ({
   stats,
+  allowExpansion = true,
   onAccountTakedownClick,
 }: {
   onAccountTakedownClick?: () => void
+  allowExpansion: boolean
   stats: {
     accountStats?: ToolsOzoneModerationDefs.AccountStats
     recordsStats?: ToolsOzoneModerationDefs.RecordsStats
@@ -269,7 +273,7 @@ export const SubjectSummary = ({
       {stats.recordsStats && (
         <RecordsStats showAll={showAll} stats={stats.recordsStats} />
       )}
-      {stats.recordsStats && stats.accountStats && (
+      {stats.recordsStats && stats.accountStats && allowExpansion && (
         <button type="button" onClick={() => setShowAll((current) => !current)}>
           <span className="text-xs">
             {showAll ? 'Show Summary' : 'Show All'}

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -26,7 +26,7 @@ export const StatView = ({
   let bgColor = 'bg-gray-400 dark:text-gray-100 text-white'
 
   if (appearance === 'info') {
-    bgColor = 'bg-blue-400'
+    bgColor = 'bg-blue-400 text-blue-800'
   } else if (appearance === 'danger') {
     bgColor = 'bg-red-200 text-red-800'
   } else if (appearance === 'warning') {

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -247,11 +247,9 @@ export const RecordsStats = ({
 
 export const SubjectSummary = ({
   stats,
-  allowExpansion = true,
   onAccountTakedownClick,
 }: {
   onAccountTakedownClick?: () => void
-  allowExpansion: boolean
   stats: {
     accountStats?: ToolsOzoneModerationDefs.AccountStats
     recordsStats?: ToolsOzoneModerationDefs.RecordsStats
@@ -273,7 +271,7 @@ export const SubjectSummary = ({
       {stats.recordsStats && (
         <RecordsStats showAll={showAll} stats={stats.recordsStats} />
       )}
-      {stats.recordsStats && stats.accountStats && allowExpansion && (
+      {stats.recordsStats && stats.accountStats && (
         <button type="button" onClick={() => setShowAll((current) => !current)}>
           <span className="text-xs">
             {showAll ? 'Show Summary' : 'Show All'}

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -1,0 +1,274 @@
+import { classNames, pluralize } from '@/lib/util'
+import { ToolsOzoneModerationDefs } from '@atproto/api'
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  FlagIcon,
+  PencilSquareIcon,
+  ShieldExclamationIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/solid'
+import { ComponentProps, useState } from 'react'
+
+export const StatView = ({
+  count,
+  Icon,
+  appearance,
+  text,
+  title,
+  ...rest
+}: {
+  count: number
+  Icon: (props: React.ComponentProps<'svg'>) => JSX.Element
+  text?: string
+  appearance?: 'danger' | 'info' | 'warning' | 'success'
+} & ComponentProps<'button'>) => {
+  let bgColor = 'bg-gray-400 dark:text-gray-100 text-white'
+
+  if (appearance === 'info') {
+    bgColor = 'bg-blue-400'
+  } else if (appearance === 'danger') {
+    bgColor = 'bg-red-200 text-red-800'
+  } else if (appearance === 'warning') {
+    bgColor = 'bg-orange-200 text-orange-800'
+  } else if (appearance === 'success') {
+    bgColor = 'bg-green-200 text-green-800'
+  }
+
+  return (
+    <button
+      type="button"
+      className={classNames(
+        'flex flex-row items-center gap-1 rounded px-1 text-xs',
+        bgColor,
+      )}
+      title={title}
+      aria-label={title}
+      {...rest}
+    >
+      <Icon className="w-3 h-3" />
+      {count}
+      {text && <span>{text}</span>}
+    </button>
+  )
+}
+
+export const AccountStats = ({
+  stats,
+  showAll,
+  onAccountTakedownClick,
+}: {
+  showAll: boolean
+  onAccountTakedownClick?: () => void
+  stats: ToolsOzoneModerationDefs.AccountStats
+}) => {
+  const { takedownCount, suspendCount, appealCount, reportCount } = stats
+  // Dont want to make the UI noisy with appeal count if we're in summary mode and already showing takedown and suspension
+  const shouldShowAppeal =
+    appealCount && (showAll || !takedownCount || !suspendCount)
+  // Dont want to make the UI noisy with report count if we're in summary mode and we have both takedown and suspension count
+  const shouldShowReport =
+    reportCount && (showAll || (!takedownCount && !suspendCount))
+  const hasStats = takedownCount || suspendCount || appealCount || reportCount
+
+  return (
+    <>
+      {hasStats && <UserCircleIcon className="w-4 h-4 dark:text-gray-200" />}
+      {suspendCount && (
+        <StatView
+          appearance="danger"
+          count={suspendCount}
+          onClick={onAccountTakedownClick}
+          text={
+            showAll
+              ? pluralize(suspendCount, 'Suspension', { includeCount: false })
+              : ''
+          }
+          Icon={ShieldExclamationIcon}
+          title={`This account was suspended ${pluralize(
+            suspendCount,
+            'time',
+          )}`}
+        />
+      )}
+      {takedownCount && (
+        <StatView
+          appearance="danger"
+          count={takedownCount}
+          onClick={onAccountTakedownClick}
+          Icon={ShieldExclamationIcon}
+          text={
+            showAll
+              ? pluralize(takedownCount, 'Takedown', { includeCount: false })
+              : ''
+          }
+          title={`This account was taken down ${pluralize(
+            takedownCount,
+            'time',
+          )}`}
+        />
+      )}
+      {shouldShowAppeal && (
+        <StatView
+          appearance="warning"
+          count={appealCount}
+          onClick={onAccountTakedownClick}
+          text={
+            showAll
+              ? pluralize(appealCount, 'Appeal', { includeCount: false })
+              : ''
+          }
+          Icon={ExclamationTriangleIcon}
+          title={`This account appealed ${pluralize(appealCount, 'decision')}`}
+        />
+      )}
+      {shouldShowReport && (
+        <StatView
+          appearance="info"
+          count={reportCount}
+          Icon={FlagIcon}
+          text={
+            showAll
+              ? pluralize(reportCount, 'Report', { includeCount: false })
+              : ''
+          }
+          title={`This account was reported ${pluralize(reportCount, 'time')}`}
+        />
+      )}
+    </>
+  )
+}
+
+export const RecordsStats = ({
+  stats,
+  showAll,
+}: {
+  showAll: boolean
+  stats: ToolsOzoneModerationDefs.RecordsStats
+}) => {
+  const {
+    totalReports,
+    reportedCount,
+    escalatedCount,
+    appealedCount,
+    pendingCount,
+    processedCount,
+    takedownCount,
+  } = stats
+
+  const hasStats =
+    totalReports ||
+    reportedCount ||
+    escalatedCount ||
+    appealedCount ||
+    pendingCount ||
+    processedCount ||
+    takedownCount
+
+  return (
+    <>
+      {hasStats && <PencilSquareIcon className="w-4 h-4 dark:text-gray-200" />}
+      {takedownCount && (
+        <StatView
+          appearance="danger"
+          count={takedownCount}
+          Icon={ShieldExclamationIcon}
+          text={
+            showAll
+              ? pluralize(takedownCount, 'Takedown', { includeCount: false })
+              : ''
+          }
+          title={`${pluralize(
+            takedownCount,
+            'record',
+          )} authored by this account has been taken down`}
+        />
+      )}
+      {escalatedCount && (
+        <StatView
+          appearance="warning"
+          count={escalatedCount}
+          text={
+            showAll
+              ? pluralize(escalatedCount, 'Escalation', { includeCount: false })
+              : ''
+          }
+          Icon={ExclamationTriangleIcon}
+          title={`${pluralize(
+            escalatedCount,
+            'record',
+          )} authored by this user were escalated`}
+        />
+      )}
+      {reportedCount && (
+        <StatView
+          appearance="info"
+          count={reportedCount}
+          Icon={FlagIcon}
+          text={showAll ? 'Reported' : ''}
+          title={`${pluralize(
+            reportedCount,
+            'record',
+          )} authored by this user reported ${pluralize(totalReports, 'time')}`}
+        />
+      )}
+      {showAll && pendingCount && (
+        <StatView
+          appearance="warning"
+          count={pendingCount}
+          text={showAll ? 'Unreviewed' : ''}
+          Icon={ExclamationCircleIcon}
+          title={`${pluralize(
+            pendingCount,
+            'record',
+          )} authored by this user are pending review`}
+        />
+      )}
+      {showAll && processedCount && (
+        <StatView
+          appearance="success"
+          count={processedCount}
+          text={showAll ? `Reviewed` : ''}
+          Icon={ExclamationCircleIcon}
+          title={`${pluralize(
+            processedCount,
+            'record',
+          )} authored by this user have been reviewed already`}
+        />
+      )}
+    </>
+  )
+}
+
+export const SubjectSummary = ({
+  stats,
+  onAccountTakedownClick,
+}: {
+  onAccountTakedownClick?: () => void
+  stats: {
+    accountStats?: ToolsOzoneModerationDefs.AccountStats
+    recordsStats?: ToolsOzoneModerationDefs.RecordsStats
+  }
+}) => {
+  const [showAll, setShowAll] = useState(false)
+  if (!stats) return null
+  
+  return (
+    <div className="flex flex-row gap-1 items-center flex-wrap">
+      {stats.accountStats && (
+        <AccountStats
+          showAll={showAll}
+          stats={stats.accountStats}
+          onAccountTakedownClick={onAccountTakedownClick}
+        />
+      )}
+      {showAll && stats.recordsStats && <div className="w-full" />}
+      {stats.recordsStats && (
+        <RecordsStats showAll={showAll} stats={stats.recordsStats} />
+      )}
+      <button type="button" onClick={() => setShowAll((current) => !current)}>
+        <span className="text-xs">{showAll ? 'Show Summary' : 'Show All'}</span>
+      </button>
+    </div>
+  )
+}

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -252,7 +252,7 @@ export const SubjectSummary = ({
 }) => {
   const [showAll, setShowAll] = useState(false)
   if (!stats) return null
-  
+
   return (
     <div className="flex flex-row gap-1 items-center flex-wrap">
       {stats.accountStats && (
@@ -266,9 +266,13 @@ export const SubjectSummary = ({
       {stats.recordsStats && (
         <RecordsStats showAll={showAll} stats={stats.recordsStats} />
       )}
-      <button type="button" onClick={() => setShowAll((current) => !current)}>
-        <span className="text-xs">{showAll ? 'Show Summary' : 'Show All'}</span>
-      </button>
+      {stats.recordsStats && stats.accountStats && (
+        <button type="button" onClick={() => setShowAll((current) => !current)}>
+          <span className="text-xs">
+            {showAll ? 'Show Summary' : 'Show All'}
+          </span>
+        </button>
+      )}
     </div>
   )
 }

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -74,7 +74,7 @@ export const AccountStats = ({
   return (
     <>
       {hasStats && <UserCircleIcon className="w-4 h-4 dark:text-gray-200" />}
-      {suspendCount && (
+      {!!suspendCount && (
         <StatView
           appearance="danger"
           count={suspendCount}
@@ -91,7 +91,7 @@ export const AccountStats = ({
           )}`}
         />
       )}
-      {takedownCount && (
+      {!!takedownCount && (
         <StatView
           appearance="danger"
           count={takedownCount}
@@ -108,7 +108,7 @@ export const AccountStats = ({
           )}`}
         />
       )}
-      {shouldShowAppeal && (
+      {!!shouldShowAppeal && (
         <StatView
           appearance="warning"
           count={appealCount}
@@ -122,7 +122,7 @@ export const AccountStats = ({
           title={`This account appealed ${pluralize(appealCount, 'decision')}`}
         />
       )}
-      {shouldShowReport && (
+      {!!shouldShowReport && (
         <StatView
           appearance="info"
           count={reportCount}
@@ -168,7 +168,7 @@ export const RecordsStats = ({
   return (
     <>
       {hasStats && <PencilSquareIcon className="w-4 h-4 dark:text-gray-200" />}
-      {takedownCount && (
+      {!!takedownCount && (
         <StatView
           appearance="danger"
           count={takedownCount}
@@ -184,7 +184,7 @@ export const RecordsStats = ({
           )} authored by this account has been taken down`}
         />
       )}
-      {escalatedCount && (
+      {!!escalatedCount && (
         <StatView
           appearance="warning"
           count={escalatedCount}
@@ -200,7 +200,7 @@ export const RecordsStats = ({
           )} authored by this user were escalated`}
         />
       )}
-      {reportedCount && (
+      {!!reportedCount && (
         <StatView
           appearance="info"
           count={reportedCount}
@@ -209,10 +209,13 @@ export const RecordsStats = ({
           title={`${pluralize(
             reportedCount,
             'record',
-          )} authored by this user reported ${pluralize(totalReports, 'time')}`}
+          )} authored by this user reported ${pluralize(
+            totalReports || 0,
+            'time',
+          )}`}
         />
       )}
-      {showAll && pendingCount && (
+      {showAll && !!pendingCount && (
         <StatView
           appearance="warning"
           count={pendingCount}
@@ -224,7 +227,7 @@ export const RecordsStats = ({
           )} authored by this user are pending review`}
         />
       )}
-      {showAll && processedCount && (
+      {showAll && !!processedCount && (
         <StatView
           appearance="success"
           count={processedCount}

--- a/components/subject/table.tsx
+++ b/components/subject/table.tsx
@@ -4,15 +4,21 @@ import {
   CheckCircleIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  Bars3BottomLeftIcon,
 } from '@heroicons/react/20/solid'
 import { SubjectStatus } from '@/lib/types'
 import { LoadMoreButton } from '../common/LoadMoreButton'
-import { classNames } from '@/lib/util'
+import { classNames, pluralize } from '@/lib/util'
 import { SubjectOverview } from '../reports/SubjectOverview'
 import { Loading } from '../common/Loader'
-import { useSearchParams, usePathname } from 'next/navigation'
-import { HTMLAttributes } from 'react'
+import { useSearchParams, usePathname, useRouter } from 'next/navigation'
+import { Fragment, HTMLAttributes } from 'react'
 import { ReviewStateIcon } from './ReviewStateMarker'
+import { Popover, Transition } from '@headlessui/react'
+import { ButtonGroup } from '@/common/buttons'
+import { ToolsOzoneModerationDefs } from '@atproto/api'
+import { StatView } from './Summary'
+import { FlagIcon, ShieldExclamationIcon } from '@heroicons/react/24/solid'
 
 const useSortOrder = () => {
   const searchParams = useSearchParams()
@@ -23,9 +29,13 @@ const useSortOrder = () => {
   const sortDirection = searchParams.get(directionKey)
   const sortField = searchParams.get(fieldKey)
 
-  function getToggleReverseOrderLink(field: string) {
+  function getToggleReverseOrderLink(field: string, newDirection?: string) {
     const params = new URLSearchParams(searchParams)
-    params.set(directionKey, sortDirection === 'asc' ? 'desc' : 'asc')
+    // If the caller wants a specific direction, use that
+    params.set(
+      directionKey,
+      newDirection || (sortDirection === 'asc' ? 'desc' : 'asc'),
+    )
     params.set(fieldKey, field)
     return `${pathname}?${params}`
   }
@@ -76,6 +86,55 @@ export function SubjectTable(
         <div className="flex justify-center py-6">
           <LoadMoreButton onClick={onLoadMore} />
         </div>
+      )}
+    </div>
+  )
+}
+
+const SubjectSummaryColumn = ({
+  recordStats,
+  accountStats,
+}: {
+  recordStats?: ToolsOzoneModerationDefs.RecordsStats
+  accountStats?: ToolsOzoneModerationDefs.AccountStats
+}) => {
+  const { takendownCount, reportedCount, totalReports } = recordStats || {}
+  const { suspendCount } = accountStats || {}
+
+  return (
+    <div className="flex flex-row gap-1 items-center">
+      {!!suspendCount && (
+        <StatView
+          appearance="danger"
+          count={suspendCount}
+          Icon={ShieldExclamationIcon}
+          title={`account suspended ${pluralize(suspendCount, 'time')}`}
+        />
+      )}
+      {!!reportedCount && (
+        <StatView
+          appearance="info"
+          count={reportedCount}
+          Icon={FlagIcon}
+          title={`${pluralize(
+            reportedCount,
+            'record',
+          )} authored by this user reported ${pluralize(
+            totalReports || 0,
+            'time',
+          )}`}
+        />
+      )}
+      {!!takendownCount && (
+        <StatView
+          appearance="danger"
+          count={takendownCount}
+          Icon={ShieldExclamationIcon}
+          title={`${pluralize(
+            takendownCount,
+            'record',
+          )} authored by this account has been taken down`}
+        />
       )}
     </div>
   )
@@ -142,6 +201,12 @@ function SubjectRow({
           subjectRepoHandle={subjectStatus.subjectRepoHandle}
         />
       </td>
+      <td className="hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-100 sm:table-cell">
+        <SubjectSummaryColumn
+          recordStats={subjectStatus.recordsStats}
+          accountStats={subjectStatus.accountStats}
+        />
+      </td>
       <td className="hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-100 sm:table-cell max-w-sm">
         {lastReviewedAt && (
           <span title={lastReviewedAt.toLocaleString()}>
@@ -163,6 +228,129 @@ function SubjectRow({
         )}
       </td>
     </tr>
+  )
+}
+
+const SummaryColumnHeader = () => {
+  const router = useRouter()
+  const { sortDirection, sortField, getToggleReverseOrderLink } = useSortOrder()
+  const hasSort =
+    sortField &&
+    ['reportedRecordsCount', 'takendownRecordsCount'].includes(sortField)
+
+  return (
+    <Popover className="relative">
+      <Popover.Button
+        className=" flex flex-row items-center gap-1"
+        type="button"
+      >
+        Summary
+        {hasSort ? (
+          sortDirection === 'asc' ? (
+            <ChevronUpIcon className="h-4 w-4" />
+          ) : (
+            <ChevronDownIcon className="h-4 w-4" />
+          )
+        ) : (
+          <Bars3BottomLeftIcon className="h-4 w-4" />
+        )}
+      </Popover.Button>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-200"
+        enterFrom="opacity-0 translate-y-1"
+        enterTo="opacity-100 translate-y-0"
+        leave="transition ease-in duration-150"
+        leaveFrom="opacity-100 translate-y-0"
+        leaveTo="opacity-0 translate-y-1"
+      >
+        <Popover.Panel className="absolute z-10 rounded p-4">
+          <div className="flex-auto w-auto rounded bg-white dark:bg-slate-800 p-4 text-sm leading-6 shadow-lg dark:shadow-slate-900 ring-1 ring-gray-900/5">
+            <div className="pb-2">
+              <p>Reported record count</p>
+              <ButtonGroup
+                size="xs"
+                leftAligned
+                appearance="primary"
+                items={[
+                  {
+                    id: 'asc',
+                    text: 'Ascending',
+                    onClick: () => {
+                      router.push(
+                        getToggleReverseOrderLink(
+                          'reportedRecordsCount',
+                          'asc',
+                        ),
+                      )
+                    },
+                    isActive:
+                      sortField === 'reportedRecordsCount' &&
+                      sortDirection === 'asc',
+                  },
+                  {
+                    id: 'desc',
+                    text: 'Descending',
+                    onClick: () => {
+                      router.push(
+                        getToggleReverseOrderLink(
+                          'reportedRecordsCount',
+                          'desc',
+                        ),
+                      )
+                    },
+                    isActive:
+                      sortField === 'reportedRecordsCount' &&
+                      sortDirection === 'desc',
+                  },
+                ]}
+              />
+            </div>
+            <div className="pb-2">
+              <p>Takendown records count</p>
+              <ButtonGroup
+                size="xs"
+                leftAligned
+                appearance="primary"
+                items={[
+                  {
+                    id: 'asc',
+                    text: 'Ascending',
+                    onClick: () => {
+                      router.push(
+                        getToggleReverseOrderLink(
+                          'takendownRecordsCount',
+                          'asc',
+                        ),
+                      )
+                    },
+                    isActive:
+                      sortField === 'takendownRecordsCount' &&
+                      sortDirection === 'asc',
+                  },
+                  {
+                    id: 'desc',
+                    text: 'Descending',
+                    onClick: () => {
+                      router.push(
+                        getToggleReverseOrderLink(
+                          'takendownRecordsCount',
+                          'desc',
+                        ),
+                      )
+                    },
+                    isActive:
+                      sortField === 'takendownRecordsCount' &&
+                      sortDirection === 'desc',
+                  },
+                ]}
+              />
+            </div>
+          </div>
+        </Popover.Panel>
+      </Transition>
+    </Popover>
   )
 }
 
@@ -188,6 +376,12 @@ function SubjectRowHead() {
         className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200 sm:table-cell"
       >
         Subject
+      </th>
+      <th
+        scope="col"
+        className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200 sm:table-cell"
+      >
+        <SummaryColumnHeader />
       </th>
       <th
         scope="col"
@@ -236,7 +430,7 @@ function EmptyRows({
 }) {
   return (
     <tr>
-      <td colSpan={5} className="text-center">
+      <td colSpan={6} className="text-center">
         {isInitialLoading ? (
           <>
             <Loading />

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.25",
+    "@atproto/api": "^0.13.29",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/service/package.json
+++ b/service/package.json
@@ -3,7 +3,7 @@
   "description": "Ozone service entrypoint",
   "main": "index.js",
   "dependencies": {
-    "@atproto/ozone": "0.1.64",
+    "@atproto/ozone": "0.1.70",
     "next": "14.2.5"
   }
 }

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -2,24 +2,24 @@
 # yarn lockfile v1
 
 
-"@atproto/api@^0.13.25":
-  version "0.13.25"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.25.tgz#917d6ae75e0c176166f67b7c340944c84a7c6413"
-  integrity sha512-5tz2NvYO7W9+0PV7x4k4KIAIazQI6Km+q4/+O6VUoNSqHsF3ry9/9mjcZKBoJLdmcVtZdcKSlPUTtxthan6iKw==
+"@atproto/api@^0.13.29":
+  version "0.13.29"
+  resolved "https://registry.npmjs.org/@atproto/api/-/api-0.13.29.tgz#34b8e8f68df95f9d44de243ff33dc92b6b421e71"
+  integrity sha512-j+2mZikK7dibAll4TrQBVFMUVlZ9UZKTlTuFMMJ/x/JrngdYSvPoCcujbPHSj3XuKuG+MCNps5e7wK4mXXQsSA==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
-    "@atproto/lexicon" "^0.4.4"
+    "@atproto/common-web" "^0.3.2"
+    "@atproto/lexicon" "^0.4.5"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.5"
+    "@atproto/xrpc" "^0.6.6"
     await-lock "^2.2.2"
     multiformats "^9.9.0"
     tlds "^1.234.0"
     zod "^3.23.8"
 
-"@atproto/common-web@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.3.1.tgz#86f8efb10a4b9073839cee914c6c08a664917cc4"
-  integrity sha512-N7wiTnus5vAr+lT//0y8m/FaHHLJ9LpGuEwkwDAeV3LCiPif4m/FS8x/QOYrx1PdZQwKso95RAPzCGWQBH5j6Q==
+"@atproto/common-web@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.3.2.tgz#4cf78ad4d24fed801882f3d35afc39bceccdff51"
+  integrity sha512-Vx0JtL1/CssJbFAb0UOdvTrkbUautsDfHNOXNTcX2vyPIxH9xOameSqLLunM1hZnOQbJwyjmQCt6TV+bhnanDg==
   dependencies:
     graphemer "^1.4.0"
     multiformats "^9.9.0"
@@ -36,12 +36,12 @@
     pino "^8.6.1"
     zod "^3.14.2"
 
-"@atproto/common@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@atproto/common/-/common-0.4.5.tgz#28fd176a9b5527c723828e725586bc0be9fa9516"
-  integrity sha512-LFAGqHcxCI5+b31Xgk+VQQtZU258iGPpHJzNeHVcdh6teIKZi4C2l6YV+m+3CEz+yYcfP7jjUmgqesx7l9Arsg==
+"@atproto/common@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.npmjs.org/@atproto/common/-/common-0.4.6.tgz#9a246244cb8f59615b2090ba4d99a2d5537e44b0"
+  integrity sha512-X33ZubLPrHLNur2Ln4tRP5TY0G0u/t9DyAeA5dgtTNGIXE3iJIlfiUSR0PW5s1iAvBbrrJK4BwaA2Pqsdl+RNw==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
+    "@atproto/common-web" "^0.3.2"
     "@ipld/dag-cbor" "^7.0.3"
     cbor-x "^1.5.1"
     iso-datestring-validator "^2.2.2"
@@ -59,50 +59,48 @@
     one-webcrypto "^1.0.3"
     uint8arrays "3.0.0"
 
-"@atproto/crypto@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@atproto/crypto/-/crypto-0.4.2.tgz#07417887ddbd4baae5298d4b9499fc727f261a31"
-  integrity sha512-aeOfPQYCDbhn2hV06oBF2KXrWjf/BK4yL8lfANJKSmKl3tKWCkiW/moi643rUXXxSE72KtWtQeqvNFYnnFJ0ig==
+"@atproto/crypto@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.4.3.tgz#15b8105892baf1ce23327f2d9cb2d1ffd8153d0d"
+  integrity sha512-YSSUAvkx+ldpXw97NXZWfLx/prgh5YJ2K0BCw51JCJmXSRp6KhhwvOm4J+K/s5hwpssyuDCVTXknyS4PHwaK5g==
   dependencies:
-    "@noble/curves" "^1.1.0"
-    "@noble/hashes" "^1.3.1"
+    "@noble/curves" "^1.7.0"
+    "@noble/hashes" "^1.6.1"
     uint8arrays "3.0.0"
 
-"@atproto/identity@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@atproto/identity/-/identity-0.4.3.tgz#fd387d4f2dd68a514e3d0138009a4b9db7f489fd"
-  integrity sha512-DLXMWh57dHvIeBl+IvC+q20z0IdDZT1awOn84vDyxacL9DfhbiTy/zCUPFEzHyvfrilNG1tDA4zQzURubdFqNg==
+"@atproto/identity@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.npmjs.org/@atproto/identity/-/identity-0.4.5.tgz#d644fb08c9998cf382d700d3ac25620d6eebc4ec"
+  integrity sha512-IyW6wk+qfX+z/LmBdjatJgjSJWDTJLSCT/6yQUD/L0mkOjRdxiG7DoYIChaF3xHOPKiIuOGu/fuzhBMxVVcCcw==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
-    "@atproto/crypto" "^0.4.2"
-    axios "^0.27.2"
+    "@atproto/common-web" "^0.3.2"
+    "@atproto/crypto" "^0.4.3"
 
-"@atproto/lexicon@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.4.tgz#0d97314bb57b693b76f2495fa5e02872469dd93a"
-  integrity sha512-QFEmr3rpj/RoAmfX9ALU/asBG/rsVtQZnw+9nOB1/AuIwoxXd+ZyndR6lVUc2+DL4GEjl6W2yvBru5xbQIZWyA==
+"@atproto/lexicon@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.5.tgz#4fcf3731193c674286e9e8d677bbab5dd530b817"
+  integrity sha512-fljWqMGKn+XWtTprBcS3F1hGBREnQYh6qYHv2sjENucc7REms1gtmZXSerB9N6pVeHVNOnXiILdukeAcic5OEw==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
+    "@atproto/common-web" "^0.3.2"
     "@atproto/syntax" "^0.3.1"
     iso-datestring-validator "^2.2.2"
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/ozone@0.1.64":
-  version "0.1.64"
-  resolved "https://registry.yarnpkg.com/@atproto/ozone/-/ozone-0.1.64.tgz#babd67fdfaef1a21423e49033a02c82a54ec09e3"
-  integrity sha512-1eJFx29eG+HW0jFGCsQM/DYI5Yy3PxDuCJk7nDj+s35IcgadV3Hv0d6QzsnL+IRygJetzfS7PewyZTbnh41x4Q==
+"@atproto/ozone@0.1.70":
+  version "0.1.70"
+  resolved "https://registry.npmjs.org/@atproto/ozone/-/ozone-0.1.70.tgz#8d5cf2e2fdde816027f246e25043bb01cbe45f07"
+  integrity sha512-0XWj6/dL53r+ww4moSiua30JYgB5xmJJ+ZIg2kuaCmsNNJh4iu8fNOUZpbkzKmOsCT18WJXkbWdaUHfN92nyGg==
   dependencies:
-    "@atproto/api" "^0.13.25"
-    "@atproto/common" "^0.4.5"
-    "@atproto/crypto" "^0.4.2"
-    "@atproto/identity" "^0.4.3"
-    "@atproto/lexicon" "^0.4.4"
+    "@atproto/api" "^0.13.29"
+    "@atproto/common" "^0.4.6"
+    "@atproto/crypto" "^0.4.3"
+    "@atproto/identity" "^0.4.5"
+    "@atproto/lexicon" "^0.4.5"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.5"
-    "@atproto/xrpc-server" "^0.7.4"
+    "@atproto/xrpc" "^0.6.6"
+    "@atproto/xrpc-server" "^0.7.7"
     "@did-plc/lib" "^0.0.1"
-    axios "^1.6.7"
     compression "^1.7.4"
     cors "^2.8.5"
     express "^4.17.2"
@@ -116,21 +114,22 @@
     structured-headers "^1.0.1"
     typed-emitter "^2.1.0"
     uint8arrays "3.0.0"
+    undici "^6.14.1"
 
 "@atproto/syntax@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.1.tgz#4346418728f9643d783d2ffcf7c77e132e1f53d4"
   integrity sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==
 
-"@atproto/xrpc-server@^0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc-server/-/xrpc-server-0.7.4.tgz#dfac8f7276c1c971a35eaba627eb6372088441c3"
-  integrity sha512-MrAwxfJBQm/kCol3D8qc+vpQzBMzLqvtUbauSSfVVJ10PlGtxg4LlXqcjkAuhrjyrqp3dQH9LHuhDpgVQK+G3w==
+"@atproto/xrpc-server@^0.7.7":
+  version "0.7.7"
+  resolved "https://registry.npmjs.org/@atproto/xrpc-server/-/xrpc-server-0.7.7.tgz#0904df2a1da639fdacd7f25593c4b0bc483f32a2"
+  integrity sha512-hfA0OoGhWYPfrk+D6fumeRz+Jfcspan9JF0F50ok9brDjLySl5c8WAwpX47VTVzrvoInSgm4DEZ/STXWNcFxJg==
   dependencies:
-    "@atproto/common" "^0.4.5"
-    "@atproto/crypto" "^0.4.2"
-    "@atproto/lexicon" "^0.4.4"
-    "@atproto/xrpc" "^0.6.5"
+    "@atproto/common" "^0.4.6"
+    "@atproto/crypto" "^0.4.3"
+    "@atproto/lexicon" "^0.4.5"
+    "@atproto/xrpc" "^0.6.6"
     cbor-x "^1.5.1"
     express "^4.17.2"
     http-errors "^2.0.0"
@@ -140,12 +139,12 @@
     ws "^8.12.0"
     zod "^3.23.8"
 
-"@atproto/xrpc@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.5.tgz#8b180fc5f6b8374fd00c41b9e4cd7b24ead48e6b"
-  integrity sha512-t6u8iPEVbWge5RhzKZDahSzNDYIAxUtop6Q/X/apAZY1rgreVU0/1sSvvRoRFH19d3UIKjYdLuwFqMi9w8nY3Q==
+"@atproto/xrpc@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.6.tgz#28f58270ef4a8056f7f718bd52512e74bcd3702f"
+  integrity sha512-umXEYVMo9/pyIBoKmIAIi64RXDW9tSXY+wqztlQ6I2GZtjLfNZqmAWU+wADk3SxUe54mvjxxGyA4TtyGtDMfhA==
   dependencies:
-    "@atproto/lexicon" "^0.4.4"
+    "@atproto/lexicon" "^0.4.5"
     zod "^3.23.8"
 
 "@cbor-extract/cbor-extract-darwin-arm64@2.2.0":
@@ -249,17 +248,17 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz#ed199a920efb510cfe941cd75ed38a7be21e756f"
   integrity sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==
 
-"@noble/curves@^1.1.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
-  integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
+"@noble/curves@^1.7.0":
+  version "1.8.1"
+  resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz#19bc3970e205c99e4bdb1c64a4785706bce497ff"
+  integrity sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==
   dependencies:
-    "@noble/hashes" "1.3.3"
+    "@noble/hashes" "1.7.1"
 
-"@noble/hashes@1.3.3", "@noble/hashes@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
-  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+"@noble/hashes@1.7.1", "@noble/hashes@^1.6.1":
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
+  integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
 "@noble/secp256k1@^1.7.0":
   version "1.7.1"
@@ -314,29 +313,12 @@ await-lock@^2.2.2:
   resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
   integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 axios@^1.3.4:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
   integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
   dependencies:
     follow-redirects "^1.15.4"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.6.7:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
-  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
-  dependencies:
-    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -657,15 +639,10 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-follow-redirects@^1.14.9, follow-redirects@^1.15.4:
+follow-redirects@^1.15.4:
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
   integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
-
-follow-redirects@^1.15.6:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -1402,6 +1379,11 @@ uint8arrays@3.0.0:
   integrity sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==
   dependencies:
     multiformats "^9.4.2"
+
+undici@^6.14.1:
+  version "6.21.1"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,15 +60,15 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@^0.13.25":
-  version "0.13.25"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.25.tgz#917d6ae75e0c176166f67b7c340944c84a7c6413"
-  integrity sha512-5tz2NvYO7W9+0PV7x4k4KIAIazQI6Km+q4/+O6VUoNSqHsF3ry9/9mjcZKBoJLdmcVtZdcKSlPUTtxthan6iKw==
+"@atproto/api@^0.13.29":
+  version "0.13.29"
+  resolved "https://registry.npmjs.org/@atproto/api/-/api-0.13.29.tgz#34b8e8f68df95f9d44de243ff33dc92b6b421e71"
+  integrity sha512-j+2mZikK7dibAll4TrQBVFMUVlZ9UZKTlTuFMMJ/x/JrngdYSvPoCcujbPHSj3XuKuG+MCNps5e7wK4mXXQsSA==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
-    "@atproto/lexicon" "^0.4.4"
+    "@atproto/common-web" "^0.3.2"
+    "@atproto/lexicon" "^0.4.5"
     "@atproto/syntax" "^0.3.1"
-    "@atproto/xrpc" "^0.6.5"
+    "@atproto/xrpc" "^0.6.6"
     await-lock "^2.2.2"
     multiformats "^9.9.0"
     tlds "^1.234.0"
@@ -84,10 +84,10 @@
     uint8arrays "3.0.0"
     zod "^3.21.4"
 
-"@atproto/common-web@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.3.1.tgz#86f8efb10a4b9073839cee914c6c08a664917cc4"
-  integrity sha512-N7wiTnus5vAr+lT//0y8m/FaHHLJ9LpGuEwkwDAeV3LCiPif4m/FS8x/QOYrx1PdZQwKso95RAPzCGWQBH5j6Q==
+"@atproto/common-web@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.3.2.tgz#4cf78ad4d24fed801882f3d35afc39bceccdff51"
+  integrity sha512-Vx0JtL1/CssJbFAb0UOdvTrkbUautsDfHNOXNTcX2vyPIxH9xOameSqLLunM1hZnOQbJwyjmQCt6TV+bhnanDg==
   dependencies:
     graphemer "^1.4.0"
     multiformats "^9.9.0"
@@ -136,12 +136,12 @@
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/lexicon@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.4.4.tgz#0d97314bb57b693b76f2495fa5e02872469dd93a"
-  integrity sha512-QFEmr3rpj/RoAmfX9ALU/asBG/rsVtQZnw+9nOB1/AuIwoxXd+ZyndR6lVUc2+DL4GEjl6W2yvBru5xbQIZWyA==
+"@atproto/lexicon@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.5.tgz#4fcf3731193c674286e9e8d677bbab5dd530b817"
+  integrity sha512-fljWqMGKn+XWtTprBcS3F1hGBREnQYh6qYHv2sjENucc7REms1gtmZXSerB9N6pVeHVNOnXiILdukeAcic5OEw==
   dependencies:
-    "@atproto/common-web" "^0.3.1"
+    "@atproto/common-web" "^0.3.2"
     "@atproto/syntax" "^0.3.1"
     iso-datestring-validator "^2.2.2"
     multiformats "^9.9.0"
@@ -194,7 +194,7 @@
 
 "@atproto/syntax@^0.3.1":
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.1.tgz#4346418728f9643d783d2ffcf7c77e132e1f53d4"
+  resolved "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.1.tgz#4346418728f9643d783d2ffcf7c77e132e1f53d4"
   integrity sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==
 
 "@atproto/xrpc@0.6.1", "@atproto/xrpc@^0.6.1":
@@ -205,12 +205,12 @@
     "@atproto/lexicon" "^0.4.1"
     zod "^3.23.8"
 
-"@atproto/xrpc@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.5.tgz#8b180fc5f6b8374fd00c41b9e4cd7b24ead48e6b"
-  integrity sha512-t6u8iPEVbWge5RhzKZDahSzNDYIAxUtop6Q/X/apAZY1rgreVU0/1sSvvRoRFH19d3UIKjYdLuwFqMi9w8nY3Q==
+"@atproto/xrpc@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.6.tgz#28f58270ef4a8056f7f718bd52512e74bcd3702f"
+  integrity sha512-umXEYVMo9/pyIBoKmIAIi64RXDW9tSXY+wqztlQ6I2GZtjLfNZqmAWU+wADk3SxUe54mvjxxGyA4TtyGtDMfhA==
   dependencies:
-    "@atproto/lexicon" "^0.4.4"
+    "@atproto/lexicon" "^0.4.5"
     zod "^3.23.8"
 
 "@babel/runtime@^7.1.2":
@@ -987,7 +987,7 @@ available-typed-arrays@^1.0.7:
 
 await-lock@^2.2.2:
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
+  resolved "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
   integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
 aws-sign2@~0.7.0:
@@ -5376,7 +5376,7 @@ tiny-invariant@^1.2.0:
 
 tlds@^1.234.0:
   version "1.255.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.255.0.tgz#53c2571766c10da95928c716c48dfcf141341e3f"
+  resolved "https://registry.npmjs.org/tlds/-/tlds-1.255.0.tgz#53c2571766c10da95928c716c48dfcf141341e3f"
   integrity sha512-tcwMRIioTcF/FcxLev8MJWxCp+GUALRhFEqbDoZrnowmKSGqPrl5pqS+Sut2m8BgJ6S4FExCSSpGffZ0Tks6Aw==
 
 tldts-core@^6.1.66:


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/3236

This PR shows moderation stats/summary for subjects/accounts.

<img width="1015" alt="Screenshot 2025-01-21 at 16 18 14" src="https://github.com/user-attachments/assets/d5d578e7-e45f-45b4-81c6-ee3f377b1b9e" />

> Stats preview in the queue table

<img width="373" alt="Screenshot 2025-01-21 at 16 18 24" src="https://github.com/user-attachments/assets/3691ab9b-06a6-493b-8bdd-a16e80230ed5" />

> Sort config for stats

<img width="951" alt="Screenshot 2025-01-21 at 16 18 45" src="https://github.com/user-attachments/assets/4bf0a654-7c4c-4723-9aa1-aea442f90ead" />

> Full stats view in quick action panel

<img width="1000" alt="Screenshot 2025-01-21 at 16 18 52" src="https://github.com/user-attachments/assets/6d1a07e6-307a-4149-896a-b491205456a8" />

> Stats summary in quick action panel

<img width="421" alt="Screenshot 2025-01-21 at 17 44 52" src="https://github.com/user-attachments/assets/f70fe2d9-a6be-4785-8851-077075c32658" />

> Stats filter view