### PR TITLE
❇️ Add reposters to workspace

### DIFF
--- a/components/common/feeds/Likes.tsx
+++ b/components/common/feeds/Likes.tsx
@@ -2,13 +2,8 @@ import { AccountsGrid } from '@/repositories/AccountView'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { LoadMoreButton } from '../LoadMoreButton'
 import { usePdsAgent } from '@/shell/AuthContext'
-import { ActionButton } from '../buttons'
-import { ConfirmationModal } from '../modals/confirmation'
-import { useEffect, useRef, useState } from 'react'
-import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
-import { toast } from 'react-toastify'
 import { Agent } from '@atproto/api'
-import { pluralize } from '@/lib/util'
+import { SubjectToWorkspaceAction } from '@/workspace/SubjectsToWorkspaceAction'
 
 const useLikes = (pdsAgent: Agent, uri: string, cid?: string) => {
   return useInfiniteQuery({
@@ -27,107 +22,41 @@ const useLikes = (pdsAgent: Agent, uri: string, cid?: string) => {
 }
 
 export const Likes = ({ uri, cid }: { uri: string; cid?: string }) => {
-  const abortController = useRef<AbortController | null>(null)
   const pdsAgent = usePdsAgent()
   const { data, fetchNextPage, hasNextPage, error } = useLikes(
     pdsAgent,
     uri,
     cid,
   )
+
   const likes = data?.pages.flatMap((page) => page.likes) || []
-
-  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
-  const [isAdding, setIsAdding] = useState(false)
-  const { mutateAsync: addItemsToWorkspace } = useWorkspaceAddItemsMutation()
-
-  const confirmAddToWorkspace = async () => {
-    // add items that are already loaded
-    await addItemsToWorkspace(likes.map((l) => l.actor.did))
-    if (!data?.pageParams) {
-      setIsConfirmationOpen(false)
-      return
+  const likedByDids = likes.map((l) => l.actor.did)
+  const getSubjectsNextPage = async () => {
+    const { data, hasNextPage } = await fetchNextPage()
+    if (data?.pages?.length) {
+      const lastPage = data?.pages[data.pages.length - 1]
+      const subjects = lastPage?.likes.map((l) => l.actor.did) || []
+      return { subjects, hasNextPage }
     }
-    setIsAdding(true)
-    const newAbortController = new AbortController()
-    abortController.current = newAbortController
 
-    try {
-      let cursor = data.pageParams[0] as string | undefined
-      do {
-        const nextLikes = await pdsAgent.app.bsky.feed.getLikes(
-          {
-            uri,
-            cid,
-            cursor,
-            limit: 50,
-          },
-          { signal: abortController.current?.signal },
-        )
-        const dids = nextLikes.data?.likes.map((l) => l.actor.did) || []
-        if (dids.length) await addItemsToWorkspace(dids)
-        cursor = nextLikes.data.cursor
-        //   if the modal is closed, that means the user decided not to add any more user to workspace
-      } while (cursor && isConfirmationOpen)
-    } catch (e) {
-      if (abortController.current?.signal.reason === 'user-cancelled') {
-        toast.info('Stopped adding users to workspace')
-      } else {
-        toast.error(`Something went wrong: ${(e as Error).message}`)
-      }
-    }
-    setIsAdding(false)
-    setIsConfirmationOpen(false)
+    return { subjects: [], hasNextPage: false }
   }
-
-  useEffect(() => {
-    if (!isConfirmationOpen) {
-      abortController.current?.abort('user-cancelled')
-    }
-  }, [isConfirmationOpen])
-
-  useEffect(() => {
-    // User cancelled by closing this view (navigation, other?)
-    return () => abortController.current?.abort('user-cancelled')
-  }, [])
 
   return (
     <>
-      {!!likes?.length && (
-        <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
-          <ActionButton
-            appearance="primary"
-            size="sm"
-            onClick={() => setIsConfirmationOpen(true)}
-          >
-            Add {pluralize(likes.length, 'user')} to workspace
-          </ActionButton>
-
-          <ConfirmationModal
-            onConfirm={() => {
-              if (isAdding) {
-                setIsAdding(false)
-                setIsConfirmationOpen(false)
-                return
-              }
-
-              confirmAddToWorkspace()
-            }}
-            isOpen={isConfirmationOpen}
-            setIsOpen={setIsConfirmationOpen}
-            confirmButtonText={isAdding ? 'Stop adding' : 'Yes, add all'}
-            title={`Add users to workspace?`}
-            description={
-              <>
-                Once confirmed, all the users who liked the post will be added
-                to the workspace. For posts with a lot of likes, this may take
-                quite some time but you can always stop the process and already
-                added users will remain in the workspace.
-              </>
-            }
-          />
-        </div>
-      )}
-
+      <SubjectToWorkspaceAction
+        hasNextPage={hasNextPage}
+        initialSubjects={likedByDids}
+        getSubjectsNextPage={getSubjectsNextPage}
+        description={
+          <>
+            Once confirmed, all the users who liked the post will be added to
+            the workspace. For posts with a lot of likes, this may take quite
+            some time but you can always stop the process and already added
+            users will remain in the workspace.
+          </>
+        }
+      />
       <AccountsGrid
         error={error?.['message']}
         accounts={likes.map((l) => l.actor)}

--- a/components/common/feeds/Likes.tsx
+++ b/components/common/feeds/Likes.tsx
@@ -44,19 +44,21 @@ export const Likes = ({ uri, cid }: { uri: string; cid?: string }) => {
 
   return (
     <>
-      <SubjectToWorkspaceAction
-        hasNextPage={hasNextPage}
-        initialSubjects={likedByDids}
-        getSubjectsNextPage={getSubjectsNextPage}
-        description={
-          <>
-            Once confirmed, all the users who liked the post will be added to
-            the workspace. For posts with a lot of likes, this may take quite
-            some time but you can always stop the process and already added
-            users will remain in the workspace.
-          </>
-        }
-      />
+      <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
+        <SubjectToWorkspaceAction
+          hasNextPage={hasNextPage}
+          initialSubjects={likedByDids}
+          getSubjectsNextPage={getSubjectsNextPage}
+          description={
+            <>
+              Once confirmed, all the users who liked the post will be added to
+              the workspace. For posts with a lot of likes, this may take quite
+              some time but you can always stop the process and already added
+              users will remain in the workspace.
+            </>
+          }
+        />
+      </div>
       <AccountsGrid
         error={error?.['message']}
         accounts={likes.map((l) => l.actor)}

--- a/components/common/feeds/Reposts.tsx
+++ b/components/common/feeds/Reposts.tsx
@@ -38,19 +38,21 @@ export const Reposts = ({ uri, cid }: { uri: string; cid?: string }) => {
   }
   return (
     <>
-      <SubjectToWorkspaceAction
-        hasNextPage={hasNextPage}
-        initialSubjects={repostedByDids}
-        getSubjectsNextPage={getSubjectsNextPage}
-        description={
-          <>
-            Once confirmed, all the users who reposted the post will be added to
-            the workspace. For posts with a lot of reposts, this may take quite
-            some time but you can always stop the process and already added
-            users will remain in the workspace.
-          </>
-        }
-      />
+      <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
+        <SubjectToWorkspaceAction
+          hasNextPage={hasNextPage}
+          initialSubjects={repostedByDids}
+          getSubjectsNextPage={getSubjectsNextPage}
+          description={
+            <>
+              Once confirmed, all the users who reposted the post will be added
+              to the workspace. For posts with a lot of reposts, this may take
+              quite some time but you can always stop the process and already
+              added users will remain in the workspace.
+            </>
+          }
+        />
+      </div>
       <AccountsGrid error="" accounts={accounts} />
       {hasNextPage && (
         <div className="flex justify-center">

--- a/components/common/feeds/Reposts.tsx
+++ b/components/common/feeds/Reposts.tsx
@@ -2,6 +2,7 @@ import { AccountsGrid } from '@/repositories/AccountView'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { LoadMoreButton } from '../LoadMoreButton'
 import { usePdsAgent } from '@/shell/AuthContext'
+import { SubjectToWorkspaceAction } from '@/workspace/SubjectsToWorkspaceAction'
 
 const useReposts = (uri: string, cid?: string) => {
   const pdsAgent = usePdsAgent()
@@ -23,8 +24,33 @@ const useReposts = (uri: string, cid?: string) => {
 export const Reposts = ({ uri, cid }: { uri: string; cid?: string }) => {
   const { data, fetchNextPage, hasNextPage } = useReposts(uri, cid)
   const accounts = data?.pages.flatMap((page) => page.repostedBy) || []
+  const repostedByDids = accounts.map((l) => l.did)
+
+  const getSubjectsNextPage = async () => {
+    const { data, hasNextPage } = await fetchNextPage()
+    if (data?.pages?.length) {
+      const lastPage = data?.pages[data.pages.length - 1]
+      const subjects = lastPage?.repostedBy.map((l) => l.did) || []
+      return { subjects, hasNextPage }
+    }
+
+    return { subjects: [], hasNextPage: false }
+  }
   return (
     <>
+      <SubjectToWorkspaceAction
+        hasNextPage={hasNextPage}
+        initialSubjects={repostedByDids}
+        getSubjectsNextPage={getSubjectsNextPage}
+        description={
+          <>
+            Once confirmed, all the users who reposted the post will be added to
+            the workspace. For posts with a lot of reposts, this may take quite
+            some time but you can always stop the process and already added
+            users will remain in the workspace.
+          </>
+        }
+      />
       <AccountsGrid error="" accounts={accounts} />
       {hasNextPage && (
         <div className="flex justify-center">

--- a/components/graph/Followers.tsx
+++ b/components/graph/Followers.tsx
@@ -1,19 +1,11 @@
-import { ActionButton } from '@/common/buttons'
 import { LoadMoreButton } from '@/common/LoadMoreButton'
-import { ConfirmationModal } from '@/common/modals/confirmation'
 import { AccountsGrid } from '@/repositories/AccountView'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
+import { SubjectToWorkspaceAction } from '@/workspace/SubjectsToWorkspaceAction'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
-import { toast } from 'react-toastify'
 
 export function Followers({ id, count }: { id: string; count?: number }) {
-  const abortController = useRef<AbortController | null>(null)
-  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
   const labelerAgent = useLabelerAgent()
-  const [isAdding, setIsAdding] = useState(false)
-  const { mutateAsync: addItemsToWorkspace } = useWorkspaceAddItemsMutation()
   const { error, isLoading, data, fetchNextPage, hasNextPage } =
     useInfiniteQuery({
       queryKey: ['followers', { id }],
@@ -26,84 +18,26 @@ export function Followers({ id, count }: { id: string; count?: number }) {
       },
       getNextPageParam: (lastPage) => lastPage.cursor,
     })
-
   const followers = data?.pages.flatMap((page) => page.followers) ?? []
-
-  const confirmAddToWorkspace = async () => {
-    // add items that are already loaded
-    await addItemsToWorkspace(followers.map((f) => f.did))
-    if (!data?.pageParams) {
-      setIsConfirmationOpen(false)
-      return
+  const getSubjectsNextPage = async () => {
+    const { data, hasNextPage } = await fetchNextPage()
+    if (data?.pages?.length) {
+      const lastPage = data?.pages[data.pages.length - 1]
+      const subjects = lastPage?.followers.map((l) => l.did) || []
+      return { subjects, hasNextPage }
     }
-    setIsAdding(true)
-    const newAbortController = new AbortController()
-    abortController.current = newAbortController
 
-    try {
-      let cursor = data.pageParams[0] as string | undefined
-      do {
-        const nextFollowers = await labelerAgent.app.bsky.graph.getFollowers(
-          {
-            actor: id,
-            cursor,
-          },
-          { signal: abortController.current?.signal },
-        )
-        await addItemsToWorkspace(
-          nextFollowers.data.followers.map((f) => f.did),
-        )
-        cursor = nextFollowers.data.cursor
-        //   if the modal is closed, that means the user decided not to add any more user to workspace
-      } while (cursor && isConfirmationOpen)
-    } catch (e) {
-      if (abortController.current?.signal.reason === 'user-cancelled') {
-        toast.info('Stopped adding followers to workspace')
-      } else {
-        toast.error(`Something went wrong: ${(e as Error).message}`)
-      }
-    }
-    setIsAdding(false)
-    setIsConfirmationOpen(false)
+    return { subjects: [], hasNextPage: false }
   }
-
-  useEffect(() => {
-    if (!isConfirmationOpen) {
-      abortController.current?.abort('user-cancelled')
-    }
-  }, [isConfirmationOpen])
-
-  useEffect(() => {
-    // User cancelled by closing this view (navigation, other?)
-    return () => abortController.current?.abort('user-cancelled')
-  }, [])
 
   return (
     <div>
       {!!count && (
         <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
-          <ActionButton
-            appearance="primary"
-            size="sm"
-            onClick={() => setIsConfirmationOpen(true)}
-          >
-            Add to workspace
-          </ActionButton>
-
-          <ConfirmationModal
-            onConfirm={() => {
-              if (isAdding) {
-                setIsAdding(false)
-                setIsConfirmationOpen(false)
-                return
-              }
-
-              confirmAddToWorkspace()
-            }}
-            isOpen={isConfirmationOpen}
-            setIsOpen={setIsConfirmationOpen}
-            confirmButtonText={isAdding ? 'Stop adding' : 'Yes, add all'}
-            title={`Add followers to workspace?`}
+          <SubjectToWorkspaceAction
+            hasNextPage={hasNextPage}
+            initialSubjects={followers.map((f) => f.did)}
+            getSubjectsNextPage={getSubjectsNextPage}
             description={
               <>
                 Once confirmed, all the followers of the user will be added to

--- a/components/graph/Follows.tsx
+++ b/components/graph/Follows.tsx
@@ -1,19 +1,11 @@
-import { ActionButton } from '@/common/buttons'
 import { LoadMoreButton } from '@/common/LoadMoreButton'
-import { ConfirmationModal } from '@/common/modals/confirmation'
 import { AccountsGrid } from '@/repositories/AccountView'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
+import { SubjectToWorkspaceAction } from '@/workspace/SubjectsToWorkspaceAction'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useEffect, useRef, useState } from 'react'
-import { toast } from 'react-toastify'
 
 export function Follows({ id, count }: { id: string; count?: number }) {
-  const abortController = useRef<AbortController | null>(null)
   const labelerAgent = useLabelerAgent()
-  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
-  const [isAdding, setIsAdding] = useState(false)
-  const { mutateAsync: addItemsToWorkspace } = useWorkspaceAddItemsMutation()
   const { error, data, isLoading, fetchNextPage, hasNextPage } =
     useInfiniteQuery({
       queryKey: ['follows', { id }],
@@ -28,79 +20,25 @@ export function Follows({ id, count }: { id: string; count?: number }) {
     })
   const follows = data?.pages.flatMap((page) => page.follows) ?? []
 
-  const confirmAddToWorkspace = async () => {
-    // add items that are already loaded
-    await addItemsToWorkspace(follows.map((f) => f.did))
-    if (!data?.pageParams) {
-      setIsConfirmationOpen(false)
-      return
+  const getSubjectsNextPage = async () => {
+    const { data, hasNextPage } = await fetchNextPage()
+    if (data?.pages?.length) {
+      const lastPage = data?.pages[data.pages.length - 1]
+      const subjects = lastPage?.follows.map((l) => l.did) || []
+      return { subjects, hasNextPage }
     }
-    setIsAdding(true)
-    const newAbortController = new AbortController()
-    abortController.current = newAbortController
 
-    try {
-      let cursor = data.pageParams[0] as string | undefined
-      do {
-        const nextFollows = await labelerAgent.app.bsky.graph.getFollows(
-          {
-            actor: id,
-            cursor,
-          },
-          { signal: abortController.current?.signal },
-        )
-        await addItemsToWorkspace(nextFollows.data.follows.map((f) => f.did))
-        cursor = nextFollows.data.cursor
-        //   if the modal is closed, that means the user decided not to add any more user to workspace
-      } while (cursor && isConfirmationOpen)
-    } catch (e) {
-      if (abortController.current?.signal.reason === 'user-cancelled') {
-        toast.info('Stopped adding follows to workspace')
-      } else {
-        toast.error(`Something went wrong: ${(e as Error).message}`)
-      }
-    }
-    setIsAdding(false)
-    setIsConfirmationOpen(false)
+    return { subjects: [], hasNextPage: false }
   }
-
-  useEffect(() => {
-    if (!isConfirmationOpen) {
-      abortController.current?.abort('user-cancelled')
-    }
-  }, [isConfirmationOpen])
-
-  useEffect(() => {
-    // User cancelled by closing this view (navigation, other?)
-    return () => abortController.current?.abort('user-cancelled')
-  }, [])
 
   return (
     <div>
       {!!count && (
         <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
-          <ActionButton
-            appearance="primary"
-            size="sm"
-            onClick={() => setIsConfirmationOpen(true)}
-          >
-            Add to workspace
-          </ActionButton>
-
-          <ConfirmationModal
-            onConfirm={() => {
-              if (isAdding) {
-                setIsAdding(false)
-                setIsConfirmationOpen(false)
-                return
-              }
-
-              confirmAddToWorkspace()
-            }}
-            isOpen={isConfirmationOpen}
-            setIsOpen={setIsConfirmationOpen}
-            confirmButtonText={isAdding ? 'Stop adding' : 'Yes, add all'}
-            title={`Add follows to workspace?`}
+          <SubjectToWorkspaceAction
+            hasNextPage={hasNextPage}
+            initialSubjects={follows.map((f) => f.did)}
+            getSubjectsNextPage={getSubjectsNextPage}
             description={
               <>
                 Once confirmed, all the users this user follows will be added to

--- a/components/workspace/SubjectsToWorkspaceAction.tsx
+++ b/components/workspace/SubjectsToWorkspaceAction.tsx
@@ -72,7 +72,7 @@ export const SubjectToWorkspaceAction = ({
 
   if (!initialSubjects?.length) return null
   return (
-    <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
+    <>
       <ActionButton
         appearance="primary"
         size="sm"
@@ -101,6 +101,6 @@ export const SubjectToWorkspaceAction = ({
         title={`Add ${subjectType} to workspace?`}
         description={description}
       />
-    </div>
+    </>
   )
 }

--- a/components/workspace/SubjectsToWorkspaceAction.tsx
+++ b/components/workspace/SubjectsToWorkspaceAction.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'react-toastify'
+
+import { ActionButton } from '@/common/buttons'
+import { ConfirmationModal } from '@/common/modals/confirmation'
+import { pluralize } from '@/lib/util'
+import { useWorkspaceAddItemsMutation } from './hooks'
+
+export const SubjectToWorkspaceAction = ({
+  getSubjectsNextPage,
+  initialSubjects,
+  hasNextPage,
+  subjectType = 'user',
+  description,
+}: {
+  initialSubjects: string[]
+  hasNextPage?: boolean
+  getSubjectsNextPage: () => Promise<{
+    subjects: string[]
+    hasNextPage?: boolean
+  }>
+  subjectType?: 'user' | 'post' | 'subject'
+  description: JSX.Element
+}) => {
+  const abortController = useRef<AbortController | null>(null)
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false)
+  const [isAdding, setIsAdding] = useState(false)
+  const { mutateAsync: addItemsToWorkspace } = useWorkspaceAddItemsMutation()
+
+  const confirmAddToWorkspace = async () => {
+    // add items that are already loaded
+    await addItemsToWorkspace(initialSubjects)
+    if (!hasNextPage) {
+      setIsConfirmationOpen(false)
+      return
+    }
+    setIsAdding(true)
+    const newAbortController = new AbortController()
+    abortController.current = newAbortController
+
+    try {
+      let hasMore = false
+      do {
+        const nextPage = await getSubjectsNextPage()
+        hasMore = !!nextPage.hasNextPage
+        if (nextPage.subjects.length) {
+          await addItemsToWorkspace(nextPage.subjects)
+        } else {
+          toast.info(`Finished adding ${subjectType} to workspace`)
+        }
+        if (abortController.current?.signal.aborted) {
+          toast.info(`Stopped adding ${subjectType} to workspace`)
+        }
+      } while (hasMore && !abortController.current?.signal.aborted)
+    } catch (e) {
+      toast.error(`Something went wrong: ${(e as Error).message}`)
+    }
+    setIsAdding(false)
+    setIsConfirmationOpen(false)
+  }
+
+  useEffect(() => {
+    if (!isConfirmationOpen) {
+      abortController.current?.abort()
+    }
+  }, [isConfirmationOpen])
+
+  useEffect(() => {
+    // User cancelled by closing this view (navigation, other?)
+    return () => abortController.current?.abort()
+  }, [])
+
+  if (!initialSubjects?.length) return null
+  return (
+    <div className="flex flex-row justify-end pt-2 mx-auto mt-2 max-w-5xl px-4 sm:px-6 lg:px-8">
+      <ActionButton
+        appearance="primary"
+        size="sm"
+        onClick={() => setIsConfirmationOpen(true)}
+      >
+        Add{' '}
+        {pluralize(initialSubjects.length, subjectType, {
+          includeCount: false,
+        })}{' '}
+        to workspace
+      </ActionButton>
+
+      <ConfirmationModal
+        onConfirm={() => {
+          if (isAdding) {
+            setIsAdding(false)
+            setIsConfirmationOpen(false)
+            return
+          }
+
+          confirmAddToWorkspace()
+        }}
+        isOpen={isConfirmationOpen}
+        setIsOpen={setIsConfirmationOpen}
+        confirmButtonText={isAdding ? 'Stop adding' : 'Yes, add all'}
+        title={`Add ${subjectType} to workspace?`}
+        description={description}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds `Add to workspace button` to the reposts tab for posts. Additionally, it refactors the `Add to workspace` feature into a shareable component and replaces the manual implementation on Likes, Followers and Follows tabs with the shared component.