### PR TITLE
❇️ Use subject view for workspace data and show warnings

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -57,6 +57,8 @@ import { EmailComposer } from 'components/email/Composer'
 import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
 import { PriorityScore } from '@/subject/PriorityScore'
 import { getEventFromFormData } from '@/mod-event/helpers/emitEvent'
+import { Alert } from '@/common/Alert'
+import { TextWithLinks } from '@/common/TextWithLinks'
 
 const FORM_ID = 'mod-action-panel'
 const useBreakpoint = createBreakpoint({ xs: 340, sm: 640 })
@@ -542,7 +544,10 @@ function Form(
                 >
                   {!isSubjectDid && record?.repo && (
                     <div className="-ml-1 my-2">
-                      <RecordAuthorStatus repo={record.repo} />
+                      <RecordAuthorStatus
+                        repo={record.repo}
+                        profile={profile}
+                      />
                     </div>
                   )}
                 </PreviewCard>
@@ -560,9 +565,13 @@ function Form(
                     <LastReviewedTimestamp subjectStatus={subjectStatus} />
                   </p>
                   {!!subjectStatus.comment && (
-                    <Card hint="important" className="mt-2">
-                      <strong>Note:</strong> {subjectStatus.comment}
-                    </Card>
+                    <div className="mt-2">
+                      <Alert
+                        type="info"
+                        title="Note"
+                        body={<TextWithLinks text={subjectStatus.comment} />}
+                      />
+                    </div>
                   )}
                 </div>
               )}

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -30,7 +30,6 @@ import { WorkspacePanel } from 'components/workspace/Panel'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { useQueueSetting } from 'components/setting/useQueueSetting'
 import QueueFilterPanel from '@/reports/QueueFilter/Panel'
-import { REVIEWESCALATED } from '@atproto/api/dist/client/types/tools/ozone/moderation/defs'
 
 const TABS = [
   {
@@ -438,7 +437,7 @@ function useModerationQueueQuery() {
       // when escalation queue count and triage queue counts are different
       if (
         queueParams?.queueNames &&
-        queryParams.reviewState === REVIEWESCALATED &&
+        queryParams.reviewState === ToolsOzoneModerationDefs.REVIEWESCALATED &&
         queueSetting.data?.escalationQueueNames
       ) {
         queueParams.queueNames = queueSetting.data.escalationQueueNames

--- a/components/common/Alert.tsx
+++ b/components/common/Alert.tsx
@@ -21,7 +21,7 @@ export const Alert = ({
       title: 'text-red-600',
     },
     info: {
-      container: 'border-blue-800 bg-blue-200 text-blue-800',
+      container: 'border-blue-800 bg-blue-200 text-blue-500',
       title: 'text-blue-800',
     },
     warning: {

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -15,10 +15,19 @@ import { CollectionId } from '@/reports/helpers/subject'
 import { ListRecordCard } from 'components/list/RecordCard'
 import { FeedGeneratorRecordCard } from './feeds/RecordCard'
 import { ProfileAvatar } from '@/repositories/ProfileAvatar'
-import { ShieldCheckIcon } from '@heroicons/react/24/solid'
+import {
+  FolderMinusIcon,
+  FolderPlusIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/solid'
 import { StarterPackRecordCard } from './starterpacks/RecordCard'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { getProfileFromRepo } from '@/repositories/helpers'
+import {
+  useWorkspaceAddItemsMutation,
+  useWorkspaceList,
+  useWorkspaceRemoveItemsMutation,
+} from '@/workspace/hooks'
 
 export function RecordCard(props: {
   uri: string
@@ -325,6 +334,11 @@ const AssociatedProfileIcon = ({
 export function RepoCard(props: { did: string }) {
   const { did } = props
   const { data: { repo, profile } = {}, error } = useRepoAndProfile({ did })
+  const { data: workspaceList } = useWorkspaceList()
+  const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
+  const { mutate: removeFromWorkspace } = useWorkspaceRemoveItemsMutation()
+  const isInWorkspace = workspaceList?.includes(did)
+
   if (error) {
     return (
       <LoadingFailedDense
@@ -389,7 +403,7 @@ export function RepoCard(props: { did: string }) {
             <div className="flex flex-row items-center gap-2">
               <Link
                 href={`/repositories/${repo.did}?tab=followers`}
-                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-400 underline hover:underline cursor-pointer"
+                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">
                   {pluralize(profile?.followersCount || 0, 'follower')}
@@ -397,7 +411,7 @@ export function RepoCard(props: { did: string }) {
               </Link>
               <Link
                 href={`/repositories/${repo.did}?tab=follows`}
-                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-400 underline hover:underline cursor-pointer"
+                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">
                   {pluralize(profile?.followsCount || 0, 'follow')}
@@ -405,12 +419,31 @@ export function RepoCard(props: { did: string }) {
               </Link>
               <Link
                 href={`/repositories/${repo.did}?tab=posts`}
-                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-400 underline hover:underline cursor-pointer"
+                className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">
                   {pluralize(profile?.postsCount || 0, 'post')}
                 </span>
               </Link>
+              {isInWorkspace ? (
+                <button
+                  type="button"
+                  className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 hover:underline cursor-pointer"
+                  onClick={() => removeFromWorkspace([did])}
+                >
+                  <FolderMinusIcon className="w-4 h-4" />
+                  <span className="text-sm">Remove from workspace</span>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 hover:underline cursor-pointer"
+                  onClick={() => addToWorkspace([did])}
+                >
+                  <FolderPlusIcon className="w-4 h-4" />
+                  <span className="text-sm">Add to workspace</span>
+                </button>
+              )}
             </div>
           )}
           {takendown && (

--- a/components/common/TextWithLinks.tsx
+++ b/components/common/TextWithLinks.tsx
@@ -1,7 +1,7 @@
 // Utility function to detect and replace links with <a> tags
 const wrapLinksInText = (text: string): JSX.Element[] => {
   // Regular expression to match URLs
-  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const urlRegex = /(https?:\/\/[^\s]+)/
 
   // Split text into parts, with URLs as matches
   const parts = text.split(urlRegex)

--- a/components/common/TextWithLinks.tsx
+++ b/components/common/TextWithLinks.tsx
@@ -1,0 +1,31 @@
+// Utility function to detect and replace links with <a> tags
+const wrapLinksInText = (text: string): JSX.Element[] => {
+  // Regular expression to match URLs
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+
+  // Split text into parts, with URLs as matches
+  const parts = text.split(urlRegex)
+
+  return parts.map((part, index) => {
+    if (urlRegex.test(part)) {
+      // If part matches a URL, return it as a link
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all underline"
+        >
+          {part}
+        </a>
+      )
+    }
+    // Otherwise, return it as plain text
+    return <span key={index}>{part}</span>
+  })
+}
+
+export const TextWithLinks: React.FC<{ text: string }> = ({ text }) => {
+  return <p className="whitespace-pre-wrap">{wrapLinksInText(text)}</p>
+}

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -19,6 +19,7 @@ import { ModEventViewWithDetails } from './useModEventList'
 import { ClockIcon, DocumentTextIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 import { pluralize } from '@/lib/util'
+import { TextWithLinks } from '@/common/TextWithLinks'
 
 const LinkToAuthor = ({
   creatorHandle,
@@ -36,38 +37,6 @@ const LinkToAuthor = ({
       {creatorHandle ? `@${creatorHandle}` : createdBy}
     </a>
   )
-}
-
-// Utility function to detect and replace links with <a> tags
-const wrapLinksInText = (text: string): JSX.Element[] => {
-  // Regular expression to match URLs
-  const urlRegex = /(https?:\/\/[^\s]+)/g
-
-  // Split text into parts, with URLs as matches
-  const parts = text.split(urlRegex)
-
-  return parts.map((part, index) => {
-    if (urlRegex.test(part)) {
-      // If part matches a URL, return it as a link
-      return (
-        <a
-          key={index}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="break-all underline"
-        >
-          {part}
-        </a>
-      )
-    }
-    // Otherwise, return it as plain text
-    return <span key={index}>{part}</span>
-  })
-}
-
-const TextWithLinks: React.FC<{ text: string }> = ({ text }) => {
-  return <p className="whitespace-pre-wrap">{wrapLinksInText(text)}</p>
 }
 
 const Comment = ({

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -9,11 +9,7 @@ import {
 } from '@atproto/api'
 import { useQueryClient } from '@tanstack/react-query'
 
-import {
-  buildItemsSummary,
-  groupSubjects,
-  isSubjectStatusView,
-} from '@/workspace/utils'
+import { buildItemsSummary, groupSubjects } from '@/workspace/utils'
 
 import { displayError } from '../../common/Loader'
 import { MOD_EVENTS } from '@/mod-event/constants'
@@ -21,10 +17,7 @@ import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { useCallback } from 'react'
 import { useCreateSubjectFromId } from '@/reports/helpers/subject'
 import { chunkArray } from '@/lib/util'
-import {
-  WorkspaceListData,
-  WorkspaceListItemData,
-} from '@/workspace/useWorkspaceListData'
+import { WorkspaceListData } from '@/workspace/useWorkspaceListData'
 import { compileTemplateContent } from 'components/email/helpers'
 import { diffTags } from 'components/tags/utils'
 import { DM_DISABLE_TAG, VIDEO_UPLOAD_DISABLE_TAG } from '@/lib/constants'
@@ -98,7 +91,7 @@ type BulkActionResults = {
 
 const eventForSubject = (
   eventData: Pick<ToolsOzoneModerationEmitEvent.InputSchema, 'event'>,
-  subjectData: WorkspaceListItemData,
+  subjectData: ToolsOzoneModerationDefs.SubjectView,
 ): Pick<ToolsOzoneModerationEmitEvent.InputSchema, 'event'> => {
   // only need to adjust event data for each subject for email events
   // for the rest, same event data is used for all subjects
@@ -121,20 +114,12 @@ const eventForSubject = (
     )
   }
 
-  const handle = ToolsOzoneModerationDefs.isRepoViewDetail(subjectData)
-    ? subjectData.handle
-    : ToolsOzoneModerationDefs.isRecordViewDetail(subjectData)
-    ? subjectData.repo.handle
-    : isSubjectStatusView(subjectData)
-    ? subjectData.subjectRepoHandle
-    : undefined
-
   return {
     ...eventData,
     event: {
       ...eventData.event,
       content: compileTemplateContent(eventData.event.content, {
-        handle,
+        handle: subjectData.repo?.handle,
       }),
     },
   }

--- a/components/repositories/HighProfileWarning.tsx
+++ b/components/repositories/HighProfileWarning.tsx
@@ -2,7 +2,7 @@ import { Alert } from '@/common/Alert'
 import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
 import { AppBskyActorDefs } from '@atproto/api'
 
-const numberFormatter = new Intl.NumberFormat('en', {
+export const numberFormatter = new Intl.NumberFormat('en', {
   notation: 'compact',
   compactDisplay: 'short',
 })

--- a/components/repositories/helpers.ts
+++ b/components/repositories/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  AppBskyActorDefs,
   AppBskyActorProfile,
   asPredicate,
   ComAtprotoAdminDefs,
@@ -59,3 +60,7 @@ export const getProfileFromRepo = (
 ) => {
   return relatedRecords.find(isValidProfileRecord)
 }
+
+export const isValidProfileViewDetailed = asPredicate(
+  AppBskyActorDefs.validateProfileViewDetailed,
+)

--- a/components/subject/RecordAuthorStatus.tsx
+++ b/components/subject/RecordAuthorStatus.tsx
@@ -4,7 +4,7 @@ import {
   YOUNG_ACCOUNT_MARKER_THRESHOLD_IN_DAYS,
 } from '@/lib/constants'
 import { getProfileFromRepo } from '@/repositories/helpers'
-import { AppBskyActorProfile, ToolsOzoneModerationDefs } from '@atproto/api'
+import { AppBskyActorDefs, ToolsOzoneModerationDefs } from '@atproto/api'
 import {
   LockClosedIcon,
   MoonIcon,
@@ -22,11 +22,13 @@ const getProfileCreatedAtFromRepo = (
 
 export const RecordAuthorStatus = ({
   repo,
+  profile,
 }: {
   repo: ToolsOzoneModerationDefs.RepoView
+  profile?: AppBskyActorDefs.ProfileViewDetailed
 }) => {
   // If a profile entry doesn't exist, use the repo.indexedAt timestamps as indicative of account creation date
-  const createdAt = getProfileCreatedAtFromRepo(repo)
+  const createdAt = profile?.createdAt || getProfileCreatedAtFromRepo(repo)
   const accountAge = differenceInDays(new Date(), new Date(createdAt))
   const isNew = accountAge < NEW_ACCOUNT_MARKER_THRESHOLD_IN_DAYS
   const isYoung = accountAge < YOUNG_ACCOUNT_MARKER_THRESHOLD_IN_DAYS

--- a/components/subject/ReviewStateMarker.tsx
+++ b/components/subject/ReviewStateMarker.tsx
@@ -2,7 +2,6 @@ import { DM_DISABLE_TAG } from '@/lib/constants'
 import { classNames } from '@/lib/util'
 import {
   ComAtprotoAdminDefs,
-  ComAtprotoRepoDefs,
   ComAtprotoRepoStrongRef,
   ToolsOzoneModerationDefs,
 } from '@atproto/api'
@@ -25,7 +24,7 @@ const reviewStateDescription = {
     'This subject received moderation events but no human review is necessary as of now',
 }
 
-const reviewStateToText = {
+export const reviewStateToText = {
   [ToolsOzoneModerationDefs.REVIEWOPEN]: 'Requires Review',
   [ToolsOzoneModerationDefs.REVIEWESCALATED]: 'Escalated',
   [ToolsOzoneModerationDefs.REVIEWCLOSED]: 'Reviewed',

--- a/components/tags/SubjectTag.tsx
+++ b/components/tags/SubjectTag.tsx
@@ -24,6 +24,16 @@ export const SubjectTag = ({
           {langDetails.flag}
         </span>
       )
+    } else if (tag.endsWith('und')) {
+      return (
+        <LabelChip
+          {...rest}
+          title="Could not reliably determine primary language"
+          aria-label="Could not reliably determine primary language"
+        >
+          lang?
+        </LabelChip>
+      )
     }
   }
 

--- a/components/tags/SubjectTag.tsx
+++ b/components/tags/SubjectTag.tsx
@@ -1,5 +1,6 @@
 import { LabelChip } from '@/common/labels'
 import { LANGUAGES_MAP_CODE2 } from '@/lib/locale/languages'
+import { FlagIcon } from '@heroicons/react/24/solid'
 import { ComponentProps } from 'react'
 
 export const getLanguageFlag = (langCode: string) => {
@@ -25,6 +26,19 @@ export const SubjectTag = ({
       )
     }
   }
-  
+
+  if (tag.startsWith('report:')) {
+    const reportType = tag.split(':')[1]?.toLowerCase()
+    return (
+      <LabelChip
+        {...rest}
+        title={`Reported with reason ${reportType}`}
+        aria-label={`Reported with reason ${reportType}`}
+      >
+        <FlagIcon className="h-3 w-3" /> {reportType}
+      </LabelChip>
+    )
+  }
+
   return <LabelChip {...rest}>{tag}</LabelChip>
 }

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState } from 'react'
 import { FilterGroup, WorkspaceFilterItem } from './types'
 import { WorkspaceListData } from './useWorkspaceListData'
 import { checkFilterMatchForWorkspaceItem } from './utils'
+import { toast } from 'react-toastify'
 
 type FilterContextType = {
   filterGroup: FilterGroup[]
@@ -82,8 +83,12 @@ export const FilterProvider = ({
       }
     }
 
-    for (const filteredItem of filteredItems) {
-      toggleItemCheck(filteredItem, select)
+    if (filteredItems.length === 0) {
+      toast.error('No items match your filters')
+    } else {
+      for (const filteredItem of filteredItems) {
+        toggleItemCheck(filteredItem, select)
+      }
     }
   }
 

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -105,7 +105,10 @@ export const FilterProvider = ({
           (f) => f.field === filter.field && filter.operator === f.operator,
         )
       ) {
-        newGroup[groupId].filters.push(filter)
+        newGroup[groupId] = {
+          ...newGroup[groupId],
+          filters: [...newGroup[groupId].filters, filter],
+        }
       }
       return newGroup
     })
@@ -122,9 +125,12 @@ export const FilterProvider = ({
   const removeFilter = (groupId: number, field: string, operator: string) => {
     setFilterGroup((prev) => {
       const newGroup = [...prev]
-      newGroup[groupId].filters = newGroup[groupId].filters.filter(
-        (f) => !(f.field === field && f.operator === operator), // fix: negate the match
-      )
+      newGroup[groupId] = {
+        ...newGroup[groupId],
+        filters: newGroup[groupId].filters.filter(
+          (f) => !(f.field === field && f.operator === operator),
+        ),
+      }
       return newGroup
     })
   }

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -1,0 +1,135 @@
+import { createContext, useContext, useState } from 'react'
+import { FilterGroup, WorkspaceFilterItem } from './types'
+import { WorkspaceListData } from './useWorkspaceListData'
+import { checkFilterMatchForWorkspaceItem } from './utils'
+
+type FilterContextType = {
+  filterGroup: FilterGroup[]
+  addFilter: (groupId: number, filter: WorkspaceFilterItem) => void
+  addGroup: (operator: 'AND' | 'OR') => void
+  removeGroup: (groupId: number) => void
+  removeFilter: (groupId: number, field: string, operator: string) => void
+  selectAll: () => void
+  unselectAll: () => void
+  toggleFilteredItems: (select: boolean) => void
+}
+
+const FilterContext = createContext<FilterContextType | null>(null)
+
+const toggleItemCheck = (item: string, select: boolean = true) => {
+  const checkbox = document?.querySelector<HTMLInputElement>(
+    `#mod-workspace input[type="checkbox"][name="workspaceItem"][value="${item}"]`,
+  )
+  if (checkbox) {
+    checkbox.checked = select
+  }
+}
+
+export const FilterProvider = ({
+  children,
+  listData,
+}: {
+  children: React.ReactNode
+  listData?: WorkspaceListData
+}) => {
+  const [filterGroup, setFilterGroup] = useState<FilterGroup[]>([
+    { filters: [] },
+  ])
+
+  const selectAll = () => {
+    if (!listData) return
+    Object.keys(listData).forEach((uri) => {
+      toggleItemCheck(uri)
+    })
+  }
+
+  const unselectAll = () => {
+    if (!listData) return
+    Object.keys(listData).forEach((uri) => {
+      toggleItemCheck(uri, false)
+    })
+  }
+
+  const toggleFilteredItems = (select: boolean) => {
+    if (!listData) return
+    const filteredItems: string[] = []
+
+    for (const [subject, data] of Object.entries(listData)) {
+      let matchesFilters = false
+
+      for (const group of filterGroup) {
+        let groupMatches = false
+
+        for (const filter of group.filters) {
+          if (checkFilterMatchForWorkspaceItem(filter, data)) {
+            groupMatches = true
+          }
+        }
+
+        if (group.operator === 'AND' && !groupMatches) {
+          matchesFilters = false
+          break
+        } else if (group.operator === 'OR' && groupMatches) {
+          matchesFilters = true
+          break
+        }
+
+        if (matchesFilters) {
+          filteredItems.push(subject)
+        }
+      }
+    }
+  }
+
+  const addFilter = (groupId: number, filter: WorkspaceFilterItem) => {
+    setFilterGroup((prev) => {
+      const newGroup = [...prev]
+      if (!newGroup[groupId]?.filters.some((f) => f.field === filter.field)) {
+        newGroup[groupId].filters.push(filter)
+      }
+      return newGroup
+    })
+  }
+
+  const addGroup = (operator: 'AND' | 'OR') => {
+    setFilterGroup((prev) => [...prev, { operator, filters: [] }])
+  }
+
+  const removeGroup = (groupId: number) => {
+    setFilterGroup((prev) => prev.filter((_, i) => i !== groupId))
+  }
+
+  const removeFilter = (groupId: number, field: string, operator: string) => {
+    setFilterGroup((prev) => {
+      const newGroup = [...prev]
+      newGroup[groupId].filters = newGroup[groupId].filters.filter(
+        (f) => !(f.field === field && f.operator === operator), // fix: negate the match
+      )
+      return newGroup
+    })
+  }
+
+  return (
+    <FilterContext.Provider
+      value={{
+        filterGroup,
+        addFilter,
+        addGroup,
+        removeFilter,
+        removeGroup,
+        selectAll,
+        unselectAll,
+        toggleFilteredItems,
+      }}
+    >
+      {children}
+    </FilterContext.Provider>
+  )
+}
+
+export const useFilter = () => {
+  const context = useContext(FilterContext)
+  if (!context)
+    throw new Error('useFilter must be used within a FilterProvider')
+  return context
+}

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -53,6 +53,7 @@ export const FilterProvider = ({
 
   const toggleFilteredItems = (select: boolean) => {
     if (!listData) return
+    console.log(listData)
     const filteredItems: string[] = []
 
     for (const [subject, data] of Object.entries(listData)) {

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -66,7 +66,9 @@ export const FilterProvider = ({
           }
         }
 
-        if (group.operator === 'AND' && !groupMatches) {
+        if (!group.operator) {
+          matchesFilters = groupMatches
+        } else if (group.operator === 'AND' && !groupMatches) {
           matchesFilters = false
           break
         } else if (group.operator === 'OR' && groupMatches) {
@@ -79,12 +81,20 @@ export const FilterProvider = ({
         }
       }
     }
+
+    for (const filteredItem of filteredItems) {
+      toggleItemCheck(filteredItem, select)
+    }
   }
 
   const addFilter = (groupId: number, filter: WorkspaceFilterItem) => {
     setFilterGroup((prev) => {
       const newGroup = [...prev]
-      if (!newGroup[groupId]?.filters.some((f) => f.field === filter.field)) {
+      if (
+        !newGroup[groupId]?.filters.some(
+          (f) => f.field === filter.field && filter.operator === f.operator,
+        )
+      ) {
         newGroup[groupId].filters.push(filter)
       }
       return newGroup

--- a/components/workspace/FilterContext.tsx
+++ b/components/workspace/FilterContext.tsx
@@ -53,7 +53,6 @@ export const FilterProvider = ({
 
   const toggleFilteredItems = (select: boolean) => {
     if (!listData) return
-    console.log(listData)
     const filteredItems: string[] = []
 
     for (const [subject, data] of Object.entries(listData)) {
@@ -90,6 +89,11 @@ export const FilterProvider = ({
       for (const filteredItem of filteredItems) {
         toggleItemCheck(filteredItem, select)
       }
+      toast.success(
+        `${filteredItems.length} items have been ${
+          select ? 'selected' : 'unselected'
+        }`,
+      )
     }
   }
 

--- a/components/workspace/FilterSelector.tsx
+++ b/components/workspace/FilterSelector.tsx
@@ -1,24 +1,15 @@
 import { Popover, Transition } from '@headlessui/react'
-import { ActionButton } from '@/common/buttons'
+import { ActionButton, ButtonGroup } from '@/common/buttons'
 import { CheckIcon } from '@heroicons/react/24/outline'
-import { Checkbox, FormLabel, Input } from '@/common/forms'
+import { Input } from '@/common/forms'
 import { useState } from 'react'
-import { WorkspaceListData } from './useWorkspaceListData'
-import { ToolsOzoneModerationDefs } from '@atproto/api'
-import { getSubjectStatusFromItemData } from './utils'
-import { getProfileFromRepo } from '@/repositories/helpers'
-import { Dropdown } from '@/common/Dropdown'
-import { ChevronDownIcon } from '@heroicons/react/24/solid'
-import { differenceInDays, differenceInHours } from 'date-fns'
 
-const toggleItemCheck = (item: string, select: boolean = true) => {
-  const checkbox = document?.querySelector<HTMLInputElement>(
-    `#mod-workspace input[type="checkbox"][name="workspaceItem"][value="${item}"]`,
-  )
-  if (checkbox) {
-    checkbox.checked = select
-  }
-}
+import { FilterProvider, useFilter } from './FilterContext'
+import { WorkspaceListData } from './useWorkspaceListData'
+import { differenceInDays, differenceInHours } from 'date-fns'
+import { WorkspaceFilterItem } from './types'
+import { Dropdown } from '@/common/Dropdown'
+import { ChevronDownIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid'
 
 const matchMinimumAccountAge = (
   minAccountAgeUnit: string,
@@ -36,42 +27,255 @@ const matchMinimumAccountAge = (
   return diff >= minAccountAge
 }
 
-const AccountFilterOptions = {
-  accountReviewOpen: {
-    label: 'Accounts in unresolved review state',
+type DurationUnit = 'days' | 'weeks' | 'months' | 'years'
+
+const availableFilters: (Omit<WorkspaceFilterItem, 'value'> &
+  Partial<{ unit: DurationUnit }> & {
+    text: string
+  })[] = [
+  { field: 'followerCount', operator: 'gte', text: 'Min. Follower Count' },
+  { field: 'followerCount', operator: 'lte', text: 'Max. Follower Count' },
+  { field: 'followCount', operator: 'gte', text: 'Min. Follow Count' },
+  { field: 'followCount', operator: 'lte', text: 'Max. Follow Count' },
+  {
+    field: 'accountAge',
+    operator: 'gte',
+    unit: 'days',
+    text: 'Min. Account Age',
+  }, // ✅ Now allowed
+  {
+    field: 'accountAge',
+    operator: 'lte',
+    unit: 'weeks',
+    text: 'Max. Account Age',
   },
-  accountReviewAppealed: {
-    label: 'Accounts in appealed state',
-  },
-  accountReviewEscalated: {
-    label: 'Accounts in escalated state',
-  },
-  accountTakendown: {
-    label: 'Accounts that have been taken down',
-  },
-  accountDeactivated: {
-    label: 'Deactivated accounts',
-  },
-  accountEmailUnConfirmed: {
-    label: 'Accounts that have not confirmed their email address',
-  },
+  { field: 'emailConfirmed', operator: 'eq', text: 'Email Confirmed' },
+  { field: 'emailConfirmed', operator: 'neq', text: 'Email Not Confirmed' },
+  { field: 'displayName', operator: 'ilike', text: 'Display Name' },
+  { field: 'description', operator: 'ilike', text: 'Profile Description' },
+  { field: 'content', operator: 'ilike', text: 'Record Content' },
+]
+const booleanFields = ['emailConfirmed', 'accountDeactivated', 'takendown']
+const isBooleanFilter = (field: string) => booleanFields.includes(field)
+const durationFields = ['accountAge']
+const isDurationFilter = (field: string) => durationFields.includes(field)
+
+export function FilterSelector({ groupId }: { groupId: number }) {
+  const { addFilter, filterGroup } = useFilter()
+  const [selected, setSelected] = useState(availableFilters[0])
+  const needsUnitField = isDurationFilter(selected.field)
+  const [value, setValue] = useState<string | number | boolean>('')
+  const [unit, setUnit] = useState<string>(selected.unit || '')
+
+  const handleAddFilter = () => {
+    // TODO: Use better validation here
+    if (value === undefined) return
+
+    let newFilter: WorkspaceFilterItem
+
+    if (selected.field === 'accountAge') {
+      newFilter = {
+        field: selected.field,
+        operator: selected.operator as 'gte' | 'lte', // Ensure valid operator
+        unit: unit as DurationUnit, // Unit is required here
+        value: Number(value), // Ensure value is a number
+      }
+    } else {
+      newFilter = {
+        field: selected.field,
+        operator: selected.operator,
+        value:
+          typeof value === 'string' && selected.operator === 'ilike'
+            ? value.trim()
+            : value, // Trim for string searches
+      } as WorkspaceFilterItem
+    }
+
+    addFilter(groupId, newFilter)
+    setValue('')
+  }
+
+  const group = filterGroup[groupId]
+  const availableOptions = availableFilters.filter(
+    (f) =>
+      !group?.filters.some(
+        (existing) =>
+          existing.operator === f.operator && existing.field === f.field,
+      ),
+  )
+
+  return (
+    <div className="flex gap-2 py-1">
+      <Dropdown
+        className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-2 py-1 text-xs text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+        items={availableOptions.map((f) => ({
+          text: f.text,
+          id: f.text,
+          onClick: () => {
+            setSelected(f)
+            if (isDurationFilter(f.field)) {
+              setUnit(f.unit || 'days')
+            }
+          },
+        }))}
+      >
+        {selected.text}
+        <ChevronDownIcon
+          className="ml-1 h-4 w-4 text-violet-200 hover:text-violet-100"
+          aria-hidden="true"
+        />
+      </Dropdown>
+      {!isBooleanFilter(selected.field) && (
+        <Input
+          className="text-xs py-0.5"
+          type="text" // Checkbox for boolean fields
+          value={`${value}`} // Ensure only string/number go in text input
+          onChange={(e) => setValue(e.target.value)}
+        />
+      )}
+      {needsUnitField && (
+        <Dropdown
+          className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-2 py-1 text-xs text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+          items={['days', 'weeks', 'months', 'years'].map((unit) => ({
+            text: unit,
+            id: unit,
+            onClick: () => {
+              setUnit(unit)
+            },
+          }))}
+        >
+          <span className="capitalize">{unit}</span>
+          <ChevronDownIcon
+            className="ml-1 h-4 w-4 text-violet-200 hover:text-violet-100"
+            aria-hidden="true"
+          />
+        </Dropdown>
+      )}
+      <ActionButton
+        size="xs"
+        type="button"
+        appearance="outlined"
+        onClick={handleAddFilter}
+        className="text-white bg-blue-600 rounded"
+      >
+        <PlusIcon className="h-3 w-3 mr-1" />
+        <span className="text-xs">Add</span>
+      </ActionButton>
+    </div>
+  )
 }
 
-const ContentFilterOptions = {
-  contentReviewOpen: { label: 'Content in unresolved review state' },
-  contentReviewAppealed: { label: 'Content in appealed state' },
-  contentReviewEscalated: { label: 'Content in escalated state' },
-  contentTakendown: { label: 'Content that have been taken down' },
-  contentAuthorDeactivated: { label: 'Content from deactivated accounts' },
-  contentWithImageEmbed: { label: 'Content with image embed' },
-  contentWithVideoEmbed: { label: 'Content with video embed' },
+export function FilterGroupComponent() {
+  const { filterGroup, addGroup, removeGroup, removeFilter } = useFilter()
+
+  return (
+    <div>
+      {filterGroup.map((group, groupId) => (
+        <div key={groupId} className="my-2">
+          <div className="p-2 mb-2 border dark:border-teal-700 rounded">
+            <div className="flex flex-row justify-between">
+              <h4 className="font-semibold">
+                {group.operator && `${group.operator} `}Group: {groupId + 1}
+              </h4>
+
+              {groupId > 0 && (
+                <ActionButton
+                  appearance="outlined"
+                  size="xs"
+                  type="button"
+                  onClick={() => removeGroup(groupId)}
+                >
+                  <TrashIcon className="h-3 w-3" />
+                </ActionButton>
+              )}
+            </div>
+
+            {group.filters.map((filter) => (
+              <div
+                key={`${filter.field}-${filter.operator}`}
+                className="flex items-center gap-2 py-0.5"
+              >
+                {filter.field} {filter.operator} {filter.value}
+                <button
+                  onClick={() =>
+                    removeFilter(groupId, filter.field, filter.operator)
+                  }
+                  className="text-red-600"
+                  type="button"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+
+            <FilterSelector groupId={groupId} />
+          </div>
+          <ButtonGroup
+            size="xs"
+            appearance="primary"
+            leftAligned
+            items={[
+              {
+                id: 'and',
+                text: 'AND Group',
+                isActive: false,
+                onClick: () => addGroup('AND'),
+              },
+              {
+                id: 'or',
+                text: 'OR Group',
+                isActive: false,
+                onClick: () => addGroup('OR'),
+              },
+            ]}
+          />
+        </div>
+      ))}
+    </div>
+  )
 }
 
-const matchKeyword = (keyword?: string, subject?: string) => {
-  if (!keyword || !subject) return false
-  const keywords = keyword.split('||')
-  return keywords.some((k) =>
-    subject.toLowerCase().includes(k.trim().toLowerCase()),
+const ActionRow = () => {
+  const { toggleFilteredItems, unselectAll, selectAll } = useFilter()
+  return (
+    <div className="flex flex-row mt-2 gap-2">
+      <ActionButton
+        size="xs"
+        appearance="outlined"
+        onClick={() => {
+          toggleFilteredItems(true)
+        }}
+      >
+        <span className="text-xs">Select Filtered</span>
+      </ActionButton>
+      <ActionButton
+        size="xs"
+        appearance="outlined"
+        onClick={() => {
+          toggleFilteredItems(false)
+        }}
+      >
+        <span className="text-xs">Unselect Filtered</span>
+      </ActionButton>
+      <ActionButton
+        size="xs"
+        appearance="outlined"
+        onClick={() => {
+          unselectAll()
+        }}
+      >
+        <span className="text-xs">Unselect All</span>
+      </ActionButton>
+      <ActionButton
+        size="xs"
+        appearance="outlined"
+        onClick={() => {
+          selectAll()
+        }}
+      >
+        <span className="text-xs">Select All</span>
+      </ActionButton>
+    </div>
   )
 }
 
@@ -80,114 +284,6 @@ export const WorkspaceFilterSelector = ({
 }: {
   listData: WorkspaceListData | undefined
 }) => {
-  const [filters, setFilters] = useState({
-    accountReviewOpen: false,
-    accountReviewAppealed: false,
-    accountReviewEscalated: false,
-    accountTakendown: false,
-    accountDeactivated: false,
-    accountEmailUnConfirmed: false,
-    contentReviewOpen: false,
-    contentReviewAppealed: false,
-    contentReviewEscalated: false,
-    contentTakendown: false,
-    contentAuthorDeactivated: false,
-    contentWithImageEmbed: false,
-    contentWithVideoEmbed: false,
-    keyword: '',
-    minAccountAge: '',
-    minAccountAgeUnit: 'days',
-  })
-
-  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, checked } = e.target
-    const newFilters = { ...filters }
-    if (!filters[name]) {
-      newFilters[name] = checked
-    } else {
-      delete newFilters[name]
-    }
-    setFilters(newFilters)
-  }
-
-  const selectAll = () => {
-    if (!listData) return
-    Object.keys(listData).forEach((uri) => {
-      toggleItemCheck(uri)
-    })
-  }
-
-  const unselectAll = () => {
-    if (!listData) return
-    Object.keys(listData).forEach((uri) => {
-      toggleItemCheck(uri, false)
-    })
-  }
-
-  const toggleFilteredItems = (select: boolean = true) => {
-    if (!listData) return
-    Object.entries(listData).forEach(([uri, item]) => {
-      const subjectStatus = getSubjectStatusFromItemData(item)
-      if (uri.startsWith('did:')) {
-        const isRepo = ToolsOzoneModerationDefs.isRepoViewDetail(item)
-        const profile = isRepo
-          ? getProfileFromRepo(item.relatedRecords)
-          : undefined
-        if (
-          (filters.accountReviewOpen &&
-            subjectStatus?.reviewState ===
-              ToolsOzoneModerationDefs.REVIEWOPEN) ||
-          (filters.accountReviewAppealed && subjectStatus?.appealed) ||
-          (filters.accountReviewEscalated &&
-            subjectStatus?.reviewState ===
-              ToolsOzoneModerationDefs.REVIEWESCALATED) ||
-          (filters.accountTakendown && subjectStatus?.takendown) ||
-          (filters.accountEmailUnConfirmed &&
-            isRepo &&
-            !item.emailConfirmedAt) ||
-          (filters.accountDeactivated && isRepo && item.deactivatedAt) ||
-          (filters.keyword &&
-            isRepo &&
-            matchKeyword(filters.keyword, profile?.description)) ||
-          matchMinimumAccountAge(
-            filters.minAccountAgeUnit,
-            profile?.createdAt,
-            filters.minAccountAge ? Number(filters.minAccountAge) : 0,
-          )
-        ) {
-          toggleItemCheck(uri, select)
-        }
-      } else {
-        const isRecord = ToolsOzoneModerationDefs.isRecordViewDetail(item)
-        if (
-          (filters.contentReviewOpen &&
-            subjectStatus?.reviewState ===
-              ToolsOzoneModerationDefs.REVIEWOPEN) ||
-          (filters.contentReviewAppealed && subjectStatus?.appealed) ||
-          (filters.contentReviewEscalated &&
-            subjectStatus?.reviewState ===
-              ToolsOzoneModerationDefs.REVIEWESCALATED) ||
-          (filters.contentTakendown && subjectStatus?.takendown) ||
-          (filters.contentAuthorDeactivated &&
-            isRecord &&
-            item.repo.deactivatedAt) ||
-          (filters.contentWithImageEmbed &&
-            subjectStatus?.tags?.includes('embed:image')) ||
-          (filters.contentWithVideoEmbed &&
-            subjectStatus?.tags?.includes('embed:video')) ||
-          (filters.keyword &&
-            isRecord &&
-            matchKeyword(
-              filters.keyword,
-              item.value?.['text'] ? `${item.value?.['text']}` : undefined,
-            ))
-        ) {
-          toggleItemCheck(uri, select)
-        }
-      }
-    })
-  }
-
   return (
     <Popover className="relative z-30">
       {({ open }) => (
@@ -214,182 +310,16 @@ export const WorkspaceFilterSelector = ({
             leaveTo="transform scale-95 opacity-0"
           >
             <Popover.Panel className="absolute left-0 z-30 mt-1 flex w-screen max-w-max -translate-x-1/5 px-4">
-              <div className="w-fit-content flex-auto rounded bg-white dark:bg-slate-800 p-4 text-sm leading-6 shadow-lg dark:shadow-slate-900 ring-1 ring-gray-900/5">
-                <div className="flex flex-col md:flex-row md:gap-4">
-                  <div>
-                    <h3 className="font-semibold text-gray-800 dark:text-gray-200 mb-2">
-                      Account filter
-                    </h3>
-
-                    {Object.entries(AccountFilterOptions).map(
-                      ([key, checkbox]) => {
-                        return (
-                          <Checkbox
-                            key={key}
-                            value="true"
-                            id={key}
-                            name={key}
-                            className="mb-2 flex items-center"
-                            label={checkbox.label}
-                            onChange={handleFilterChange}
-                          />
-                        )
-                      },
-                    )}
-                  </div>
-                  <div>
-                    <h3 className="font-semibold text-gray-800 dark:text-gray-200 mt-4 mb-2 md:mt-0">
-                      Content filter
-                    </h3>
-
-                    {Object.entries(ContentFilterOptions).map(
-                      ([key, checkbox]) => {
-                        return (
-                          <Checkbox
-                            key={key}
-                            value="true"
-                            id={key}
-                            name={key}
-                            className="mb-2 flex items-center"
-                            label={checkbox.label}
-                            onChange={handleFilterChange}
-                          />
-                        )
-                      },
-                    )}
-                  </div>
+              <FilterProvider listData={listData}>
+                <div className="w-fit-content flex-auto rounded bg-white dark:bg-slate-800 p-4 text-sm leading-6 shadow-lg dark:shadow-slate-900 ring-1 ring-gray-900/5">
+                  <FilterGroupComponent />
+                  <p className="py-2 block max-w-lg text-gray-500 dark:text-gray-300 text-xs">
+                    Account age is computed using profile creation date. Some
+                    bots and accounts may not have this set.
+                  </p>
+                  <ActionRow />
                 </div>
-                <div className="mb-2">
-                  <FormLabel
-                    label="Keyword"
-                    htmlFor="keyword"
-                    className="flex-1"
-                  >
-                    <Input
-                      type="text"
-                      id="keyword"
-                      name="keyword"
-                      required
-                      list="subject-suggestions"
-                      placeholder="Keyword"
-                      className="block w-full"
-                      value={filters.keyword}
-                      onChange={(ev) =>
-                        setFilters({ ...filters, keyword: ev.target.value })
-                      }
-                      autoComplete="off"
-                    />
-                  </FormLabel>
-                </div>
-                <p className="py-2 block max-w-lg text-gray-500 dark:text-gray-300 text-xs">
-                  You can use {'||'} separator in the keyword filter to look for
-                  multiple keywords in either {"user's"} profile bio or record
-                  content
-                </p>
-                <div className="mb-2">
-                  <FormLabel
-                    label="Min. account age"
-                    htmlFor="minAccountAge"
-                    className="flex-1"
-                  >
-                    <div className="flex flex-row gap-2">
-                      <Input
-                        type="number"
-                        id="minAccountAge"
-                        name="minAccountAge"
-                        className="block"
-                        value={filters.minAccountAge}
-                        onChange={(ev) =>
-                          setFilters({
-                            ...filters,
-                            minAccountAge: ev.target.value,
-                          })
-                        }
-                        autoComplete="off"
-                      />
-                      <Dropdown
-                        className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
-                        items={[
-                          {
-                            id: 'days',
-                            text: 'days',
-                            onClick: () =>
-                              setFilters({
-                                ...filters,
-                                minAccountAgeUnit: 'days',
-                              }),
-                          },
-                          {
-                            id: 'hours',
-                            text: 'hours',
-                            onClick: () =>
-                              setFilters({
-                                ...filters,
-                                minAccountAgeUnit: 'hours',
-                              }),
-                          },
-                        ]}
-                      >
-                        {filters.minAccountAgeUnit}
-                        <ChevronDownIcon
-                          className="ml-2 -mr-1 h-5 w-5 text-violet-200 hover:text-violet-100"
-                          aria-hidden="true"
-                        />
-                      </Dropdown>
-                    </div>
-                  </FormLabel>
-                </div>
-                <p className="py-2 block max-w-lg text-gray-500 dark:text-gray-300 text-xs">
-                  Account age is computed using profile creation date. Some bots
-                  and accounts may not have this set.
-                </p>
-                <p className="py-2 block max-w-lg text-gray-500 dark:text-gray-300 text-xs border-t border-gray-700">
-                  You can select or unselect all items that matches the above
-                  configured filters. The configured filters work with OR
-                  operator. <br />
-                  So, if you select {'"Deactivated accounts"'} and
-                  {'"Accounts in appealed state"'}, all accounts that are either
-                  deactivated OR in appealed state will be selected. <br />
-                </p>
-                <div className="flex flex-row mt-2 gap-2">
-                  <ActionButton
-                    size="xs"
-                    appearance="outlined"
-                    onClick={() => {
-                      toggleFilteredItems()
-                    }}
-                  >
-                    <span className="text-xs">Select Filtered</span>
-                  </ActionButton>
-                  <ActionButton
-                    size="xs"
-                    appearance="outlined"
-                    onClick={() => {
-                      toggleFilteredItems(false)
-                    }}
-                  >
-                    <span className="text-xs">Unselect Filtered</span>
-                  </ActionButton>
-                  <ActionButton
-                    size="xs"
-                    appearance="outlined"
-                    onClick={() => {
-                      unselectAll()
-                    }}
-                  >
-                    <span className="text-xs">Unselect All</span>
-                  </ActionButton>
-                  <ActionButton
-                    size="xs"
-                    appearance="outlined"
-                    onClick={() => {
-                      selectAll()
-                    }}
-                  >
-                    <span className="text-xs">Select All</span>
-                  </ActionButton>
-                </div>
-              </div>
+              </FilterProvider>
             </Popover.Panel>
           </Transition>
         </>

--- a/components/workspace/FilterSelector.tsx
+++ b/components/workspace/FilterSelector.tsx
@@ -1,32 +1,16 @@
 import { Popover, Transition } from '@headlessui/react'
-import { ActionButton, ButtonGroup } from '@/common/buttons'
+import { ActionButton } from '@/common/buttons'
 import { CheckIcon } from '@heroicons/react/24/outline'
 import { Input } from '@/common/forms'
 import { useState } from 'react'
 
 import { FilterProvider, useFilter } from './FilterContext'
 import { WorkspaceListData } from './useWorkspaceListData'
-import { differenceInDays, differenceInHours } from 'date-fns'
 import { DurationUnit, WorkspaceFilterItem } from './types'
 import { Dropdown } from '@/common/Dropdown'
 import { ChevronDownIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid'
 import { FilterView } from './FilterView'
-
-const matchMinimumAccountAge = (
-  minAccountAgeUnit: string,
-  profileCreatedAt?: string,
-  minAccountAge?: number,
-) => {
-  if (!profileCreatedAt || !minAccountAge) return false
-  const createdAt = new Date(profileCreatedAt)
-  const now = new Date()
-  const diff =
-    minAccountAgeUnit === 'days'
-      ? differenceInDays(now, createdAt)
-      : differenceInHours(now, createdAt)
-
-  return diff >= minAccountAge
-}
+import { reviewStateToText } from '@/subject/ReviewStateMarker'
 
 const availableFilters: (Omit<WorkspaceFilterItem, 'value'> &
   Partial<{ unit: DurationUnit }> & {
@@ -53,6 +37,8 @@ const availableFilters: (Omit<WorkspaceFilterItem, 'value'> &
   { field: 'displayName', operator: 'ilike', text: 'Display Name' },
   { field: 'description', operator: 'ilike', text: 'Profile Description' },
   { field: 'content', operator: 'ilike', text: 'Record Content' },
+  { field: 'reviewState', operator: 'eq', text: 'In Review State' },
+  { field: 'reviewState', operator: 'neq', text: 'Not In Review State' },
 ]
 const booleanFields = ['emailConfirmed', 'accountDeactivated', 'takendown']
 const isBooleanFilter = (field: string) => booleanFields.includes(field)
@@ -134,13 +120,29 @@ export function FilterSelector({ groupId }: { groupId: number }) {
           aria-hidden="true"
         />
       </Dropdown>
-      {!isBooleanFilter(selected.field) && (
+      {!isBooleanFilter(selected.field) && selected.field !== 'reviewState' && (
         <Input
           className="text-xs py-0.5"
           type="text" // Checkbox for boolean fields
           value={`${value}`} // Ensure only string/number go in text input
           onChange={(e) => setValue(e.target.value)}
         />
+      )}
+      {selected.field === 'reviewState' && (
+        <Dropdown
+          className="inline-flex justify-center rounded-md border border-gray-300 dark:border-teal-500 bg-white dark:bg-slate-800 dark:text-gray-100 dark:focus:border-teal-500  dark px-2 py-1 text-xs text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+          items={Object.entries(reviewStateToText).map(([value, text]) => ({
+            text,
+            id: value,
+            onClick: () => setValue(value),
+          }))}
+        >
+          {value ? reviewStateToText[`${value}`] : 'Select Review State'}
+          <ChevronDownIcon
+            className="ml-1 h-4 w-4 text-violet-200 hover:text-violet-100"
+            aria-hidden="true"
+          />
+        </Dropdown>
       )}
       {needsUnitField && (
         <Dropdown

--- a/components/workspace/FilterSelector.tsx
+++ b/components/workspace/FilterSelector.tsx
@@ -34,11 +34,14 @@ const availableFilters: (Omit<WorkspaceFilterItem, 'value'> &
   },
   { field: 'emailConfirmed', operator: 'eq', text: 'Email Confirmed' },
   { field: 'emailConfirmed', operator: 'neq', text: 'Email Not Confirmed' },
+  { field: 'emailContains', operator: 'ilike', text: 'Email Contains' },
   { field: 'displayName', operator: 'ilike', text: 'Display Name' },
   { field: 'description', operator: 'ilike', text: 'Profile Description' },
   { field: 'content', operator: 'ilike', text: 'Record Content' },
   { field: 'reviewState', operator: 'eq', text: 'In Review State' },
   { field: 'reviewState', operator: 'neq', text: 'Not In Review State' },
+  { field: 'takendown', operator: 'eq', text: 'Is Takendown' },
+  { field: 'takendown', operator: 'neq', text: 'Not Takendown' },
 ]
 const booleanFields = ['emailConfirmed', 'accountDeactivated', 'takendown']
 const isBooleanFilter = (field: string) => booleanFields.includes(field)

--- a/components/workspace/FilterView.tsx
+++ b/components/workspace/FilterView.tsx
@@ -9,6 +9,16 @@ export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
       </div>
     )
   }
+  if (filter.field === 'emailContains') {
+    return (
+      <div>
+        {filter.operator === 'ilike'
+          ? 'Email Contains'
+          : 'Email Does Not Contain'}{' '}
+        <span className="font-semibold">{filter.value}</span>
+      </div>
+    )
+  }
 
   if (filter.field === 'reviewState') {
     return (
@@ -16,6 +26,12 @@ export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
         {filter.operator === 'eq' ? 'In Review State' : 'Not In Review State'}{' '}
         <span className="font-semibold">{reviewStateToText[filter.value]}</span>
       </div>
+    )
+  }
+
+  if (filter.field === 'takendown') {
+    return (
+      <div>{filter.operator === 'eq' ? 'Is Takendown' : 'Not Takendown'} </div>
     )
   }
 

--- a/components/workspace/FilterView.tsx
+++ b/components/workspace/FilterView.tsx
@@ -1,3 +1,4 @@
+import { reviewStateToText } from '@/subject/ReviewStateMarker'
 import { WorkspaceFilterItem } from './types'
 
 export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
@@ -5,6 +6,15 @@ export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
     return (
       <div>
         {filter.operator === 'eq' ? 'Email Confirmed' : 'Email Not Confirmed'}
+      </div>
+    )
+  }
+
+  if (filter.field === 'reviewState') {
+    return (
+      <div>
+        {filter.operator === 'eq' ? 'In Review State' : 'Not In Review State'}{' '}
+        <span className="font-semibold">{reviewStateToText[filter.value]}</span>
       </div>
     )
   }

--- a/components/workspace/FilterView.tsx
+++ b/components/workspace/FilterView.tsx
@@ -1,0 +1,75 @@
+import { WorkspaceFilterItem } from './types'
+
+export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
+  if (filter.field === 'emailConfirmed') {
+    return (
+      <div>
+        {filter.operator === 'eq' ? 'Email Confirmed' : 'Email Not Confirmed'}
+      </div>
+    )
+  }
+
+  if (filter.field === 'accountAge') {
+    return (
+      <div>
+        {filter.operator === 'gte' ? 'Min.' : 'Max.'} Account Age{' '}
+        <span className="font-semibold">
+          {filter.value} {filter.unit}
+        </span>
+      </div>
+    )
+  }
+
+  if (filter.field === 'followersCount' || filter.field === 'followsCount') {
+    return (
+      <div>
+        {filter.operator === 'gte' ? 'Min.' : 'Max.'}{' '}
+        {filter.field === 'followersCount' ? 'Follower' : 'Follow'} Count{' '}
+        <span className="font-semibold">{filter.value}</span>
+      </div>
+    )
+  }
+
+  if (filter.field === 'displayName') {
+    return (
+      <div>
+        Profile display name contains{' '}
+        <span className="font-semibold">{filter.value}</span>
+        <br />
+        <span className="text-xs dark:text-gray-300">
+          This filter is case-insensitive
+        </span>
+      </div>
+    )
+  }
+
+  if (filter.field === 'content') {
+    return (
+      <div>
+        Record content contains{' '}
+        <span className="font-semibold">{filter.value}</span>
+        <br />
+        <span className="text-xs dark:text-gray-300">
+          This filter is case-insensitive
+        </span>
+      </div>
+    )
+  }
+
+  if (filter.field === 'description') {
+    return (
+      <div>
+        Profile description contains{' '}
+        <span className="font-semibold">{filter.value}</span>
+        <br />
+        <span className="text-sm">This filter is case-insensitive</span>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {filter.field} {filter.operator} {filter.value}
+    </div>
+  )
+}

--- a/components/workspace/List.tsx
+++ b/components/workspace/List.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUpIcon,
   EnvelopeIcon,
   LockClosedIcon,
+  StarIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid'
 
@@ -19,6 +20,7 @@ import { WorkspaceListData } from './useWorkspaceListData'
 import { SubjectTag } from 'components/tags/SubjectTag'
 import { ModerationLabel } from '@/common/labels'
 import { WorkspaceExportPanel } from './ExportPanel'
+import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
 
 interface WorkspaceListProps {
   list: string[]
@@ -218,10 +220,18 @@ const ListItem = <ItemType extends string>({
                 omitQueryParamsInLinks={['workspaceOpen']}
                 subjectRepoHandle={itemData.repo?.handle}
               />
+              {itemData.profile?.followersCount &&
+                itemData.profile.followersCount > 1 && (
+                  <StarIcon
+                    className="w-4 h-4 ml-1 text-orange-300"
+                    title={`High profile user with ${itemData.profile.followersCount} followers`}
+                  />
+                )}
               {itemData.status && (
                 <ReviewStateIcon
                   subjectStatus={itemData.status}
                   className="ml-1"
+                  size="sm"
                 />
               )}
               {!!itemData.repo?.deactivatedAt && (

--- a/components/workspace/List.tsx
+++ b/components/workspace/List.tsx
@@ -221,7 +221,8 @@ const ListItem = <ItemType extends string>({
                 subjectRepoHandle={itemData.repo?.handle}
               />
               {itemData.profile?.followersCount &&
-                itemData.profile.followersCount > 1 && (
+                itemData.profile.followersCount >
+                  HIGH_PROFILE_FOLLOWER_THRESHOLD && (
                   <StarIcon
                     className="w-4 h-4 ml-1 text-orange-300"
                     title={`High profile user with ${itemData.profile.followersCount} followers`}

--- a/components/workspace/List.tsx
+++ b/components/workspace/List.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react'
-import { ToolsOzoneModerationDefs } from '@atproto/api'
+import { AppBskyActorDefs, ToolsOzoneModerationDefs } from '@atproto/api'
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -21,6 +21,7 @@ import { SubjectTag } from 'components/tags/SubjectTag'
 import { ModerationLabel } from '@/common/labels'
 import { WorkspaceExportPanel } from './ExportPanel'
 import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
+import { isValidProfileViewDetailed } from '@/repositories/helpers'
 
 interface WorkspaceListProps {
   list: string[]
@@ -188,9 +189,7 @@ const ListItem = <ItemType extends string>({
     : []
 
   const isSubjectRecord = item.startsWith('at://')
-  const displayTags = isSubjectRecord
-    ? itemData?.record?.moderation.subjectStatus?.tags
-    : itemData?.repo?.moderation.subjectStatus?.tags
+  const displayTags = itemData?.status?.tags
   const displayLabels = isSubjectRecord
     ? itemData?.record?.labels
     : itemData?.repo?.labels
@@ -220,8 +219,8 @@ const ListItem = <ItemType extends string>({
                 omitQueryParamsInLinks={['workspaceOpen']}
                 subjectRepoHandle={itemData.repo?.handle}
               />
-              {itemData.profile?.followersCount &&
-                itemData.profile.followersCount >
+              {isValidProfileViewDetailed(itemData.profile) &&
+                (itemData.profile.followersCount || 0) >
                   HIGH_PROFILE_FOLLOWER_THRESHOLD && (
                   <StarIcon
                     className="w-4 h-4 ml-1 text-orange-300"

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -20,7 +20,7 @@ import { Dialog } from '@headlessui/react'
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
 import { CheckCircleIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
-import { createRef, FormEvent, useRef, useState } from 'react'
+import { createRef, FormEvent, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import { WORKSPACE_FORM_ID } from './constants'
 import {
@@ -37,7 +37,9 @@ import { useWorkspaceListData } from './useWorkspaceListData'
 import { isNonNullable, isValidDid } from '@/lib/util'
 import { EmailComposerData } from 'components/email/helpers'
 import { Alert } from '@/common/Alert'
-import { isSubjectStatusView } from './utils'
+import { findHighProfileCountInWorkspace, isSubjectStatusView } from './utils'
+import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
+import { numberFormatter } from '@/repositories/HighProfileWarning'
 
 export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
   const { onClose, ...others } = props
@@ -297,6 +299,14 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
     }
   }
 
+  const highProfileAccountCount = useMemo(
+    () =>
+      workspaceListStatuses
+        ? findHighProfileCountInWorkspace(workspaceListStatuses)
+        : 0,
+    [workspaceListStatuses],
+  )
+
   return (
     <FullScreenActionPanel
       title={
@@ -374,6 +384,17 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                           type="error"
                           body={submission.error}
                           title="Error submitting bulk action"
+                        />
+                      </div>
+                    )}
+                    {highProfileAccountCount > 0 && (
+                      <div className="mb-3">
+                        <Alert
+                          type="warning"
+                          title="High profile account in workspace"
+                          body={`There are ${highProfileAccountCount} accounts in your workspace with ${numberFormatter.format(
+                            HIGH_PROFILE_FOLLOWER_THRESHOLD,
+                          )} followers. Please take caution when including those accounts in bulk action.`}
                         />
                       </div>
                     )}

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -37,7 +37,7 @@ import { useWorkspaceListData } from './useWorkspaceListData'
 import { isNonNullable, isValidDid } from '@/lib/util'
 import { EmailComposerData } from 'components/email/helpers'
 import { Alert } from '@/common/Alert'
-import { findHighProfileCountInWorkspace, isSubjectStatusView } from './utils'
+import { findHighProfileCountInWorkspace } from './utils'
 import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
 import { numberFormatter } from '@/repositories/HighProfileWarning'
 
@@ -111,14 +111,14 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
             .map((item) => {
               if (item.startsWith('did:')) return item
 
-              const status = workspaceListStatuses?.[item]
+              const itemData = workspaceListStatuses?.[item]
 
-              if (status?.repo?.did) {
-                return status.repo.did
+              if (itemData?.repo?.did) {
+                return itemData.repo.did
               }
 
-              if (status?.subjectStatus) {
-                const { subject } = status.subjectStatus
+              if (itemData?.status) {
+                const { subject } = itemData.status
                 if (ComAtprotoAdminDefs.isRepoRef(subject)) {
                   return subject.did
                 }

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -34,7 +34,7 @@ import WorkspaceList from './List'
 import { WorkspacePanelActionForm } from './PanelActionForm'
 import { WorkspacePanelActions } from './PanelActions'
 import { useWorkspaceListData } from './useWorkspaceListData'
-import { isNonNullable, isValidDid } from '@/lib/util'
+import { isNonNullable, isValidDid, pluralize } from '@/lib/util'
 import { EmailComposerData } from 'components/email/helpers'
 import { Alert } from '@/common/Alert'
 import { findHighProfileCountInWorkspace } from './utils'
@@ -392,7 +392,10 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                         <Alert
                           type="warning"
                           title="High profile account in workspace"
-                          body={`There are ${highProfileAccountCount} accounts in your workspace with ${numberFormatter.format(
+                          body={`There are ${pluralize(
+                            highProfileAccountCount,
+                            'account',
+                          )} in your workspace with ${numberFormatter.format(
                             HIGH_PROFILE_FOLLOWER_THRESHOLD,
                           )} followers. Please take caution when including those accounts in bulk action.`}
                         />

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -111,16 +111,12 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
 
               const status = workspaceListStatuses?.[item]
 
-              if (ToolsOzoneModerationDefs.isRepoViewDetail(status)) {
-                return status.did
-              }
-
-              if (ToolsOzoneModerationDefs.isRecordViewDetail(status)) {
+              if (status?.repo?.did) {
                 return status.repo.did
               }
 
-              if (status && isSubjectStatusView(status)) {
-                const { subject } = status
+              if (status?.subjectStatus) {
+                const { subject } = status.subjectStatus
                 if (ComAtprotoAdminDefs.isRepoRef(subject)) {
                   return subject.did
                 }

--- a/components/workspace/hooks.tsx
+++ b/components/workspace/hooks.tsx
@@ -136,8 +136,6 @@ const ifString = (val: unknown): string | undefined =>
 const getExportFieldsFromWorkspaceListItem = (
   item: ToolsOzoneModerationDefs.SubjectView,
 ) => {
-  const isRecord = ToolsOzoneModerationDefs.isRecordViewDetail(item)
-
   if (item.repo) {
     const { repo } = item
     const profile = getProfileFromRepo(repo.relatedRecords)

--- a/components/workspace/hooks.tsx
+++ b/components/workspace/hooks.tsx
@@ -8,7 +8,6 @@ import { getLocalStorageData, setLocalStorageData } from '@/lib/local-storage'
 import { buildBlueSkyAppUrl, isNonNullable, pluralize } from '@/lib/util'
 import { useServerConfig } from '@/shell/ConfigurationContext'
 import {
-  AppBskyActorProfile,
   AtUri,
   ComAtprotoAdminDefs,
   ComAtprotoRepoStrongRef,
@@ -18,12 +17,8 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'react'
 import { toast } from 'react-toastify'
-import {
-  WorkspaceListData,
-  WorkspaceListItemData,
-} from './useWorkspaceListData'
+import { WorkspaceListData } from './useWorkspaceListData'
 import { getProfileFromRepo } from '@/repositories/helpers'
-import { isSubjectStatusView } from './utils'
 
 const WORKSPACE_LIST_KEY = 'workspace_list'
 const WORKSPACE_LIST_DELIMITER = ','

--- a/components/workspace/types.ts
+++ b/components/workspace/types.ts
@@ -1,18 +1,20 @@
+export type DurationUnit = 'days' | 'weeks' | 'months' | 'years'
+
 export type WorkspaceFilterItem =
   | {
-      field: 'followerCount'
+      field: 'followersCount'
       operator: 'gte' | 'lte'
       value: number
     }
   | {
-      field: 'followCount'
+      field: 'followsCount'
       operator: 'gte' | 'lte'
       value: number
     }
   | {
       field: 'accountAge'
       operator: 'gte' | 'lte'
-      unit: 'days' | 'weeks' | 'months' | 'years'
+      unit: DurationUnit
       value: number
     }
   | {
@@ -41,14 +43,10 @@ export type WorkspaceFilterItem =
       value: string
     }
   | {
-      field: 'accountCreated'
-      operator: 'gte' | 'lte'
-      value: string
-    }
-  | {
       field: 'recordCreated'
       operator: 'gte' | 'lte'
-      value: string
+      unit: DurationUnit
+      value: number
     }
   | {
       field: 'imageEmbed'

--- a/components/workspace/types.ts
+++ b/components/workspace/types.ts
@@ -1,0 +1,79 @@
+export type WorkspaceFilterItem =
+  | {
+      field: 'followerCount'
+      operator: 'gte' | 'lte'
+      value: number
+    }
+  | {
+      field: 'followCount'
+      operator: 'gte' | 'lte'
+      value: number
+    }
+  | {
+      field: 'accountAge'
+      operator: 'gte' | 'lte'
+      unit: 'days' | 'weeks' | 'months' | 'years'
+      value: number
+    }
+  | {
+      field: 'accountDeactivated'
+      operator: 'eq' | 'neq'
+      value: boolean
+    }
+  | {
+      field: 'takendown'
+      operator: 'eq' | 'neq'
+      value: boolean
+    }
+  | {
+      field: 'emailConfirmed'
+      operator: 'eq' | 'neq'
+      value: boolean
+    }
+  | {
+      field: 'displayName'
+      operator: 'ilike'
+      value: string
+    }
+  | {
+      field: 'description'
+      operator: 'ilike'
+      value: string
+    }
+  | {
+      field: 'accountCreated'
+      operator: 'gte' | 'lte'
+      value: string
+    }
+  | {
+      field: 'recordCreated'
+      operator: 'gte' | 'lte'
+      value: string
+    }
+  | {
+      field: 'imageEmbed'
+      operator: 'eq' | 'neq'
+      value: boolean
+    }
+  | {
+      field: 'videoEmbed'
+      operator: 'eq' | 'neq'
+      value: boolean
+    }
+  | {
+      field: 'content'
+      operator: 'ilike'
+      value: string
+    }
+  | {
+      field: 'reviewState'
+      operator: 'eq' | 'neq'
+      value: string
+    }
+
+export type FilterOperator = 'AND' | 'OR'
+
+export type FilterGroup = {
+  operator?: FilterOperator
+  filters: WorkspaceFilterItem[]
+}

--- a/components/workspace/types.ts
+++ b/components/workspace/types.ts
@@ -33,6 +33,11 @@ export type WorkspaceFilterItem =
       value: boolean
     }
   | {
+      field: 'emailContains'
+      operator: 'ilike'
+      value: string
+    }
+  | {
       field: 'displayName'
       operator: 'ilike'
       value: string

--- a/components/workspace/useWorkspaceListData.tsx
+++ b/components/workspace/useWorkspaceListData.tsx
@@ -1,16 +1,12 @@
-import { chunkArray } from '@/lib/util'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { ToolsOzoneModerationDefs } from '@atproto/api'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'react-toastify'
 
-// Technically, we could allow RepoViewNotFound and RecordViewNotFound but we don't show specific info for those cases anyways
-export type WorkspaceListItemData =
-  | ToolsOzoneModerationDefs.RepoViewDetail
-  | ToolsOzoneModerationDefs.RecordViewDetail
-  | ToolsOzoneModerationDefs.SubjectStatusView
-
-export type WorkspaceListData = Record<string, WorkspaceListItemData>
+export type WorkspaceListData = Record<
+  string,
+  ToolsOzoneModerationDefs.SubjectView
+>
 
 export const useWorkspaceListData = ({
   subjects,
@@ -28,87 +24,28 @@ export const useWorkspaceListData = ({
     queryFn: async () => {
       const errorCount = { repos: 0, records: 0 }
       const dataBySubject: WorkspaceListData = {}
-      const repos: string[] = []
-      const records: string[] = []
-      const notFound: string[] = []
 
-      subjects.forEach((subject) => {
-        if (subject.startsWith('did:')) {
-          repos.push(subject)
-        } else {
-          records.push(subject)
-        }
-      })
-
-      const getRecords = chunkArray(records, 50).map(async (uris) => {
-        try {
-          const { data } = await labelerAgent.tools.ozone.moderation.getRecords(
-            {
-              uris,
-            },
-          )
-
-          data.records.forEach((record) => {
-            if (ToolsOzoneModerationDefs.isRecordViewDetail(record)) {
-              dataBySubject[record.uri] = record
-            } else if (ToolsOzoneModerationDefs.isRecordViewNotFound(record)) {
-              notFound.push(record.uri)
-            }
-          })
-        } catch (err) {
-          // if a batch fails to load, let's not fail the whole queue
-          // instead just show the error to the user
-          errorCount.records++
-        }
-      })
-
-      const getRepos = chunkArray(repos, 50).map(async (dids) => {
-        try {
-          const { data } = await labelerAgent.tools.ozone.moderation.getRepos({
-            dids,
-          })
-
-          data.repos.forEach((repo) => {
-            // If the repo is not found or any other type, we can assume it's just not found or non-existent
-            if (ToolsOzoneModerationDefs.isRepoViewDetail(repo)) {
-              dataBySubject[repo.did] = repo
-            } else if (ToolsOzoneModerationDefs.isRepoViewNotFound(repo)) {
-              notFound.push(repo.did)
-            }
-          })
-        } catch (err) {
-          // if a batch fails to load, let's not fail the whole queue
-          // instead just show the error to the user
-          errorCount.repos++
-        }
-      })
-
-      const getSubjectStatus = async (subject: string) => {
-        try {
-          const { data } =
-            await labelerAgent.tools.ozone.moderation.queryStatuses({
-              subject,
-              limit: 1,
-              includeMuted: true,
-            })
-
-          if (data.subjectStatuses?.length) {
-            dataBySubject[subject] = data.subjectStatuses[0]
-          }
-        } catch (err) {
-          // if a batch fails to load, let's not fail the whole queue
-          // instead just show the error to the user
-          errorCount.repos++
-        }
+      if (!subjects.length) {
+        return dataBySubject
       }
 
-      await Promise.all([...getRepos, ...getRecords])
-      // For items that we couldn't find record/repo for, there's a chance those are removed
-      // but they do have moderation history so we want to load subject status for those separately
-      // we can only load 1 subject at a time so chunking the entire not found set into buckets
-      // to ensure that we only ever fire 50 reqs at a time
-      for (const notFoundSubjects of chunkArray(notFound, 50)) {
-        await Promise.all(notFoundSubjects.map(getSubjectStatus))
+      const { data } = await labelerAgent.tools.ozone.moderation.getSubjects({
+        subjects,
+      })
+
+      for (const sub of data.subjects) {
+        dataBySubject[sub.subject] = sub
+      }
+
+      for (const sub of subjects) {
+        if (dataBySubject[sub]) {
+          continue
+        }
+        if (sub.startsWith('did:')) {
+          errorCount.repos++
+        } else {
+          errorCount.records++
+        }
       }
 
       if (errorCount.repos > 0 || errorCount.records > 0) {

--- a/components/workspace/utils.ts
+++ b/components/workspace/utils.ts
@@ -143,12 +143,16 @@ export const checkFilterMatchForWorkspaceItem = (
         filter.value,
         data.record?.value?.text ? `${data.record?.value?.text}` : undefined,
       )
+    case 'emailContains':
+      return matchText(filter.value, data.repo?.email)
     case 'reviewState':
       return filter.operator === 'eq'
         ? data.status?.reviewState === filter.value
         : data.status?.reviewState !== filter.value
     case 'takendown':
-      return !!data.status?.takendown
+      return filter.operator === 'eq'
+        ? !!data.status?.takendown
+        : !data.status?.takendown
     default:
       return false
   }
@@ -159,7 +163,8 @@ export const findHighProfileCountInWorkspace = (list: WorkspaceListData) => {
 
   for (const item of Object.values(list)) {
     if (
-      item.profile?.followersCount &&
+      isValidProfileViewDetailed(item.profile) &&
+      item.profile.followersCount &&
       item.profile.followersCount >= HIGH_PROFILE_FOLLOWER_THRESHOLD
     ) {
       total++

--- a/components/workspace/utils.ts
+++ b/components/workspace/utils.ts
@@ -141,7 +141,7 @@ export const checkFilterMatchForWorkspaceItem = (
     case 'content':
       return matchText(
         filter.value,
-        data.record?.value?.text ? `${data.record?.value?.text}` : undefined,
+        data.record?.value?.text ? `${data.record.value.text}` : undefined,
       )
     case 'emailContains':
       return matchText(filter.value, data.repo?.email)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "link:../atproto/packages/api/dist",
+    "@atproto/api": "0.14.13",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "^0.14.9",
+    "@atproto/api": "link:../atproto/packages/api/dist",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,19 +60,9 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@^0.14.9":
-  version "0.14.9"
-  resolved "https://registry.npmjs.org/@atproto/api/-/api-0.14.9.tgz#5a49b36348b11376a6b2a82316a90b8cf1784ca8"
-  integrity sha512-9S7Vl6gK8hmy0+Gw5AWriUsQfQYZxwW7yTK5UdPPGlmjvQP49YeSLrsxB1ZkTyrlLSG2tpYrGsN4vco6KOORAQ==
-  dependencies:
-    "@atproto/common-web" "^0.4.0"
-    "@atproto/lexicon" "^0.4.8"
-    "@atproto/syntax" "^0.3.4"
-    "@atproto/xrpc" "^0.6.10"
-    await-lock "^2.2.2"
-    multiformats "^9.9.0"
-    tlds "^1.234.0"
-    zod "^3.23.8"
+"@atproto/api@link:../atproto/packages/api/dist":
+  version "0.0.0"
+  uid ""
 
 "@atproto/common-web@^0.3.0":
   version "0.3.0"
@@ -83,16 +73,6 @@
     multiformats "^9.9.0"
     uint8arrays "3.0.0"
     zod "^3.21.4"
-
-"@atproto/common-web@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.0.tgz#b1407ae3f964f0ee23c2c3184f38041bac99d1f4"
-  integrity sha512-ZYL0P9myHybNgwh/hBY0HaBzqiLR1B5/ie5bJpLQAg0whRzNA28t8/nU2vh99tbsWcAF0LOD29M8++LyENJLNQ==
-  dependencies:
-    graphemer "^1.4.0"
-    multiformats "^9.9.0"
-    uint8arrays "3.0.0"
-    zod "^3.23.8"
 
 "@atproto/did@0.1.1":
   version "0.1.1"
@@ -132,17 +112,6 @@
   dependencies:
     "@atproto/common-web" "^0.3.0"
     "@atproto/syntax" "^0.3.0"
-    iso-datestring-validator "^2.2.2"
-    multiformats "^9.9.0"
-    zod "^3.23.8"
-
-"@atproto/lexicon@^0.4.8":
-  version "0.4.8"
-  resolved "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.8.tgz#389d09f14e190b0e607348613ec5ded586a7df47"
-  integrity sha512-NPhu4MNHqft4muvHvcU0BrkWoEpTI+OmbQzvZzzRpw54MW3PfrQ4TPEpAfPOrWugPB9y4mD+l8OMN1c9eOGWMQ==
-  dependencies:
-    "@atproto/common-web" "^0.4.0"
-    "@atproto/syntax" "^0.3.4"
     iso-datestring-validator "^2.2.2"
     multiformats "^9.9.0"
     zod "^3.23.8"
@@ -192,25 +161,12 @@
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.0.tgz#fafa2dbea9add37253005cb663e7373e05e618b3"
   integrity sha512-Weq0ZBxffGHDXHl9U7BQc2BFJi/e23AL+k+i5+D9hUq/bzT4yjGsrCejkjq0xt82xXDjmhhvQSZ0LqxyZ5woxA==
 
-"@atproto/syntax@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.4.tgz#28326c73f8dff010399145f5bd4ceeeb1ab206ba"
-  integrity sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg==
-
 "@atproto/xrpc@0.6.1", "@atproto/xrpc@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.1.tgz#dcd1315c8c60eef5af2db7fa4e35a38ebc6d79d5"
   integrity sha512-Zy5ydXEdk6sY7FDUZcEVfCL1jvbL4tXu5CcdPqbEaW6LQtk9GLds/DK1bCX9kswTGaBC88EMuqQMfkxOhp2t4A==
   dependencies:
     "@atproto/lexicon" "^0.4.1"
-    zod "^3.23.8"
-
-"@atproto/xrpc@^0.6.10":
-  version "0.6.10"
-  resolved "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.10.tgz#c3500e452ddbc792c2b6f39a905e25ecb1a049c6"
-  integrity sha512-ClMiO+oAl3KrFe7sdo8Wzw81yV7EpEradZLJnYilPq4s7uF0by1jHGI/LarHBKHnE5RpaFpBC/5XD/ZzgmvAeg==
-  dependencies:
-    "@atproto/lexicon" "^0.4.8"
     zod "^3.23.8"
 
 "@babel/runtime@^7.1.2":
@@ -984,11 +940,6 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
-
-await-lock@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
-  integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5373,11 +5324,6 @@ tiny-invariant@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
-
-tlds@^1.234.0:
-  version "1.255.0"
-  resolved "https://registry.npmjs.org/tlds/-/tlds-1.255.0.tgz#53c2571766c10da95928c716c48dfcf141341e3f"
-  integrity sha512-tcwMRIioTcF/FcxLev8MJWxCp+GUALRhFEqbDoZrnowmKSGqPrl5pqS+Sut2m8BgJ6S4FExCSSpGffZ0Tks6Aw==
 
 tldts-core@^6.1.66:
   version "6.1.66"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,9 +60,19 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@link:../atproto/packages/api/dist":
-  version "0.0.0"
-  uid ""
+"@atproto/api@0.14.13":
+  version "0.14.13"
+  resolved "https://registry.npmjs.org/@atproto/api/-/api-0.14.13.tgz#10ceccac0afa585481cf08cb48a93c2bca590847"
+  integrity sha512-bKzbzxvOMeIenGIOiRQ60gTnrTWHsceXvy19Ajmpqwbe/zvFEn+Y/wrayEDPT8Pbk7O8jgtLeRZotjOJF2+Gxg==
+  dependencies:
+    "@atproto/common-web" "^0.4.0"
+    "@atproto/lexicon" "^0.4.9"
+    "@atproto/syntax" "^0.4.0"
+    "@atproto/xrpc" "^0.6.11"
+    await-lock "^2.2.2"
+    multiformats "^9.9.0"
+    tlds "^1.234.0"
+    zod "^3.23.8"
 
 "@atproto/common-web@^0.3.0":
   version "0.3.0"
@@ -73,6 +83,16 @@
     multiformats "^9.9.0"
     uint8arrays "3.0.0"
     zod "^3.21.4"
+
+"@atproto/common-web@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.0.tgz#b1407ae3f964f0ee23c2c3184f38041bac99d1f4"
+  integrity sha512-ZYL0P9myHybNgwh/hBY0HaBzqiLR1B5/ie5bJpLQAg0whRzNA28t8/nU2vh99tbsWcAF0LOD29M8++LyENJLNQ==
+  dependencies:
+    graphemer "^1.4.0"
+    multiformats "^9.9.0"
+    uint8arrays "3.0.0"
+    zod "^3.23.8"
 
 "@atproto/did@0.1.1":
   version "0.1.1"
@@ -112,6 +132,17 @@
   dependencies:
     "@atproto/common-web" "^0.3.0"
     "@atproto/syntax" "^0.3.0"
+    iso-datestring-validator "^2.2.2"
+    multiformats "^9.9.0"
+    zod "^3.23.8"
+
+"@atproto/lexicon@^0.4.9":
+  version "0.4.9"
+  resolved "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.9.tgz#612951a85ecc1398366bd837cda6be89440f179d"
+  integrity sha512-/tmEuHQFr51V2V7EAVJzaA40sqJ7ylAZpR962VbOsPtmcdOHvezbjVHYEMXgfb927hS+xqbVyzBTbu5w9v8prA==
+  dependencies:
+    "@atproto/common-web" "^0.4.0"
+    "@atproto/syntax" "^0.4.0"
     iso-datestring-validator "^2.2.2"
     multiformats "^9.9.0"
     zod "^3.23.8"
@@ -161,12 +192,25 @@
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.3.0.tgz#fafa2dbea9add37253005cb663e7373e05e618b3"
   integrity sha512-Weq0ZBxffGHDXHl9U7BQc2BFJi/e23AL+k+i5+D9hUq/bzT4yjGsrCejkjq0xt82xXDjmhhvQSZ0LqxyZ5woxA==
 
+"@atproto/syntax@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.0.tgz#bec71552087bb24c208a06ef418c0040b65542f2"
+  integrity sha512-b9y5ceHS8YKOfP3mdKmwAx5yVj9294UN7FG2XzP6V5aKUdFazEYRnR9m5n5ZQFKa3GNvz7de9guZCJ/sUTcOAA==
+
 "@atproto/xrpc@0.6.1", "@atproto/xrpc@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.6.1.tgz#dcd1315c8c60eef5af2db7fa4e35a38ebc6d79d5"
   integrity sha512-Zy5ydXEdk6sY7FDUZcEVfCL1jvbL4tXu5CcdPqbEaW6LQtk9GLds/DK1bCX9kswTGaBC88EMuqQMfkxOhp2t4A==
   dependencies:
     "@atproto/lexicon" "^0.4.1"
+    zod "^3.23.8"
+
+"@atproto/xrpc@^0.6.11":
+  version "0.6.11"
+  resolved "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.11.tgz#54c527e39a2f5ddd2655b11f7cb99b8f303d8364"
+  integrity sha512-J2cZP8FjoDN0UkyTYBlCvKvxwBbDm4dld47u6FQK30RJy9YpSiUkdxJJ10NYqpi7JVny3M0qWQgpWJDV94+PdA==
+  dependencies:
+    "@atproto/lexicon" "^0.4.9"
     zod "^3.23.8"
 
 "@babel/runtime@^7.1.2":
@@ -940,6 +984,11 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+await-lock@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
+  integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -5324,6 +5373,11 @@ tiny-invariant@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
+tlds@^1.234.0:
+  version "1.256.0"
+  resolved "https://registry.npmjs.org/tlds/-/tlds-1.256.0.tgz#4285b41a7ed4fcc7c5eed8516c3a180e892fad36"
+  integrity sha512-ZmyVB9DAw+FFTmLElGYJgdZFsKLYd/I59Bg9NHkCGPwAbVZNRilFWDMAdX8UG+bHuv7kfursd5XGqo/9wi26lA==
 
 tldts-core@^6.1.66:
   version "6.1.66"


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/3651
This PR refactors workspace data loading to use `tools.ozone.moderation.getSubjects` endpoint and adds a more advanced filtering system for workspace items that allows grouping and using OR filters between groups. 

Thanks to the unified dataloader, workspace can now also filter by follower count and other profile info and shows warnings when workspace has high profile accounts in it.

<img width="1029" alt="Screenshot 2025-03-24 at 22 22 17" src="https://github.com/user-attachments/assets/33908b2e-24e2-4bad-ac7a-086dec859251" />

> High profile warning in workspace action form

<img width="591" alt="Screenshot 2025-03-24 at 21 54 28" src="https://github.com/user-attachments/assets/75651d5b-09c4-4419-a9ea-2207a256a81a" />

> Advanced grouped filtering for workspace items

Few little touches here and there
1. show star icon in workspace item rows for items of high profile account
2. change label prefix `report:` to a flag icon to save real-estate and make workspace items more legible
3. change `lang:und` tag to `lang?` to save real-estate and add more descriptive title