### PR TITLE
:sparkles: Show subject type and collection filter in events filter panel

### DIFF
--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -154,6 +154,8 @@ export const ModEventList = (
     hasFilter,
     commentFilter,
     policies,
+    subjectType,
+    selectedCollections,
     toggleCommentFilter,
     setCommentFilterKeyword,
     createdBy,
@@ -312,6 +314,8 @@ export const ModEventList = (
             applyFilterMacro,
             changeListFilter,
             policies,
+            subjectType,
+            selectedCollections,
           }}
         />
       )}

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -17,10 +17,8 @@ import { useState } from 'react'
 import { RepoFinder } from '@/repositories/Finder'
 import { Dropdown } from '@/common/Dropdown'
 import { ChevronDownIcon } from '@heroicons/react/24/solid'
-import {
-  ActionPoliciesSelector,
-  ActionPolicySelector,
-} from '@/reports/ModerationForm/ActionPolicySelector'
+import { ActionPoliciesSelector } from '@/reports/ModerationForm/ActionPolicySelector'
+import { SubjectTypeFilter } from '@/reports/QueueFilter/SubjectType'
 
 export const EventFilterPanel = ({
   limit,
@@ -38,6 +36,8 @@ export const EventFilterPanel = ({
   toggleCommentFilter,
   setCommentFilterKeyword,
   changeListFilter,
+  subjectType,
+  selectedCollections,
 }: Omit<EventListState, 'includeAllUserRecords' | 'showContentPreview'> &
   Pick<
     ReturnType<typeof useModEventList>,
@@ -169,6 +169,40 @@ export const EventFilterPanel = ({
               />
             </FormLabel>
           )}
+
+          <div className="pt-2">
+            <SubjectTypeFilter
+              hasSubjectTypeFilter={!!subjectType}
+              isSubjectTypeAccount={subjectType === 'account'}
+              selectedCollections={selectedCollections}
+              isSubjectTypeRecord={subjectType === 'record'}
+              toggleCollection={(collectionId) => {
+                const newCollections = new Set(selectedCollections)
+                if (newCollections.has(collectionId)) {
+                  newCollections.delete(collectionId)
+                } else {
+                  newCollections.add(collectionId)
+                }
+                changeListFilter({
+                  field: 'selectedCollections',
+                  value: Array.from(newCollections),
+                })
+              }}
+              toggleSubjectType={(newSubjectType) => {
+                changeListFilter({
+                  field: 'subjectType',
+                  value:
+                    newSubjectType === subjectType ? undefined : newSubjectType,
+                })
+              }}
+              clearSubjectType={() => {
+                changeListFilter({
+                  field: 'subjectType',
+                  value: undefined,
+                })
+              }}
+            />
+          </div>
 
           <FormLabel label="Page Size" htmlFor="limit" className="flex-1 mt-2">
             <Dropdown

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -65,6 +65,8 @@ const initialListState = {
   policies: [],
   showContentPreview: false,
   limit: 25,
+  subjectType: undefined,
+  selectedCollections: [],
 }
 
 const getReposAndRecordsForEvents = async (
@@ -142,6 +144,8 @@ export type EventListState = Omit<
   addedLabels: string[]
   removedLabels: string[]
   showContentPreview: boolean
+  subjectType?: 'account' | 'record'
+  selectedCollections: string[]
 }
 
 type EventListFilterPayload =
@@ -160,6 +164,8 @@ type EventListFilterPayload =
   | { field: 'removedTags'; value: string }
   | { field: 'policies'; value: string[] }
   | { field: 'limit'; value: number }
+  | { field: 'subjectType'; value?: 'account' | 'record' }
+  | { field: 'selectedCollections'; value: string[] }
 
 type EventListAction =
   | {
@@ -263,9 +269,12 @@ export const useModEventList = (
         reportTypes,
         policies,
         limit,
+        subjectType,
+        selectedCollections,
       } = listState
       const queryParams: ToolsOzoneModerationQueryEvents.QueryParams = {
         limit,
+        subjectType,
         cursor: pageParam,
         includeAllUserRecords,
       }
@@ -308,6 +317,10 @@ export const useModEventList = (
         if (commentFilter.keyword) {
           queryParams.comment = commentFilter.keyword
         }
+      }
+
+      if (selectedCollections.length && subjectType === 'record') {
+        queryParams.collections = selectedCollections
       }
 
       if (addedTags?.trim().length) {
@@ -397,7 +410,9 @@ export const useModEventList = (
     listState.addedLabels.length > 0 ||
     listState.removedLabels.length > 0 ||
     listState.addedTags.length > 0 ||
-    listState.removedTags.length > 0
+    listState.removedTags.length > 0 ||
+    listState.subjectType ||
+    listState.selectedCollections.length > 0
 
   const addToWorkspace = async () => {
     if (!showWorkspaceConfirmation) {

--- a/components/reports/QueueFilter/SubjectType.tsx
+++ b/components/reports/QueueFilter/SubjectType.tsx
@@ -21,6 +21,40 @@ export const QueueFilterSubjectType = () => {
     }) || []
 
   return (
+    <SubjectTypeFilter
+      hasSubjectTypeFilter={hasSubjectTypeFilter}
+      isSubjectTypeAccount={queueFilters.subjectType === 'account'}
+      selectedCollections={selectedCollections}
+      isSubjectTypeRecord={
+        queueFilters.subjectType === 'record' ||
+        !!selectedCollections.length ||
+        !!selectedIncludeEmbedTypes.length
+      }
+      toggleCollection={toggleCollection}
+      toggleSubjectType={toggleSubjectType}
+      clearSubjectType={clearSubjectType}
+    />
+  )
+}
+
+export const SubjectTypeFilter = ({
+  hasSubjectTypeFilter,
+  isSubjectTypeRecord,
+  isSubjectTypeAccount,
+  selectedCollections,
+  toggleSubjectType,
+  clearSubjectType,
+  toggleCollection,
+}: {
+  hasSubjectTypeFilter: boolean
+  isSubjectTypeRecord: boolean
+  isSubjectTypeAccount: boolean
+  selectedCollections: string[]
+  toggleSubjectType: (subjectType: 'account' | 'record') => void
+  clearSubjectType: () => void
+  toggleCollection: (collectionId: string) => void
+}) => {
+  return (
     <div>
       <h3 className="text-gray-900 dark:text-gray-200 mb-2">
         <button
@@ -48,7 +82,7 @@ export const QueueFilterSubjectType = () => {
             onClick: () => {
               toggleSubjectType('account')
             },
-            isActive: queueFilters.subjectType === 'account',
+            isActive: isSubjectTypeAccount,
           },
           {
             id: 'subjectTypeRecord',
@@ -56,15 +90,12 @@ export const QueueFilterSubjectType = () => {
             onClick: () => {
               toggleSubjectType('record')
             },
-            isActive:
-              queueFilters.subjectType === 'record' ||
-              !!selectedCollections.length ||
-              !!selectedIncludeEmbedTypes.length,
+            isActive: isSubjectTypeRecord,
           },
         ]}
       />
 
-      {queueFilters.subjectType === 'record' && (
+      {isSubjectTypeRecord && (
         <div className="flex flex-row gap-4">
           <div>
             <h3 className="text-gray-900 dark:text-gray-200 my-2 border-b border-gray-400 pb-1">


### PR DESCRIPTION
This PR brings the already available filters for subject type and record collection to the event list allowing moderators to monitor events on account or record of certain collections either from event page or the quick action panel.