### PR TITLE
:sparkles: Separate triage and escalation queue config

### DIFF
--- a/components/reports/QueueSelector.tsx
+++ b/components/reports/QueueSelector.tsx
@@ -1,12 +1,21 @@
 import { Dropdown } from '@/common/Dropdown'
+import { ToolsOzoneModerationDefs } from '@atproto/api/'
 import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import { useQueueSetting } from 'components/setting/useQueueSetting'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+const NoListQueueHeader = () => (
+  <h3 className="flex items-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-200">
+    Queue
+  </h3>
+)
 
 export const QueueSelector = () => {
   const searchParams = useSearchParams()
   const router = useRouter()
   const pathname = usePathname()
+  const isEscalationTab =
+    searchParams.get('reviewState') === ToolsOzoneModerationDefs.REVIEWESCALATED
   const queueName = searchParams.get('queueName')
   const { setting: queueSetting } = useQueueSetting()
 
@@ -21,19 +30,15 @@ export const QueueSelector = () => {
   }
 
   // If no queues are configured, just use a static title
-  if (
-    queueSetting.isLoading ||
-    !queueSetting.data ||
-    !queueSetting.data?.queueNames.length
-  ) {
-    return (
-      <h3 className="flex items-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-200">
-        Queue
-      </h3>
-    )
+  if (queueSetting.isLoading || !queueSetting.data) {
+    return <NoListQueueHeader />
   }
+  const { queueNames, escalationQueueNames, queueList } = queueSetting.data
+  const queueNamesToShow = isEscalationTab ? escalationQueueNames : queueNames
 
-  const { queueNames, queueList } = queueSetting.data
+  if (queueNamesToShow.length <= 0) {
+    return <NoListQueueHeader />
+  }
 
   return (
     <Dropdown
@@ -44,14 +49,16 @@ export const QueueSelector = () => {
           text: 'All',
           onClick: selectQueue(''),
         },
-        ...queueNames.map((q) => ({
+        ...queueNamesToShow.map((q) => ({
           text: queueList.setting[q].name,
           onClick: selectQueue(q),
         })),
       ]}
     >
-      <h3 className="flex items-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-200">
-        {queueName ? `${queueList.setting[queueName].name} Queue` : 'Queue'}
+      <h3 className="capitalize flex items-center text-lg font-medium leading-6 text-gray-900 dark:text-gray-200">
+        {queueName && queueNamesToShow.includes(queueName)
+          ? queueName
+          : 'Queue'}
         <ChevronDownIcon
           className="text-gray-900 dark:text-gray-200 h-4 w-4"
           aria-hidden="true"

--- a/components/setting/useQueueSetting.ts
+++ b/components/setting/useQueueSetting.ts
@@ -3,7 +3,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { QUEUE_CONFIG } from '@/lib/constants'
 import { toast } from 'react-toastify'
 
-type QueueConfig = Record<string, { name: string }>
+type QueueConfig = Record<
+  string,
+  { name: string; includesEscalation?: boolean }
+>
 
 const getQueueConfig = () => {
   const config = QUEUE_CONFIG
@@ -52,10 +55,16 @@ export const useQueueSetting = () => {
         }
       })
 
+      const queueNames = Object.keys(queueList.setting)
+      const escalationQueueNames = queueNames.filter(
+        (name) => queueList.setting[name].includesEscalation,
+      )
+
       return {
         queueList,
         queueSeed,
-        queueNames: Object.keys(queueList.setting),
+        queueNames,
+        escalationQueueNames,
       }
     },
   })

--- a/components/subject/useSubjectStatus.tsx
+++ b/components/subject/useSubjectStatus.tsx
@@ -11,7 +11,7 @@ export const useSubjectStatus = ({ subject }: { subject: string | null }) => {
     queryFn: async () => {
       if (!subject) return null
       const { data } =
-        await labelerAgent.api.tools.ozone.moderation.queryStatuses({
+        await labelerAgent.tools.ozone.moderation.queryStatuses({
           subject,
           includeMuted: true,
           limit: 1,
@@ -46,7 +46,7 @@ export const useSubjectStatuses = ({
       const statusBySubject: StatusBySubject = {}
       await Promise.allSettled(
         subjects.map((subject) => {
-          return labelerAgent.api.tools.ozone.moderation
+          return labelerAgent.tools.ozone.moderation
             .queryStatuses({ subject, includeMuted: true, limit: 1 })
             .then(({ data }) => {
               if (data?.subjectStatuses[0]) {


### PR DESCRIPTION
This PR makes default queue config only applicable to non-escalation tabs and adds an additional flag per queue config to make a queue available on the escalation tab. This makes it really easy to have different number of queues for `triage` and `moderator` roles.

