### PR TITLE
Allow local client to be used with public url

### DIFF
--- a/components/shell/AuthContext.tsx
+++ b/components/shell/AuthContext.tsx
@@ -56,7 +56,9 @@ export function AuthProvider({ children, ...options }: AuthProviderProps) {
     clientId:
       !ozonePublicUrl || typeof window === 'undefined'
         ? undefined // Disabled server side
-        : isLoopbackHost(ozonePublicUrl.hostname)
+        : isLoopbackHost(ozonePublicUrl.hostname) ||
+          (process.env.NODE_ENV === 'development' &&
+            isLoopbackHost(window.location.hostname))
         ? // The following requires a yet to be released version of the oauth-client:
           // &scope=${OAUTH_SCOPE.split(' ').map(encodeURIComponent).join('+')}
           `http://localhost?redirect_uri=${encodeURIComponent(


### PR DESCRIPTION
When running the ozone UI locally with `yarn dev` but pointing it at an API service on the public internet, it was not possible to login due to an oauth misconfiguration.  This situation is now handled by using a local oauth client.