### PR TITLE
❇️ Link to post thread

### DIFF
--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -168,7 +168,10 @@ function PostHeader({
             </Link>
             &nbsp;&middot;&nbsp;
             <Link
-              href={`/repositories/${item.post.uri.replace('at://', '')}`}
+              href={`/repositories/${item.post.uri.replace(
+                'at://',
+                '',
+              )}?tab=thread`}
               className="text-gray-500 dark:text-gray-50 hover:underline"
             >
               {new Date(item.post.indexedAt).toLocaleString()}

--- a/components/reports/SubjectOverview.tsx
+++ b/components/reports/SubjectOverview.tsx
@@ -224,7 +224,11 @@ export function SubjectOverview(props: {
 
   return (
     <div className="flex flex-row items-center">
-      <Link href={`/repositories/${summary.did}`} target="_blank">
+      <Link
+        href={`/repositories/${summary.did}`}
+        prefetch={false}
+        target="_blank"
+      >
         <ArrowTopRightOnSquareIcon className="inline-block h-4 w-4 mr-1" />
       </Link>
 

--- a/components/repositories/RepositoriesTable.tsx
+++ b/components/repositories/RepositoriesTable.tsx
@@ -1,6 +1,5 @@
 import { UserGroupIcon } from '@heroicons/react/20/solid'
 import { formatDistanceToNow } from 'date-fns'
-import { AppBskyActorProfile } from '@atproto/api'
 import { Repo } from '@/lib/types'
 import { LoadMoreButton } from '../common/LoadMoreButton'
 import { ReviewStateIcon } from '@/subject/ReviewStateMarker'
@@ -115,6 +114,7 @@ function RepoRow(props: { repo: Repo; showEmail: boolean }) {
             )}
             {lastSigninCountry && (
               <Link
+                prefetch={false}
                 href={`/repositories?term=sig:${encodeURIComponent(
                   lastSigninCountry,
                 )}`}
@@ -157,6 +157,7 @@ function RepoRow(props: { repo: Repo; showEmail: boolean }) {
             </Link>
             {ipCountry && (
               <Link
+                prefetch={false}
                 href={`/repositories?term=sig:${encodeURIComponent(ipCountry)}`}
               >
                 <LabelChip>{ipCountry}</LabelChip>


### PR DESCRIPTION
Link the timestamp in post card view to post thread view tab in record page instead of record detail page since that's the most common view mods use when reviewing post.