### PR TITLE
:bug: Fix min record takedown filter and add stats on repositories page

### DIFF
--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -342,6 +342,7 @@ function useModerationQueueQuery() {
         collections,
         minAccountSuspendCount,
         minReportedRecordsCount,
+        minTakendownRecordsCount,
       },
     ],
     queryFn: async ({ pageParam }) => {

--- a/components/reports/useQueueFilter.tsx
+++ b/components/reports/useQueueFilter.tsx
@@ -137,7 +137,6 @@ export const useQueueFilter = () => {
 
   return {
     queueFilters,
-    updateFilters,
     updateTagExclusions,
     addTags,
     toggleCollection,

--- a/components/repositories/AccountView.tsx
+++ b/components/repositories/AccountView.tsx
@@ -61,6 +61,7 @@ import { DidHistory } from './DidHistory'
 import { InviteCodeGenerationStatus } from './InviteCodeGenerationStatus'
 import { MuteReporting } from './MuteReporting'
 import { ProfileAvatar } from './ProfileAvatar'
+import { obscureIp, parseThreatSigs } from './helpers'
 
 enum Views {
   Details,
@@ -953,52 +954,4 @@ const EmailView = (props: ComponentProps<typeof EmailComposer>) => {
       <EmailComposer {...props} />
     </div>
   )
-}
-
-function obscureIp(ip: string) {
-  const parts = ip.split('.')
-  if (parts.length !== 4) return '***.***.***.***'
-  return `${parts[0]}.${parts[1]}.***.***`
-}
-
-function parseThreatSigs(sigs?: ComAtprotoAdminDefs.ThreatSignature[]) {
-  const hcapDetail: ComAtprotoAdminDefs.ThreatSignature[] = []
-  let registrationIp,
-    lastSigninIp,
-    lastSigninTime,
-    lastSigninCountry,
-    ipCountry: string | undefined
-
-  if (sigs) {
-    for (const sig of sigs) {
-      switch (sig.property) {
-        case 'registrationIp':
-          registrationIp = sig.value
-          break
-        case 'lastSigninIp':
-          lastSigninIp = sig.value
-          break
-        case 'lastSigninTime':
-          lastSigninTime = sig.value
-          break
-        case 'lastSigninCountry':
-          lastSigninCountry = sig.value
-          break
-        case 'ipCountry':
-          ipCountry = sig.value
-          break
-        default:
-          hcapDetail.push(sig)
-      }
-    }
-  }
-
-  return {
-    registrationIp,
-    lastSigninIp,
-    lastSigninTime,
-    lastSigninCountry,
-    ipCountry,
-    hcapDetail,
-  }
 }

--- a/components/repositories/helpers.ts
+++ b/components/repositories/helpers.ts
@@ -1,0 +1,49 @@
+import { ComAtprotoAdminDefs } from '@atproto/api'
+
+export function obscureIp(ip: string) {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return '***.***.***.***'
+  return `${parts[0]}.${parts[1]}.***.***`
+}
+
+export function parseThreatSigs(sigs?: ComAtprotoAdminDefs.ThreatSignature[]) {
+  const hcapDetail: ComAtprotoAdminDefs.ThreatSignature[] = []
+  let registrationIp,
+    lastSigninIp,
+    lastSigninTime,
+    lastSigninCountry,
+    ipCountry: string | undefined
+
+  if (sigs) {
+    for (const sig of sigs) {
+      switch (sig.property) {
+        case 'registrationIp':
+          registrationIp = sig.value
+          break
+        case 'lastSigninIp':
+          lastSigninIp = sig.value
+          break
+        case 'lastSigninTime':
+          lastSigninTime = sig.value
+          break
+        case 'lastSigninCountry':
+          lastSigninCountry = sig.value
+          break
+        case 'ipCountry':
+          ipCountry = sig.value
+          break
+        default:
+          hcapDetail.push(sig)
+      }
+    }
+  }
+
+  return {
+    registrationIp,
+    lastSigninIp,
+    lastSigninTime,
+    lastSigninCountry,
+    ipCountry,
+    hcapDetail,
+  }
+}

--- a/components/subject/table.tsx
+++ b/components/subject/table.tsx
@@ -91,7 +91,7 @@ export function SubjectTable(
   )
 }
 
-const SubjectSummaryColumn = ({
+export const SubjectSummaryColumn = ({
   recordStats,
   accountStats,
 }: {


### PR DESCRIPTION
- Threat sig details on the repositories page help mods quickly find correlation and skim through long list of accounts
- Bugfix to trigger statuses refresh when minRecordTakedown is changed