### PR TITLE
improve info tag contrast

### DIFF
--- a/components/subject/PriorityScore.tsx
+++ b/components/subject/PriorityScore.tsx
@@ -15,7 +15,7 @@ export const PriorityScore = ({
   return (
     <LabelChip
       className={classNames(
-        'flex flex-row gap-1 items-center bg-orange-300 text-orange-800',
+        'flex flex-row gap-1 items-center bg-orange-200 text-orange-800',
         size === 'sm' ? 'text-xs px-1 py-0' : '',
       )}
       title={`This subject's priority score is set to ${priorityScore} out of 100. Subjects with higher score should be reviewed more urgently.`}

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -26,7 +26,7 @@ export const StatView = ({
   let bgColor = 'bg-gray-400 dark:text-gray-100 text-white'
 
   if (appearance === 'info') {
-    bgColor = 'bg-blue-400 text-blue-800'
+    bgColor = 'bg-blue-200 text-blue-800'
   } else if (appearance === 'danger') {
     bgColor = 'bg-red-200 text-red-800'
   } else if (appearance === 'warning') {


### PR DESCRIPTION
Not great, but at least a bit better. My web accessibility dev tool thing isn't detecting/confirming if this is enough.

Top is changed colors, bottom is old colors.

![2025-03-06T23:40:53,269131906-08:00](https://github.com/user-attachments/assets/6c9351c5-8e25-4002-b7b0-8915599ce22c)

This is related to @rahaeli's https://github.com/bluesky-social/ozone/issues/310

Maybe even better/clearer would be something like `border-2 border-blue-400`? I'm not sure if that is clear enough for any current workflows, and hesitant to make a bigger change w/o mod team feedback.