### PR TITLE
:sparkles: Support for verification feature.

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -651,7 +651,6 @@ function Form(
                     <ModEventDetailsPopover modEventType={modEventType} />
                     {isSubjectDid && profile && (
                       <VerificationActionButton
-                        repo={repo}
                         did={subject}
                         profile={profile}
                       />

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -932,7 +932,7 @@ function useSubjectQuery(subject: string) {
 
   return useQuery({
     // subject of the report
-    queryKey: ['modActionSubject', { subject }],
+    queryKey: ['modActionSubject', subject],
     queryFn: async () => {
       if (subject.startsWith('did:')) {
         const [{ data: repo }, profile] = await Promise.all([

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -58,6 +58,7 @@ import { PriorityScore } from '@/subject/PriorityScore'
 import { getEventFromFormData } from '@/mod-event/helpers/emitEvent'
 import { Alert } from '@/common/Alert'
 import { TextWithLinks } from '@/common/TextWithLinks'
+import { VerificationActionButton } from 'components/verification/ActionButton'
 
 const FORM_ID = 'mod-action-panel'
 const useBreakpoint = createBreakpoint({ xs: 340, sm: 640 })
@@ -639,7 +640,7 @@ function Form(
                       <HighProfileWarning profile={profile} />
                     </div>
                   )}
-                  <div className="relative flex flex-row gap-1 items-center">
+                  <div className="relative flex flex-row gap-3 items-center">
                     <ModEventSelectorButton
                       subjectStatus={subjectStatus}
                       selectedAction={modEventType}
@@ -648,6 +649,13 @@ function Form(
                       setSelectedAction={(action) => setModEventType(action)}
                     />
                     <ModEventDetailsPopover modEventType={modEventType} />
+                    {isSubjectDid && profile && (
+                      <VerificationActionButton
+                        repo={repo}
+                        did={subject}
+                        profile={profile}
+                      />
+                    )}
                   </div>
                   {shouldShowDurationInHoursField && (
                     <div className="flex flex-row gap-2">

--- a/app/search/page-content.tsx
+++ b/app/search/page-content.tsx
@@ -6,7 +6,6 @@ import { PostAsCard } from '@/common/posts/PostsFeed'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { ProfileCard } from '@/repositories/AccountView'
 import { WorkspacePanel } from '@/workspace/Panel'
-import { AppBskyActorDefs, AppBskyFeedDefs } from '@atproto/api'
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
 import {
   isActorData,

--- a/app/verification/page-content.tsx
+++ b/app/verification/page-content.tsx
@@ -2,14 +2,12 @@ import { Dropdown } from '@/common/Dropdown'
 import { EmptyDataset } from '@/common/feeds/EmptyFeed'
 import { Loading } from '@/common/Loader'
 import { LoadMoreButton } from '@/common/LoadMoreButton'
-import { PostAsCard } from '@/common/posts/PostsFeed'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
-import { ProfileCard } from '@/repositories/AccountView'
 import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
 import { WorkspacePanel } from '@/workspace/Panel'
 import { ToolsOzoneModerationEmitEvent } from '@atproto/api'
-import { CheckBadgeIcon, Cog8ToothIcon } from '@heroicons/react/24/solid'
+import { CheckCircleIcon, Cog8ToothIcon } from '@heroicons/react/24/solid'
 import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
 import { VerificationFilterPanel } from 'components/verification/FilterPanel'
 import { VerificationList } from 'components/verification/List'
@@ -112,7 +110,7 @@ export const VerificationPageContent = () => {
 
       {!isLoading && !verifications.length && (
         <EmptyDataset message="No verifications indexed">
-          <CheckBadgeIcon className="h-8 w-8" />
+          <CheckCircleIcon className="h-8 w-8" />
         </EmptyDataset>
       )}
 

--- a/app/verification/page-content.tsx
+++ b/app/verification/page-content.tsx
@@ -4,36 +4,66 @@ import { Loading } from '@/common/Loader'
 import { LoadMoreButton } from '@/common/LoadMoreButton'
 import { PostAsCard } from '@/common/posts/PostsFeed'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
+import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
 import { ProfileCard } from '@/repositories/AccountView'
 import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
 import { WorkspacePanel } from '@/workspace/Panel'
-import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { ToolsOzoneModerationEmitEvent } from '@atproto/api'
+import { CheckBadgeIcon, Cog8ToothIcon } from '@heroicons/react/24/solid'
+import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
+import { VerificationFilterPanel } from 'components/verification/FilterPanel'
 import { VerificationList } from 'components/verification/List'
-import { useVerificationList } from 'components/verification/useVerificationList'
-import { useSearchParams } from 'next/navigation'
+import {
+  useVerificationFilter,
+  useVerificationList,
+} from 'components/verification/useVerificationList'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useState } from 'react'
 import { useTitle } from 'react-use'
 
 export const VerificationPageContent = () => {
+  const [isFiltersShown, setIsFiltersShown] = useState(false)
+  const emitEvent = useEmitEvent()
   const searchParams = useSearchParams()
   const isRevoked = searchParams.get('isRevoked') || undefined
   const issuers = searchParams.get('issuers') ?? ''
   const createdAfter = searchParams.get('createdAfter') ?? undefined
   const createdBefore = searchParams.get('createdBefore') ?? undefined
 
+  const router = useRouter()
+  const pathname = usePathname()
+  const quickOpenParam = searchParams.get('quickOpen') ?? ''
+
+  const setQuickActionPanelSubject = (subject?: string) => {
+    // This route should not have any search params but in case it does, let's make sure original params are maintained
+    const newParams = new URLSearchParams(searchParams)
+    if (!subject) {
+      newParams.delete('quickOpen')
+    } else {
+      newParams.set('quickOpen', subject)
+    }
+    router.push((pathname ?? '') + '?' + newParams.toString())
+  }
+
   let pageTitle = `Verifications`
 
   useTitle(pageTitle)
-  const { data, isLoading, fetchNextPage, hasNextPage } = useVerificationList({
-    createdAfter,
-    createdBefore,
-    issuers: issuers.split(','),
-    isRevoked: isRevoked ? isRevoked === 'true' : undefined,
-  })
+
+  const { filters, applyFilters, resetFilters } = useVerificationFilter()
+  const { data, isLoading, fetchNextPage, hasNextPage, isInitialLoading } =
+    useVerificationList(filters)
   const verifications = data?.pages?.flatMap((page) => page.verifications) ?? []
 
   const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
   const { toggleWorkspacePanel, isWorkspaceOpen } = useWorkspaceOpener()
-  const workspaceOptions = [
+  const configOptions = [
+    {
+      id: 'filters',
+      text: isFiltersShown ? 'Hide filters' : 'Show filters',
+      onClick: () => {
+        setIsFiltersShown((show) => !show)
+      },
+    },
     {
       id: 'add_users_to_workspace',
       text: 'Add verified users to workspace',
@@ -49,32 +79,64 @@ export const VerificationPageContent = () => {
       },
     },
   ]
+
   return (
     <div className="w-5/6 sm:w-3/4 md:w-2/3 lg:w-1/2 mx-auto my-4 dark:text-gray-100">
       <div className="flex flex-row justify-between items-center">
         <h4 className="font-medium text-gray-700 dark:text-gray-100">
           Verifications
         </h4>
-        {!!verifications.length && (
-          <div className="flex-1 lg:text-right lg:pr-2 px-1 lg:pt-0">
-            <Dropdown
-              containerClassName="inline-block"
-              rightAligned
-              className="inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-400 bg-white dark:bg-slate-800 dark:text-gray-100 dark px-3 py-1 text-sm text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
-              items={workspaceOptions}
-            >
-              Add to workspace
-            </Dropdown>
-          </div>
-        )}
+        <div className="flex-1 lg:text-right pl-1 lg:pt-0">
+          <Dropdown
+            containerClassName="inline-block"
+            rightAligned
+            className="inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-400 bg-white dark:bg-slate-800 dark:text-gray-100 dark px-3 py-1 text-sm text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+            items={configOptions}
+          >
+            <Cog8ToothIcon
+              className="-ml-1 mr-2 h-4 w-4 text-gray-400"
+              aria-hidden="true"
+            />
+            <span className="text-xs">Options</span>
+          </Dropdown>
+        </div>
       </div>
+
+      {isFiltersShown && (
+        <VerificationFilterPanel
+          filters={filters}
+          onApplyFilters={applyFilters}
+          onResetFilters={resetFilters}
+        />
+      )}
+
       {!isLoading && !verifications.length && (
         <EmptyDataset message="No verifications indexed">
           <CheckBadgeIcon className="h-8 w-8" />
         </EmptyDataset>
       )}
+
       {isLoading && <Loading message="Loading verifications..." />}
+
       <VerificationList verifications={verifications} />
+
+      {hasNextPage && (
+        <div className="flex justify-center">
+          <LoadMoreButton onClick={() => fetchNextPage()} />
+        </div>
+      )}
+
+      <ModActionPanelQuick
+        open={!!quickOpenParam}
+        onClose={() => setQuickActionPanelSubject()}
+        setSubject={setQuickActionPanelSubject}
+        subject={quickOpenParam} // select first subject if there are multiple
+        subjectOptions={[quickOpenParam]}
+        isInitialLoading={isInitialLoading}
+        onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
+          await emitEvent(vals)
+        }}
+      />
       <WorkspacePanel
         open={isWorkspaceOpen}
         onClose={() => toggleWorkspacePanel()}

--- a/app/verification/page-content.tsx
+++ b/app/verification/page-content.tsx
@@ -1,0 +1,84 @@
+import { Dropdown } from '@/common/Dropdown'
+import { EmptyDataset } from '@/common/feeds/EmptyFeed'
+import { Loading } from '@/common/Loader'
+import { LoadMoreButton } from '@/common/LoadMoreButton'
+import { PostAsCard } from '@/common/posts/PostsFeed'
+import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
+import { ProfileCard } from '@/repositories/AccountView'
+import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
+import { WorkspacePanel } from '@/workspace/Panel'
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { VerificationList } from 'components/verification/List'
+import { useVerificationList } from 'components/verification/useVerificationList'
+import { useSearchParams } from 'next/navigation'
+import { useTitle } from 'react-use'
+
+export const VerificationPageContent = () => {
+  const searchParams = useSearchParams()
+  const isRevoked = searchParams.get('isRevoked') || undefined
+  const issuers = searchParams.get('issuers') ?? ''
+  const createdAfter = searchParams.get('createdAfter') ?? undefined
+  const createdBefore = searchParams.get('createdBefore') ?? undefined
+
+  let pageTitle = `Verifications`
+
+  useTitle(pageTitle)
+  const { data, isLoading, fetchNextPage, hasNextPage } = useVerificationList({
+    createdAfter,
+    createdBefore,
+    issuers: issuers.split(','),
+    isRevoked: isRevoked ? isRevoked === 'true' : undefined,
+  })
+  const verifications = data?.pages?.flatMap((page) => page.verifications) ?? []
+
+  const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
+  const { toggleWorkspacePanel, isWorkspaceOpen } = useWorkspaceOpener()
+  const workspaceOptions = [
+    {
+      id: 'add_users_to_workspace',
+      text: 'Add verified users to workspace',
+      onClick: () => {
+        addToWorkspace(verifications.map((item) => item.subject))
+      },
+    },
+    {
+      id: 'add_issuers_to_workspace',
+      text: 'Add verifiers to workspace',
+      onClick: () => {
+        addToWorkspace(verifications.map((item) => item.issuer))
+      },
+    },
+  ]
+  return (
+    <div className="w-5/6 sm:w-3/4 md:w-2/3 lg:w-1/2 mx-auto my-4 dark:text-gray-100">
+      <div className="flex flex-row justify-between items-center">
+        <h4 className="font-medium text-gray-700 dark:text-gray-100">
+          Verifications
+        </h4>
+        {!!verifications.length && (
+          <div className="flex-1 lg:text-right lg:pr-2 px-1 lg:pt-0">
+            <Dropdown
+              containerClassName="inline-block"
+              rightAligned
+              className="inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-400 bg-white dark:bg-slate-800 dark:text-gray-100 dark px-3 py-1 text-sm text-gray-700 shadow-sm hover:bg-gray-50 dark:hover:bg-slate-700"
+              items={workspaceOptions}
+            >
+              Add to workspace
+            </Dropdown>
+          </div>
+        )}
+      </div>
+      {!isLoading && !verifications.length && (
+        <EmptyDataset message="No verifications indexed">
+          <CheckBadgeIcon className="h-8 w-8" />
+        </EmptyDataset>
+      )}
+      {isLoading && <Loading message="Loading verifications..." />}
+      <VerificationList verifications={verifications} />
+      <WorkspacePanel
+        open={isWorkspaceOpen}
+        onClose={() => toggleWorkspacePanel()}
+      />
+    </div>
+  )
+}

--- a/app/verification/page.tsx
+++ b/app/verification/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { Suspense } from 'react'
+import { VerificationPageContent } from './page-content'
+
+export default function VerificationPage() {
+  return (
+    <Suspense fallback={<div></div>}>
+      <VerificationPageContent />
+    </Suspense>
+  )
+}

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -22,7 +22,10 @@ import {
 } from '@heroicons/react/24/solid'
 import { StarterPackRecordCard } from './starterpacks/RecordCard'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { getProfileFromRepo } from '@/repositories/helpers'
+import {
+  getProfileFromRepo,
+  isValidRepoViewDetailed,
+} from '@/repositories/helpers'
 import {
   useWorkspaceAddItemsMutation,
   useWorkspaceList,
@@ -336,10 +339,6 @@ const AssociatedProfileIcon = ({
 export function RepoCard(props: { did: string }) {
   const { did } = props
   const { data: { repo, profile } = {}, error } = useRepoAndProfile({ did })
-  const { data: workspaceList } = useWorkspaceList()
-  const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
-  const { mutate: removeFromWorkspace } = useWorkspaceRemoveItemsMutation()
-  const isInWorkspace = workspaceList?.includes(did)
 
   if (error) {
     return (
@@ -353,7 +352,25 @@ export function RepoCard(props: { did: string }) {
   if (!repo) {
     return <LoadingDense />
   }
-  const takendown = !!repo.moderation.subjectStatus?.takendown
+
+  return <RepoCardView {...{ did, repo, profile }} />
+}
+
+export const RepoCardView = ({
+  did,
+  repo,
+  profile,
+}: {
+  did: string
+  repo?: ToolsOzoneModerationDefs.RepoViewDetail
+  profile?: AppBskyActorDefs.ProfileViewDetailed
+}) => {
+  const { data: workspaceList } = useWorkspaceList()
+  const { mutate: addToWorkspace } = useWorkspaceAddItemsMutation()
+  const { mutate: removeFromWorkspace } = useWorkspaceRemoveItemsMutation()
+  const isInWorkspace = workspaceList?.includes(did)
+  const isRepoView = isValidRepoViewDetailed(repo)
+  const takendown = isRepoView && !!repo?.moderation.subjectStatus?.takendown
 
   return (
     <div className="bg-white dark:bg-slate-800">
@@ -370,7 +387,7 @@ export function RepoCard(props: { did: string }) {
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
             <Link
-              href={`/repositories/${repo.did}`}
+              href={`/repositories/${did}`}
               className="hover:underline text-gray-500 dark:text-gray-50"
             >
               {profile?.displayName ? (
@@ -378,13 +395,13 @@ export function RepoCard(props: { did: string }) {
                   <span className="font-bold">{profile.displayName}</span>
                   <span
                     className="ml-1 text-gray-500 dark:text-gray-50"
-                    title={`@${repo.handle}`}
+                    title={`@${repo?.handle || did}`}
                   >
-                    @{repo.handle}
+                    @{repo?.handle || did}
                   </span>
                 </>
               ) : (
-                <span className="font-bold">@{repo.handle}</span>
+                <span className="font-bold">@{repo?.handle || did}</span>
               )}
             </Link>{' '}
             &nbsp;&middot;&nbsp;
@@ -404,7 +421,7 @@ export function RepoCard(props: { did: string }) {
           {!!profile && (
             <div className="flex flex-row items-center gap-2">
               <Link
-                href={`/repositories/${repo.did}?tab=followers`}
+                href={`/repositories/${did}?tab=followers`}
                 className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">
@@ -412,7 +429,7 @@ export function RepoCard(props: { did: string }) {
                 </span>
               </Link>
               <Link
-                href={`/repositories/${repo.did}?tab=follows`}
+                href={`/repositories/${did}?tab=follows`}
                 className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">
@@ -420,7 +437,7 @@ export function RepoCard(props: { did: string }) {
                 </span>
               </Link>
               <Link
-                href={`/repositories/${repo.did}?tab=posts`}
+                href={`/repositories/${did}?tab=posts`}
                 className="flex gap-1 items-center rounded-md pt-2 pb-1 text-gray-500 dark:text-gray-50 underline hover:underline cursor-pointer"
               >
                 <span className="text-sm">

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/workspace/hooks'
 
 import type { JSX } from 'react'
+import { VerificationBadge } from 'components/verification/Badge'
 
 export function RecordCard(props: {
   uri: string
@@ -390,7 +391,7 @@ export const RepoCardView = ({
               href={`/repositories/${did}`}
               className="hover:underline text-gray-500 dark:text-gray-50"
             >
-              {profile?.displayName ? (
+              {profile ? (
                 <>
                   <span className="font-bold">{profile.displayName}</span>
                   <span
@@ -399,6 +400,11 @@ export const RepoCardView = ({
                   >
                     @{repo?.handle || did}
                   </span>
+                  <VerificationBadge
+                    className="ml-0.5"
+                    size="sm"
+                    profile={profile}
+                  />
                 </>
               ) : (
                 <span className="font-bold">@{repo?.handle || did}</span>

--- a/components/common/buttons.tsx
+++ b/components/common/buttons.tsx
@@ -30,7 +30,7 @@ export function ButtonSecondary(props: ComponentProps<'button'>) {
   )
 }
 
-type ButtonAppearance = 'outlined' | 'primary' | 'secondary'
+type ButtonAppearance = 'outlined' | 'primary' | 'secondary' | 'negative'
 type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
 type ActionButtonProps = {
   appearance: ButtonAppearance
@@ -42,6 +42,8 @@ const appearanceClassNames = {
     'bg-transparent dark:bg-slate-800 disabled:bg-gray-300 text-black dark:text-gray-50 hover:bg-gray-500 dark:hover:bg-slate-700 focus:ring-gray-500 dark:focus:ring-slate-600 border-gray-700 dark:border-slate-600',
   primary:
     'bg-indigo-600 dark:bg-teal-600 disabled:bg-gray-400 text-white hover:bg-indigo-700 dark:hover:bg-teal-700 focus:ring-indigo-500 dark:focus:ring-teal-500 border-transparent',
+  negative:
+    'bg-red-600 dark:bg-red-700 disabled:bg-gray-400 text-white hover:bg-red-700 dark:hover:bg-red-800 focus:ring-red-500 dark:focus:ring-red-500 border-transparent',
 }
 const sizeClassNames = {
   xs: 'px-1 py-1 text-xs font-light',

--- a/components/common/modals/confirmation.tsx
+++ b/components/common/modals/confirmation.tsx
@@ -81,16 +81,15 @@ export const ConfirmationModal = forwardRef(function ConfirmationModal(
                     {description}
                   </Description>
                 )}
-                <Description>
-                  {children}
-                  {!!error && (
-                    <Alert
-                      type="error"
-                      body={error}
-                      title="Something went wrong"
-                    />
-                  )}
-                </Description>
+                
+                {children}
+                {!!error && (
+                  <Alert
+                    type="error"
+                    body={error}
+                    title="Something went wrong"
+                  />
+                )}
 
                 <div className="mt-4 flex flex-row justify-end">
                   <ActionButton

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -41,6 +41,7 @@ import { ImageList } from './ImageList'
 import { useGraphicMediaPreferences } from '@/config/useLocalPreferences'
 import { getVideoUrlWithFallback } from '../video/helpers'
 import { isValidPostRecord, extractEmbed } from './helpers'
+import { VerificationBadge } from 'components/verification/Badge'
 
 const VideoPlayer = dynamic(() => import('@/common/video/player'), {
   ssr: false,
@@ -165,6 +166,11 @@ function PostHeader({
               ) : (
                 <span className="font-bold">@{item.post.author.handle}</span>
               )}
+              <VerificationBadge
+                className="ml-0.5"
+                size="sm"
+                profile={item.post.author}
+              />
             </Link>
             &nbsp;&middot;&nbsp;
             <Link

--- a/components/mod-event/DetailsPopover.tsx
+++ b/components/mod-event/DetailsPopover.tsx
@@ -17,8 +17,8 @@ export const ModEventDetailsPopover = ({
     <Popover className="relative">
       {() => (
         <>
-          <PopoverButton className="ring-none">
-            <QuestionMarkCircleIcon className="h-6 w-6 ml-2 dark:fill-teal-500" />
+          <PopoverButton className="ring-none h-5">
+            <QuestionMarkCircleIcon className="h-6 w-6 dark:fill-teal-500" />
           </PopoverButton>
           <Transition
             as={Fragment}

--- a/components/mod-event/SelectorButton.tsx
+++ b/components/mod-event/SelectorButton.tsx
@@ -4,7 +4,11 @@ import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import { Dropdown } from '@/common/Dropdown'
 import { MOD_EVENTS } from './constants'
 import { isReporterMuted, isSubjectMuted } from '@/subject/helpers'
-import { DM_DISABLE_TAG, VIDEO_UPLOAD_DISABLE_TAG } from '@/lib/constants'
+import {
+  DM_DISABLE_TAG,
+  TRUSTED_VERIFIER_TAG,
+  VIDEO_UPLOAD_DISABLE_TAG,
+} from '@/lib/constants'
 import { usePermission } from '@/shell/ConfigurationContext'
 
 const actions = [
@@ -61,6 +65,14 @@ const actions = [
     key: MOD_EVENTS.ENABLE_VIDEO_UPLOAD,
   },
   {
+    text: 'Make Trusted Verifier',
+    key: MOD_EVENTS.MAKE_VERIFIER,
+  },
+  {
+    text: 'Revoke Trusted Verifier',
+    key: MOD_EVENTS.REVOKE_VERIFIER,
+  },
+  {
     text: 'Set Priority Score',
     key: MOD_EVENTS.SET_PRIORITY,
   },
@@ -89,14 +101,8 @@ export const ModEventSelectorButton = ({
   const canTakedown = usePermission('canTakedown')
   const canManageChat = usePermission('canManageChat')
   const canSendEmail = usePermission('canSendEmail')
-  const {
-    takendown,
-    muteUntil,
-    muteReportingUntil,
-    reviewState,
-    appealed,
-    tags,
-  } = subjectStatus || {}
+  const canVerify = usePermission('canVerify')
+  const { takendown, reviewState, appealed, tags } = subjectStatus || {}
   const isMutedSubject = isSubjectMuted(subjectStatus)
   const isMutedReporter = isReporterMuted(subjectStatus)
 
@@ -207,6 +213,19 @@ export const ModEventSelectorButton = ({
         return false
       }
 
+      if (
+        key === MOD_EVENTS.MAKE_VERIFIER &&
+        (tags?.includes(TRUSTED_VERIFIER_TAG) || !isSubjectDid || !canVerify)
+      ) {
+        return false
+      }
+      if (
+        key === MOD_EVENTS.REVOKE_VERIFIER &&
+        (!tags?.includes(TRUSTED_VERIFIER_TAG) || !isSubjectDid || !canVerify)
+      ) {
+        return false
+      }
+
       return true
     })
   }, [
@@ -222,6 +241,7 @@ export const ModEventSelectorButton = ({
     canTakedown,
     canDivertBlob,
     canSendEmail,
+    canVerify,
     forceDisplayActions,
   ])
 

--- a/components/mod-event/constants.ts
+++ b/components/mod-event/constants.ts
@@ -20,6 +20,8 @@ export const MOD_EVENTS = {
   ENABLE_DMS: 'enableDms',
   DISABLE_VIDEO_UPLOAD: 'disableVideoUpload',
   ENABLE_VIDEO_UPLOAD: 'enableVideoUpload',
+  MAKE_VERIFIER: 'makeVerifier',
+  REVOKE_VERIFIER: 'revokeVerifier',
 } as const
 
 export const MOD_EVENT_TITLES = {
@@ -44,6 +46,8 @@ export const MOD_EVENT_TITLES = {
   [MOD_EVENTS.ENABLE_DMS]: 'Enable DMs',
   [MOD_EVENTS.DISABLE_VIDEO_UPLOAD]: 'Disable Video Upload',
   [MOD_EVENTS.ENABLE_VIDEO_UPLOAD]: 'Enable Video Upload',
+  [MOD_EVENTS.MAKE_VERIFIER]: 'Make Trusted Verifier',
+  [MOD_EVENTS.REVOKE_VERIFIER]: 'Revoke Trusted Verifier',
 }
 
 export const FILTER_MACROS_LIST_KEY = 'filter_macros_list'

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -20,7 +20,11 @@ import { chunkArray } from '@/lib/util'
 import { WorkspaceListData } from '@/workspace/useWorkspaceListData'
 import { compileTemplateContent } from 'components/email/helpers'
 import { diffTags } from 'components/tags/utils'
-import { DM_DISABLE_TAG, VIDEO_UPLOAD_DISABLE_TAG } from '@/lib/constants'
+import {
+  DM_DISABLE_TAG,
+  TRUSTED_VERIFIER_TAG,
+  VIDEO_UPLOAD_DISABLE_TAG,
+} from '@/lib/constants'
 
 const DELAY_DURATION_MS = 10000 // 10 seconds
 
@@ -458,7 +462,9 @@ export const getEventFromFormData = (
     MOD_EVENTS.DISABLE_DMS === $type ||
     MOD_EVENTS.ENABLE_DMS === $type ||
     MOD_EVENTS.DISABLE_VIDEO_UPLOAD === $type ||
-    MOD_EVENTS.ENABLE_VIDEO_UPLOAD === $type
+    MOD_EVENTS.ENABLE_VIDEO_UPLOAD === $type ||
+    MOD_EVENTS.MAKE_VERIFIER === $type ||
+    MOD_EVENTS.REVOKE_VERIFIER === $type
   ) {
     let add,
       remove: string[] = []
@@ -477,6 +483,14 @@ export const getEventFromFormData = (
     if ($type === MOD_EVENTS.ENABLE_VIDEO_UPLOAD) {
       add = []
       remove = [VIDEO_UPLOAD_DISABLE_TAG]
+    }
+    if ($type === MOD_EVENTS.MAKE_VERIFIER) {
+      add = [TRUSTED_VERIFIER_TAG]
+      remove = []
+    }
+    if ($type === MOD_EVENTS.REVOKE_VERIFIER) {
+      add = []
+      remove = [TRUSTED_VERIFIER_TAG]
     }
     return {
       add,

--- a/components/repositories/AccountView.tsx
+++ b/components/repositories/AccountView.tsx
@@ -64,6 +64,7 @@ import { ProfileAvatar } from './ProfileAvatar'
 import { obscureIp, parseThreatSigs } from './helpers'
 import { useCopyAccountDetails } from './useCopyAccountDetails'
 import { getProfiles } from './api'
+import { VerificationBadge } from 'components/verification/Badge'
 
 enum Views {
   Details,
@@ -455,6 +456,7 @@ function Header({
                   target="_blank"
                 >
                   {displayActorName}
+                  {profile && <VerificationBadge profile={profile} />}
                 </a>{' '}
                 {subjectStatus && (
                   <SubjectReviewStateBadge subjectStatus={subjectStatus} />

--- a/components/repositories/HighProfileWarning.tsx
+++ b/components/repositories/HighProfileWarning.tsx
@@ -12,21 +12,64 @@ export const HighProfileWarning = ({
 }: {
   profile: AppBskyActorDefs.ProfileViewDetailed
 }) => {
-  const { followersCount } = profile
+  const { followersCount, verification } = profile
+  const lowFollowerCount =
+    !followersCount || followersCount < HIGH_PROFILE_FOLLOWER_THRESHOLD
+  const trustedVerifier = verification?.trustedVerifierStatus === 'valid'
+  const isVerified = verification?.verifiedStatus === 'valid'
 
-  if (!followersCount || followersCount < HIGH_PROFILE_FOLLOWER_THRESHOLD) {
+  if (lowFollowerCount && !trustedVerifier && !isVerified) {
     return null
+  }
+
+  const fragments: React.ReactNode[] = []
+
+  if (!lowFollowerCount) {
+    fragments.push(
+      <>
+        has more than {numberFormatter.format(HIGH_PROFILE_FOLLOWER_THRESHOLD)}{' '}
+        followers (<b>{numberFormatter.format(followersCount)} total</b>)
+      </>,
+    )
+  }
+
+  if (trustedVerifier) {
+    fragments.push(
+      <>
+        is a <b>trusted verifier</b>
+      </>,
+    )
+  }
+
+  if (isVerified) {
+    fragments.push(
+      <>
+        has been <b>verified</b>
+      </>,
+    )
   }
 
   return (
     <Alert
       type="warning"
       title="High profile account"
-      body={`This user has more than ${numberFormatter.format(
-        HIGH_PROFILE_FOLLOWER_THRESHOLD,
-      )} followers (${numberFormatter.format(
-        followersCount,
-      )} total). Please take caution when moderating this account.`}
+      body={
+        <div>
+          Please take caution when moderating this account.{' '}
+          {fragments.length > 1 ? (
+            <>
+              This user: <br />
+              <ul className="list-disc pl-4">
+                {fragments.map((fragment, index) => (
+                  <li key={index}>{fragment}</li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <>This user {fragments[0]}.</>
+          )}
+        </div>
+      }
     />
   )
 }

--- a/components/repositories/helpers.ts
+++ b/components/repositories/helpers.ts
@@ -64,3 +64,7 @@ export const getProfileFromRepo = (
 export const isValidProfileViewDetailed = asPredicate(
   AppBskyActorDefs.validateProfileViewDetailed,
 )
+
+export const isValidRepoViewDetailed = asPredicate(
+  ToolsOzoneModerationDefs.validateRepoViewDetail,
+)

--- a/components/shell/ConfigurationContext.tsx
+++ b/components/shell/ConfigurationContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Agent, CredentialSession } from '@atproto/api'
+import { Agent } from '@atproto/api'
 import {
   createContext,
   ReactNode,

--- a/components/shell/SidebarNav.tsx
+++ b/components/shell/SidebarNav.tsx
@@ -5,13 +5,25 @@ import { usePathname } from 'next/navigation'
 import { useKBar } from 'kbar'
 import { classNames } from '@/lib/util'
 import { ICONS, NAV_ITEMS, isCurrent } from './common'
+import { useServerConfig } from './ConfigurationContext'
+import { useMemo } from 'react'
 
 export function SidebarNav({ theme, toggleTheme }) {
   const kbar = useKBar()
   const pathname = usePathname() || '/'
+  const { verifierDid } = useServerConfig()
+  const navItems = useMemo(() => {
+    return NAV_ITEMS.filter((item) => {
+      if (item.name === 'Verification') {
+        return !!verifierDid
+      }
+      return true
+    })
+  }, [verifierDid])
+
   return (
     <div className="mt-6 w-full flex-1 space-y-1 px-2">
-      {NAV_ITEMS.map((item) => {
+      {navItems.map((item) => {
         let iconName = item.icon
         if (iconName === 'sun' && theme === 'dark') {
           iconName = 'moon'

--- a/components/shell/common.ts
+++ b/components/shell/common.ts
@@ -8,7 +8,7 @@ import {
   MoonIcon,
   WrenchScrewdriverIcon,
   MagnifyingGlassIcon,
-  CheckBadgeIcon,
+  CheckCircleIcon,
 } from '@heroicons/react/24/outline'
 import { useKBar } from 'kbar'
 import { MouseEventHandler } from 'react'
@@ -23,7 +23,7 @@ export const ICONS = {
   moon: MoonIcon,
   configure: WrenchScrewdriverIcon,
   search: MagnifyingGlassIcon,
-  verification: CheckBadgeIcon,
+  verification: CheckCircleIcon,
 }
 
 export type SidebarNavItem = {

--- a/components/shell/common.ts
+++ b/components/shell/common.ts
@@ -8,6 +8,7 @@ import {
   MoonIcon,
   WrenchScrewdriverIcon,
   MagnifyingGlassIcon,
+  CheckBadgeIcon,
 } from '@heroicons/react/24/outline'
 import { useKBar } from 'kbar'
 import { MouseEventHandler } from 'react'
@@ -22,6 +23,7 @@ export const ICONS = {
   moon: MoonIcon,
   configure: WrenchScrewdriverIcon,
   search: MagnifyingGlassIcon,
+  verification: CheckBadgeIcon,
 }
 
 export type SidebarNavItem = {
@@ -60,6 +62,11 @@ export const NAV_ITEMS: SidebarNavItem[] = [
     name: 'Configure',
     href: '/configure',
     icon: 'configure',
+  },
+  {
+    name: 'Verification',
+    href: '/verification',
+    icon: 'verification',
   },
   {
     name: 'Theme',

--- a/components/subject/ReviewStateMarker.tsx
+++ b/components/subject/ReviewStateMarker.tsx
@@ -126,7 +126,7 @@ export const ReviewStateIcon = ({
     reviewStateToText[subjectStatus.reviewState] || subjectStatus.reviewState
   let color =
     reviewStateToColor[subjectStatus.reviewState]?.text || 'text-gray-800'
-  let Icon = reviewStateToIcon[subjectStatus.reviewState] || HandThumbUpIcon
+  let Icon = reviewStateToIcon[subjectStatus.reviewState] || CheckCircleIcon
 
   if (subjectStatus.takendown) {
     text = 'Taken Down'

--- a/components/subject/ReviewStateMarker.tsx
+++ b/components/subject/ReviewStateMarker.tsx
@@ -6,13 +6,13 @@ import {
   ToolsOzoneModerationDefs,
 } from '@atproto/api'
 import {
-  CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   ScaleIcon,
   ShieldExclamationIcon,
   NoSymbolIcon,
 } from '@heroicons/react/20/solid'
+import { HandThumbUpIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 
 const reviewStateDescription = {
@@ -53,7 +53,7 @@ const reviewStateToColor = {
 const reviewStateToIcon = {
   [ToolsOzoneModerationDefs.REVIEWOPEN]: ExclamationCircleIcon,
   [ToolsOzoneModerationDefs.REVIEWESCALATED]: ExclamationTriangleIcon,
-  [ToolsOzoneModerationDefs.REVIEWCLOSED]: CheckCircleIcon,
+  [ToolsOzoneModerationDefs.REVIEWCLOSED]: HandThumbUpIcon,
   [ToolsOzoneModerationDefs.REVIEWNONE]: NoSymbolIcon,
 }
 
@@ -126,7 +126,7 @@ export const ReviewStateIcon = ({
     reviewStateToText[subjectStatus.reviewState] || subjectStatus.reviewState
   let color =
     reviewStateToColor[subjectStatus.reviewState]?.text || 'text-gray-800'
-  let Icon = reviewStateToIcon[subjectStatus.reviewState] || CheckCircleIcon
+  let Icon = reviewStateToIcon[subjectStatus.reviewState] || HandThumbUpIcon
 
   if (subjectStatus.takendown) {
     text = 'Taken Down'

--- a/components/subject/ReviewStateMarker.tsx
+++ b/components/subject/ReviewStateMarker.tsx
@@ -12,7 +12,7 @@ import {
   ShieldExclamationIcon,
   NoSymbolIcon,
 } from '@heroicons/react/20/solid'
-import { HandThumbUpIcon } from '@heroicons/react/24/solid'
+import { CheckCircleIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 
 const reviewStateDescription = {
@@ -53,7 +53,7 @@ const reviewStateToColor = {
 const reviewStateToIcon = {
   [ToolsOzoneModerationDefs.REVIEWOPEN]: ExclamationCircleIcon,
   [ToolsOzoneModerationDefs.REVIEWESCALATED]: ExclamationTriangleIcon,
-  [ToolsOzoneModerationDefs.REVIEWCLOSED]: HandThumbUpIcon,
+  [ToolsOzoneModerationDefs.REVIEWCLOSED]: CheckCircleIcon,
   [ToolsOzoneModerationDefs.REVIEWNONE]: NoSymbolIcon,
 }
 

--- a/components/team/helpers.ts
+++ b/components/team/helpers.ts
@@ -3,6 +3,7 @@ import { ToolsOzoneTeamDefs } from '@atproto/api'
 export const MemberRoleNames = {
   [ToolsOzoneTeamDefs.ROLETRIAGE]: 'Triage',
   [ToolsOzoneTeamDefs.ROLEMODERATOR]: 'Moderator',
+  [ToolsOzoneTeamDefs.ROLEVERIFIER]: 'Verifier',
   [ToolsOzoneTeamDefs.ROLEADMIN]: 'Admin',
 }
 
@@ -15,6 +16,9 @@ export const getRoleText = (role: ToolsOzoneTeamDefs.Member['role']) => {
   }
   if (role === ToolsOzoneTeamDefs.ROLETRIAGE) {
     return MemberRoleNames[ToolsOzoneTeamDefs.ROLETRIAGE]
+  }
+  if (role === ToolsOzoneTeamDefs.ROLEVERIFIER) {
+    return MemberRoleNames[ToolsOzoneTeamDefs.ROLEVERIFIER]
   }
   return 'Unknown'
 }
@@ -33,6 +37,10 @@ export const isRoleSuperiorOrSame = (manager: string, target: string) => {
 
   if (manager === ToolsOzoneTeamDefs.ROLETRIAGE) {
     return target === ToolsOzoneTeamDefs.ROLETRIAGE
+  }
+
+  if (manager === ToolsOzoneTeamDefs.ROLEVERIFIER) {
+    return target === ToolsOzoneTeamDefs.ROLEVERIFIER
   }
 
   return false

--- a/components/verification/ActionButton.tsx
+++ b/components/verification/ActionButton.tsx
@@ -7,7 +7,7 @@ import {
   PopoverPanel,
   Transition,
 } from '@headlessui/react'
-import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { CheckCircleIcon } from '@heroicons/react/24/solid'
 import { Fragment } from 'react'
 import { useVerifier } from './useVerifier'
 import { WorkspaceListData } from '@/workspace/useWorkspaceListData'
@@ -150,7 +150,7 @@ const VerificationActionPopup = ({
         <>
           <PopoverButton className="ring-none">
             <ActionButton appearance="outlined" size={size} type="button">
-              <CheckBadgeIcon className="inline-block h-4 w-4 mr-1" />
+              <CheckCircleIcon className="inline-block h-4 w-4 mr-1" />
               <span className={classNames(`text-${size}`)}>{buttonText}</span>
             </ActionButton>
           </PopoverButton>

--- a/components/verification/ActionButton.tsx
+++ b/components/verification/ActionButton.tsx
@@ -52,8 +52,8 @@ export const BulkVerificationActionButton = ({
       grantVerifications={grantVerifications}
       size="xs"
     >
-      Granting verification will issue a verification record for each{' '}
-      <b>selected</b> user in your workspace.
+      Granting verification will issue a verification record for all users in
+      your workspace.
       <br />
       Revoking verification will remove any active verification record issued by
       you in the past.

--- a/components/verification/ActionButton.tsx
+++ b/components/verification/ActionButton.tsx
@@ -1,0 +1,220 @@
+import { ActionButton } from '@/common/buttons'
+import { usePermission, useServerConfig } from '@/shell/ConfigurationContext'
+import { AppBskyActorDefs, ToolsOzoneVerificationGrant } from '@atproto/api'
+import {
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  Transition,
+} from '@headlessui/react'
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { Fragment } from 'react'
+import { useVerifier } from './useVerifier'
+import { WorkspaceListData } from '@/workspace/useWorkspaceListData'
+import { isValidProfileViewDetailed } from '@/repositories/helpers'
+import { classNames } from '@/lib/util'
+
+export const BulkVerificationActionButton = ({
+  subjects,
+}: {
+  subjects?: WorkspaceListData
+}) => {
+  const { verifierDid } = useServerConfig()
+  const grantVerifications: ToolsOzoneVerificationGrant.VerificationInput[] = []
+  const revokeUris: string[] = []
+
+  Object.values(subjects || {}).map((sub) => {
+    if (isValidProfileViewDetailed(sub.profile)) {
+      const verification = sub.profile.verification?.verifications?.find(
+        (v) => v.issuer == verifierDid,
+      )
+      if (verification) {
+        revokeUris.push(verification.uri)
+      } else {
+        grantVerifications.push({
+          subject: sub.profile.did,
+          handle: sub.profile.handle,
+          displayName: sub.profile.displayName || '',
+        })
+      }
+    }
+  })
+
+  if (!grantVerifications.length && !revokeUris.length) {
+    return null
+  }
+
+  return (
+    <VerificationActionPopup
+      buttonText="User Verification"
+      title="Verify Users/Revoke Verifications"
+      revokeUris={revokeUris}
+      grantVerifications={grantVerifications}
+      size="xs"
+    >
+      Granting verification will issue a verification record for each{' '}
+      <b>selected</b> user in your workspace.
+      <br />
+      Revoking verification will remove any active verification record issued by
+      you in the past.
+    </VerificationActionPopup>
+  )
+}
+
+export const VerificationActionButton = ({
+  did,
+  profile,
+}: {
+  did: string
+  profile: AppBskyActorDefs.ProfileViewDetailed
+}) => {
+  const { verifierDid } = useServerConfig()
+  // Revocation is only allowed when there is a verification record by the issuer that is configured with the ozone agent
+  const revocableVerificationUri = profile.verification?.verifications?.find(
+    (v) => v.issuer == verifierDid,
+  )?.uri
+
+  return (
+    <VerificationActionPopup
+      buttonText={
+        revocableVerificationUri ? 'Revoke Verification' : 'Verify User'
+      }
+      title={
+        revocableVerificationUri
+          ? `Revoke Verification?`
+          : `Verify ${profile.displayName || profile.handle}?`
+      }
+      revokeUris={revocableVerificationUri ? [revocableVerificationUri] : []}
+      grantVerifications={
+        !revocableVerificationUri
+          ? [
+              {
+                subject: did,
+                handle: profile.handle,
+                displayName: profile.displayName || '',
+              },
+            ]
+          : []
+      }
+    >
+      {revocableVerificationUri ? (
+        <div>
+          You have already verified this user. Do you want to revoke the
+          verification record at <b>{revocableVerificationUri}</b>?
+        </div>
+      ) : (
+        <div>
+          A verification record will be created with the following details
+          <ul className="list-disc ml-4">
+            <li>
+              Name: <b>{profile.displayName}</b>
+            </li>
+            <li>
+              Handle: <b>{profile.handle}</b>
+            </li>
+          </ul>
+          <p className="mt-2">
+            You can always revoke this verification later if needed.
+          </p>
+        </div>
+      )}
+    </VerificationActionPopup>
+  )
+}
+
+const VerificationActionPopup = ({
+  size = 'sm',
+  buttonText,
+  title,
+  children,
+  revokeUris,
+  grantVerifications,
+}: {
+  size?: 'xs' | 'sm'
+  buttonText: string
+  title: string
+  children?: React.ReactNode
+  revokeUris?: string[]
+  grantVerifications: ToolsOzoneVerificationGrant.VerificationInput[]
+}) => {
+  const canVerify = usePermission('canVerify')
+  const { revoke, grant } = useVerifier()
+
+  if (!canVerify) {
+    return null
+  }
+
+  return (
+    <Popover className="relative">
+      {({ close }) => (
+        <>
+          <PopoverButton className="ring-none">
+            <ActionButton appearance="outlined" size={size} type="button">
+              <CheckBadgeIcon className="inline-block h-4 w-4 mr-1" />
+              <span className={classNames(`text-${size}`)}>{buttonText}</span>
+            </ActionButton>
+          </PopoverButton>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-200"
+            enterFrom="opacity-0 translate-y-1"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition ease-in duration-150"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-1"
+          >
+            <PopoverPanel className="absolute left-2 z-20 mt-3 w-72 transform lg:max-w-3xl max-w-sm">
+              <div className="overflow-hidden rounded-lg shadow-lg">
+                <div className="relative bg-white dark:bg-slate-700 text-gray-500 dark:text-gray-50">
+                  <div className="px-4 py-2">
+                    <h3 className="font-semibold text-gray-700 dark:text-gray-100 flex flex-row items-center">
+                      {title}
+                    </h3>
+                  </div>
+                  <div className="bg-gray-50 dark:bg-slate-600 px-4 py-3">
+                    {children}
+                  </div>
+                  <div className="flex flex-row justify-between">
+                    <ActionButton
+                      onClick={() => close()}
+                      appearance="outlined"
+                      className="m-2"
+                      type="button"
+                      size="xs"
+                    >
+                      Cancel
+                    </ActionButton>
+                    {!!revokeUris?.length && (
+                      <ActionButton
+                        disabled={revoke.isLoading}
+                        appearance="negative"
+                        className="m-2"
+                        type="button"
+                        size="xs"
+                        onClick={() => revoke.mutate(revokeUris)}
+                      >
+                        {revoke.isLoading ? 'Revoking...' : 'Yes, Revoke'}
+                      </ActionButton>
+                    )}
+                    {!!grantVerifications.length && (
+                      <ActionButton
+                        disabled={grant.isLoading}
+                        appearance="primary"
+                        className="m-2"
+                        type="button"
+                        size="xs"
+                        onClick={() => grant.mutate(grantVerifications)}
+                      >
+                        {grant.isLoading ? 'Verifying user...' : 'Yes, Verify'}
+                      </ActionButton>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </PopoverPanel>
+          </Transition>
+        </>
+      )}
+    </Popover>
+  )
+}

--- a/components/verification/ActionButton.tsx
+++ b/components/verification/ActionButton.tsx
@@ -77,23 +77,24 @@ export const VerificationActionButton = ({
 }) => {
   const { verifierDid } = useServerConfig()
   // Revocation is only allowed when there is a verification record by the issuer that is configured with the ozone agent
-  const revocableVerificationUri = profile.verification?.verifications?.find(
-    (v) => v.issuer == verifierDid,
-  )?.uri
+  const revocableVerificationUris = profile.verification?.verifications
+    ?.filter((v) => v.issuer == verifierDid)
+    ?.map((v) => v.uri)
+  const hasRevocableVerification = !!revocableVerificationUris?.length
 
   return (
     <VerificationActionPopup
       buttonText={
-        revocableVerificationUri ? 'Revoke Verification' : 'Verify User'
+        hasRevocableVerification ? 'Revoke Verification' : 'Verify User'
       }
       title={
-        revocableVerificationUri
+        hasRevocableVerification
           ? `Revoke Verification?`
           : `Verify ${profile.displayName || profile.handle}?`
       }
-      revokeUris={revocableVerificationUri ? [revocableVerificationUri] : []}
+      revokeUris={hasRevocableVerification ? revocableVerificationUris : []}
       grantVerifications={
-        !revocableVerificationUri
+        !hasRevocableVerification
           ? [
               {
                 subject: did,
@@ -104,7 +105,7 @@ export const VerificationActionButton = ({
           : []
       }
     >
-      {revocableVerificationUri ? (
+      {hasRevocableVerification ? (
         <div>
           You have already verified this user. Do you want to revoke the
           verification record?

--- a/components/verification/ActionButton.tsx
+++ b/components/verification/ActionButton.tsx
@@ -1,6 +1,9 @@
 import { ActionButton } from '@/common/buttons'
 import { usePermission, useServerConfig } from '@/shell/ConfigurationContext'
-import { AppBskyActorDefs, ToolsOzoneVerificationGrant } from '@atproto/api'
+import {
+  AppBskyActorDefs,
+  ToolsOzoneVerificationGrantVerifications,
+} from '@atproto/api'
 import {
   Popover,
   PopoverButton,
@@ -20,7 +23,8 @@ export const BulkVerificationActionButton = ({
   subjects?: WorkspaceListData
 }) => {
   const { verifierDid } = useServerConfig()
-  const grantVerifications: ToolsOzoneVerificationGrant.VerificationInput[] = []
+  const grantVerifications: ToolsOzoneVerificationGrantVerifications.VerificationInput[] =
+    []
   const revokeUris: string[] = []
 
   Object.values(subjects || {}).map((sub) => {
@@ -135,7 +139,7 @@ const VerificationActionPopup = ({
   title: string
   children?: React.ReactNode
   revokeUris?: string[]
-  grantVerifications: ToolsOzoneVerificationGrant.VerificationInput[]
+  grantVerifications: ToolsOzoneVerificationGrantVerifications.VerificationInput[]
 }) => {
   const canVerify = usePermission('canVerify')
   const { revoke, grant } = useVerifier()

--- a/components/verification/Badge.tsx
+++ b/components/verification/Badge.tsx
@@ -1,0 +1,74 @@
+import { AppBskyActorDefs } from '@atproto/api'
+import {
+  CheckCircleIcon as VerifiedIcon,
+  CheckBadgeIcon as VerifierIcon,
+} from '@heroicons/react/24/solid'
+import {
+  CheckCircleIcon as InvalidVerificationIcon,
+  CheckBadgeIcon as InvalidVerifierIcon,
+} from '@heroicons/react/24/outline'
+import { classNames } from '@/lib/util'
+
+const sizeClasNames = {
+  xs: 'h-3 w-3',
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+}
+
+const statusClassNames = {
+  valid: 'text-blue-600 dark:text-blue-500',
+  invalid: 'text-red-600 dark:text-red-200',
+}
+
+export const VerificationBadge = ({
+  profile,
+  size = 'md',
+  className,
+}: {
+  className?: string
+  size?: 'xs' | 'sm' | 'md' | 'lg'
+  profile?:
+    | AppBskyActorDefs.ProfileViewDetailed
+    | AppBskyActorDefs.ProfileViewBasic
+}) => {
+  if (!profile || !profile?.verification) return null
+  const { verification } = profile
+  const classes = classNames(className, 'inline-block', sizeClasNames[size])
+
+  if (verification?.trustedVerifierStatus === 'valid') {
+    return (
+      <VerifierIcon
+        className={classNames(classes, statusClassNames.valid)}
+        title="This user is a trusted verifier"
+      />
+    )
+  }
+
+  if (verification?.trustedVerifierStatus === 'invalid') {
+    return (
+      <InvalidVerifierIcon
+        className={classNames(classes, statusClassNames.invalid)}
+        title="This user is no longer a trusted a verifier"
+      />
+    )
+  }
+
+  if (verification?.verifiedStatus === 'valid') {
+    return (
+      <VerifiedIcon
+        className={classNames(classes, statusClassNames.valid)}
+        title="This is a verified user"
+      />
+    )
+  }
+
+  if (verification?.verifiedStatus === 'valid') {
+    return (
+      <InvalidVerificationIcon
+        className={classNames(classes, statusClassNames.invalid)}
+        title="This user has an invalid verification"
+      />
+    )
+  }
+}

--- a/components/verification/FilterPanel.tsx
+++ b/components/verification/FilterPanel.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useEffect, FormEvent, useState } from 'react'
+import { VerificationFilterOptions } from './useVerificationList'
+import { FormLabel, Input, Select } from '@/common/forms'
+import { ActionButton } from '@/common/buttons'
+
+interface VerificationFilterPanelProps {
+  filters: VerificationFilterOptions
+  onApplyFilters: (filters: VerificationFilterOptions) => void
+  onResetFilters: () => void
+}
+
+export const VerificationFilterPanel = ({
+  filters,
+  onApplyFilters,
+  onResetFilters,
+}: VerificationFilterPanelProps) => {
+  const [formState, setFormState] = useState({
+    subjectsInput: (filters.subjects || []).join(', '),
+    issuersInput: (filters.issuers || []).join(', '),
+    isRevoked:
+      filters.isRevoked === undefined ? 'any' : filters.isRevoked.toString(),
+    createdAfter: filters.createdAfter || '',
+    createdBefore: filters.createdBefore || '',
+  })
+
+  useEffect(() => {
+    setFormState({
+      subjectsInput: (filters.subjects || []).join(', '),
+      issuersInput: (filters.issuers || []).join(', '),
+      isRevoked:
+        filters.isRevoked === undefined ? 'any' : filters.isRevoked.toString(),
+      createdAfter: filters.createdAfter || '',
+      createdBefore: filters.createdBefore || '',
+    })
+  }, [filters, setFormState])
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = e.target
+    setFormState((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+
+    const subjects = formState.subjectsInput
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+
+    const issuers = formState.issuersInput
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+
+    const newFilters: VerificationFilterOptions = {
+      subjects: subjects.length > 0 ? subjects : undefined,
+      issuers: issuers.length > 0 ? issuers : undefined,
+      isRevoked:
+        formState.isRevoked === 'any'
+          ? undefined
+          : formState.isRevoked === 'true',
+      createdAfter: formState.createdAfter || undefined,
+      createdBefore: formState.createdBefore || undefined,
+    }
+
+    onApplyFilters(newFilters)
+  }
+
+  const handleReset = () => {
+    setFormState({
+      subjectsInput: '',
+      issuersInput: '',
+      isRevoked: 'any',
+      createdAfter: '',
+      createdBefore: '',
+    })
+
+    onResetFilters()
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="border-t border-b border-gray-200 dark:border-gray-700 py-2 my-1"
+    >
+      <FormLabel label="Subjects" className="mt-2">
+        <Input
+          type="text"
+          name="subjectsInput"
+          className="w-full"
+          value={formState.subjectsInput}
+          onChange={handleInputChange}
+          placeholder="Comma separated list of subject dids"
+        />
+      </FormLabel>
+
+      <FormLabel label="Issuers" className="mt-2">
+        <Input
+          type="text"
+          name="issuersInput"
+          className="w-full"
+          value={formState.issuersInput}
+          onChange={handleInputChange}
+          placeholder="Comma separated list of issuer dids"
+        />
+      </FormLabel>
+
+      {/* Revocation Status */}
+      <FormLabel label="Revocation Status" className="mt-2">
+        <Select
+          name="isRevoked"
+          value={formState.isRevoked}
+          onChange={handleInputChange}
+        >
+          <option value="any">Any</option>
+          <option value="true">Revoked</option>
+          <option value="false">Not Revoked</option>
+        </Select>
+      </FormLabel>
+
+      <div className="flex flex-row gap-3">
+        <FormLabel
+          label="Created After"
+          htmlFor="createdAfter"
+          className="flex-1 mt-2"
+        >
+          <Input
+            type="datetime-local"
+            id="createdAfter"
+            name="createdAfter"
+            className="block w-full dark:[color-scheme:dark]"
+            value={formState.createdAfter}
+            onChange={handleInputChange}
+            autoComplete="off"
+          />
+        </FormLabel>
+
+        <FormLabel
+          label="Created Before"
+          htmlFor="createdBefore"
+          className="flex-1 mt-2"
+        >
+          <Input
+            type="datetime-local"
+            id="createdBefore"
+            name="createdBefore"
+            className="block w-full dark:[color-scheme:dark]"
+            value={formState.createdBefore}
+            onChange={handleInputChange}
+            autoComplete="off"
+            max={new Date().toISOString().split('T')[0]} // Set max to today
+          />
+        </FormLabel>
+      </div>
+
+      {/* Action buttons */}
+      <div className="mt-3 flex gap-2">
+        <ActionButton type="submit" size="sm" appearance="primary">
+          Apply Filters
+        </ActionButton>
+
+        <ActionButton
+          type="button"
+          size="sm"
+          appearance="outlined"
+          onClick={handleReset}
+        >
+          Reset Filters
+        </ActionButton>
+      </div>
+    </form>
+  )
+}

--- a/components/verification/FilterPanel.tsx
+++ b/components/verification/FilterPanel.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { FormEvent } from 'react'
+import { useEffect, FormEvent, useState } from 'react'
 import { VerificationFilterOptions } from './useVerificationList'
 import { FormLabel, Input, Select } from '@/common/forms'
 import { ActionButton } from '@/common/buttons'
-import { useSyncedState } from '@/lib/useSyncedState'
 
 interface VerificationFilterPanelProps {
   filters: VerificationFilterOptions
@@ -17,7 +16,7 @@ export const VerificationFilterPanel = ({
   onApplyFilters,
   onResetFilters,
 }: VerificationFilterPanelProps) => {
-  const [formState, setFormState] = useSyncedState({
+  const [formState, setFormState] = useState({
     subjectsInput: (filters.subjects || []).join(', '),
     issuersInput: (filters.issuers || []).join(', '),
     isRevoked:
@@ -25,6 +24,17 @@ export const VerificationFilterPanel = ({
     createdAfter: filters.createdAfter || '',
     createdBefore: filters.createdBefore || '',
   })
+
+  useEffect(() => {
+    setFormState({
+      subjectsInput: (filters.subjects || []).join(', '),
+      issuersInput: (filters.issuers || []).join(', '),
+      isRevoked:
+        filters.isRevoked === undefined ? 'any' : filters.isRevoked.toString(),
+      createdAfter: filters.createdAfter || '',
+      createdBefore: filters.createdBefore || '',
+    })
+  }, [filters])
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,

--- a/components/verification/FilterPanel.tsx
+++ b/components/verification/FilterPanel.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect, FormEvent, useState } from 'react'
+import { FormEvent } from 'react'
 import { VerificationFilterOptions } from './useVerificationList'
 import { FormLabel, Input, Select } from '@/common/forms'
 import { ActionButton } from '@/common/buttons'
+import { useSyncedState } from '@/lib/useSyncedState'
 
 interface VerificationFilterPanelProps {
   filters: VerificationFilterOptions
@@ -16,7 +17,7 @@ export const VerificationFilterPanel = ({
   onApplyFilters,
   onResetFilters,
 }: VerificationFilterPanelProps) => {
-  const [formState, setFormState] = useState({
+  const [formState, setFormState] = useSyncedState({
     subjectsInput: (filters.subjects || []).join(', '),
     issuersInput: (filters.issuers || []).join(', '),
     isRevoked:
@@ -24,17 +25,6 @@ export const VerificationFilterPanel = ({
     createdAfter: filters.createdAfter || '',
     createdBefore: filters.createdBefore || '',
   })
-
-  useEffect(() => {
-    setFormState({
-      subjectsInput: (filters.subjects || []).join(', '),
-      issuersInput: (filters.issuers || []).join(', '),
-      isRevoked:
-        filters.isRevoked === undefined ? 'any' : filters.isRevoked.toString(),
-      createdAfter: filters.createdAfter || '',
-      createdBefore: filters.createdBefore || '',
-    })
-  }, [filters, setFormState])
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,

--- a/components/verification/List.tsx
+++ b/components/verification/List.tsx
@@ -1,0 +1,47 @@
+import { ProfileCard } from '@/repositories/AccountView'
+import { isValidProfileViewDetailed } from '@/repositories/helpers'
+import { ToolsOzoneVerificationDefs } from '@atproto/api'
+import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+
+const VerificationCard = ({
+  verification,
+}: {
+  verification: ToolsOzoneVerificationDefs.VerificationView
+}) => {
+  return (
+    <div>
+      <div className="flex flex-row gap-2">
+        <div>
+          <CheckBadgeIcon className="w-6 h-6" />
+        </div>
+        <div>
+          <p>{verification.displayName}</p>
+          <p>{verification.handle}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const VerificationList = ({
+  verifications,
+}: {
+  verifications: ToolsOzoneVerificationDefs.VerificationView[]
+}) => {
+  return (
+    <div className="mt-2">
+      {verifications.map((verification) => {
+        const { subjectProfile, uri } = verification
+        return (
+          <div key={uri}>
+            {isValidProfileViewDetailed(subjectProfile) ? (
+              <ProfileCard profile={subjectProfile} />
+            ) : (
+              <div>Profile not found</div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/verification/List.tsx
+++ b/components/verification/List.tsx
@@ -1,25 +1,69 @@
 import { ProfileCard } from '@/repositories/AccountView'
-import { isValidProfileViewDetailed } from '@/repositories/helpers'
+import {
+  isValidProfileViewDetailed,
+  isValidRepoViewDetailed,
+} from '@/repositories/helpers'
 import { ToolsOzoneVerificationDefs } from '@atproto/api'
 import { CheckBadgeIcon } from '@heroicons/react/24/solid'
+import { getVerificationIssuerHandle } from './utils'
+import { Card } from '@/common/Card'
+import { SubjectOverview } from '@/reports/SubjectOverview'
+import { RepoCardView } from '@/common/RecordCard'
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
 
 const VerificationCard = ({
   verification,
 }: {
   verification: ToolsOzoneVerificationDefs.VerificationView
 }) => {
+  const {
+    subject,
+    handle,
+    displayName,
+    subjectRepo,
+    subjectProfile,
+    issuer,
+    createdAt,
+  } = verification
+  const isRepoView = isValidRepoViewDetailed(subjectRepo)
+  const isProfileView = isValidProfileViewDetailed(subjectProfile)
+
   return (
-    <div>
+    <Card className="mb-3 text-sm px-3">
       <div className="flex flex-row gap-2">
         <div>
-          <CheckBadgeIcon className="w-6 h-6" />
-        </div>
-        <div>
-          <p>{verification.displayName}</p>
-          <p>{verification.handle}</p>
+          <div className="flex flex-row items-center">
+            <span className="mr-1">{displayName}</span>
+            <SubjectOverview
+              subject={{ did: subject }}
+              subjectRepoHandle={handle}
+              withTruncation={true}
+            />
+          </div>
+          <div className="flex flex-row items-center">
+            Verified{' '}
+            {createdAt && `At ${dateFormatter.format(new Date(createdAt))} `}
+            <span className="mx-1">By</span>
+            <SubjectOverview
+              subject={{ did: issuer }}
+              subjectRepoHandle={getVerificationIssuerHandle(verification)}
+              withTruncation={true}
+            />
+          </div>
         </div>
       </div>
-    </div>
+      <div className="border-t mt-2 pt-2 border-gray-200 dark:border-gray-700">
+        <RepoCardView
+          did={subject}
+          repo={isRepoView ? subjectRepo : undefined}
+          profile={isProfileView ? subjectProfile : undefined}
+        />
+      </div>
+    </Card>
   )
 }
 
@@ -31,14 +75,9 @@ export const VerificationList = ({
   return (
     <div className="mt-2">
       {verifications.map((verification) => {
-        const { subjectProfile, uri } = verification
         return (
-          <div key={uri}>
-            {isValidProfileViewDetailed(subjectProfile) ? (
-              <ProfileCard profile={subjectProfile} />
-            ) : (
-              <div>Profile not found</div>
-            )}
+          <div key={verification.uri}>
+            <VerificationCard verification={verification} />
           </div>
         )
       })}

--- a/components/verification/List.tsx
+++ b/components/verification/List.tsx
@@ -7,6 +7,7 @@ import { getVerificationIssuerHandle } from './utils'
 import { Card } from '@/common/Card'
 import { SubjectOverview } from '@/reports/SubjectOverview'
 import { RepoCardView } from '@/common/RecordCard'
+import VerificationErrorBoundary from './VerificationError'
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   dateStyle: 'medium',
@@ -28,11 +29,14 @@ const VerificationCard = ({
     createdAt,
     revokedAt,
     revokedBy,
-    uri,
   } = verification
   const isRepoView = isValidRepoViewDetailed(subjectRepo)
   const isProfileView = isValidProfileViewDetailed(subjectProfile)
   const revokedByNonIssuer = revokedBy && revokedBy !== issuer
+
+  if (handle.includes('ar')) {
+    throw new Error('Invalid handle')
+  }
 
   return (
     <Card className="mb-3 text-sm px-3">
@@ -85,7 +89,9 @@ export const VerificationList = ({
       {verifications.map((verification) => {
         return (
           <div key={verification.uri}>
-            <VerificationCard verification={verification} />
+            <VerificationErrorBoundary uri={verification.uri}>
+              <VerificationCard verification={verification} />
+            </VerificationErrorBoundary>
           </div>
         )
       })}

--- a/components/verification/List.tsx
+++ b/components/verification/List.tsx
@@ -1,10 +1,8 @@
-import { ProfileCard } from '@/repositories/AccountView'
 import {
   isValidProfileViewDetailed,
   isValidRepoViewDetailed,
 } from '@/repositories/helpers'
 import { ToolsOzoneVerificationDefs } from '@atproto/api'
-import { CheckBadgeIcon } from '@heroicons/react/24/solid'
 import { getVerificationIssuerHandle } from './utils'
 import { Card } from '@/common/Card'
 import { SubjectOverview } from '@/reports/SubjectOverview'

--- a/components/verification/List.tsx
+++ b/components/verification/List.tsx
@@ -26,9 +26,13 @@ const VerificationCard = ({
     subjectProfile,
     issuer,
     createdAt,
+    revokedAt,
+    revokedBy,
+    uri,
   } = verification
   const isRepoView = isValidRepoViewDetailed(subjectRepo)
   const isProfileView = isValidProfileViewDetailed(subjectProfile)
+  const revokedByNonIssuer = revokedBy && revokedBy !== issuer
 
   return (
     <Card className="mb-3 text-sm px-3">
@@ -52,6 +56,12 @@ const VerificationCard = ({
               withTruncation={true}
             />
           </div>
+          {!!revokedAt && (
+            <div className="text-red-500 dark:text-red-300">
+              Revoked at {dateFormatter.format(new Date(revokedAt))}{' '}
+              {revokedByNonIssuer && ` by ${revokedBy}`}
+            </div>
+          )}
         </div>
       </div>
       <div className="border-t mt-2 pt-2 border-gray-200 dark:border-gray-700">

--- a/components/verification/VerificationError.tsx
+++ b/components/verification/VerificationError.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Card } from '@/common/Card'
+import { Component, ReactNode } from 'react'
+
+interface VerificationErrorBoundaryProps {
+  children: ReactNode
+  uri?: string
+}
+
+class VerificationErrorBoundary extends Component<
+  VerificationErrorBoundaryProps,
+  { hasError: boolean }
+> {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Verification item error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Card className="mb-3 text-sm px-3 text-red-500 dark:text-red-300">
+          Something went wrong when showing verification.
+          <br />
+          {this.props.uri}
+        </Card>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default VerificationErrorBoundary

--- a/components/verification/useVerificationList.tsx
+++ b/components/verification/useVerificationList.tsx
@@ -1,29 +1,181 @@
 import { useLabelerAgent, useServerConfig } from '@/shell/ConfigurationContext'
 import { useInfiniteQuery } from '@tanstack/react-query'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+export type VerificationFilterOptions = {
+  subjects?: string[]
+  issuers?: string[]
+  isRevoked?: boolean
+  createdAfter?: string
+  createdBefore?: string
+}
+
+// Parse query parameters into filter options
+const parseQueryToFilters = (
+  searchParams: URLSearchParams,
+): VerificationFilterOptions => {
+  const filters: VerificationFilterOptions = {}
+
+  const subjects = searchParams.get('subjects')
+  if (subjects) {
+    filters.subjects = subjects
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  const issuers = searchParams.get('issuers')
+  if (issuers) {
+    filters.issuers = issuers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  const isRevoked = searchParams.get('isRevoked')
+  if (isRevoked !== null) {
+    if (isRevoked === 'true') filters.isRevoked = true
+    else if (isRevoked === 'false') filters.isRevoked = false
+  }
+
+  // Parse date range
+  const createdAfter = searchParams.get('createdAfter')
+  if (createdAfter) {
+    filters.createdAfter = createdAfter
+  }
+
+  const createdBefore = searchParams.get('createdBefore')
+  if (createdBefore) {
+    filters.createdBefore = createdBefore
+  }
+
+  return filters
+}
+
+const emptyFilters: VerificationFilterOptions = {
+  subjects: [],
+  issuers: [],
+  isRevoked: undefined,
+  createdAfter: undefined,
+  createdBefore: undefined,
+}
+
+export function useVerificationFilter(
+  onFilterChange?: (filters: VerificationFilterOptions) => void,
+) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const [initializedFromUrl, setInitializedFromUrl] = useState(false)
+
+  const [filters, setFilters] =
+    useState<VerificationFilterOptions>(emptyFilters)
+
+  useEffect(() => {
+    if (!initializedFromUrl) {
+      const parsedFilters = parseQueryToFilters(searchParams)
+      setFilters(parsedFilters)
+      setInitializedFromUrl(true)
+
+      // Notify parent component if needed
+      if (onFilterChange) {
+        onFilterChange(parsedFilters)
+      }
+    }
+  }, [searchParams, initializedFromUrl, onFilterChange])
+
+  const applyFilters = (newFilters: VerificationFilterOptions) => {
+    setFilters(newFilters)
+
+    const newSearchParams = new URLSearchParams(searchParams.toString())
+
+    newSearchParams.delete('subjects')
+    newSearchParams.delete('issuers')
+    newSearchParams.delete('isRevoked')
+    newSearchParams.delete('createdAfter')
+    newSearchParams.delete('createdBefore')
+
+    if (newFilters.subjects && newFilters.subjects.length > 0) {
+      newSearchParams.set('subjects', newFilters.subjects.join(','))
+    }
+
+    if (newFilters.issuers && newFilters.issuers.length > 0) {
+      newSearchParams.set('issuers', newFilters.issuers.join(','))
+    }
+
+    if (newFilters.isRevoked !== undefined) {
+      newSearchParams.set('isRevoked', newFilters.isRevoked.toString())
+    }
+
+    if (newFilters.createdAfter) {
+      newSearchParams.set('createdAfter', newFilters.createdAfter)
+    }
+
+    if (newFilters.createdBefore) {
+      newSearchParams.set('createdBefore', newFilters.createdBefore)
+    }
+
+    router.push(`?${newSearchParams.toString()}`)
+
+    if (onFilterChange) {
+      onFilterChange(newFilters)
+    }
+  }
+
+  const resetFilters = () => {
+    setFilters(emptyFilters)
+
+    const newSearchParams = new URLSearchParams(searchParams.toString())
+
+    newSearchParams.delete('subjects')
+    newSearchParams.delete('issuers')
+    newSearchParams.delete('isRevoked')
+    newSearchParams.delete('createdAfter')
+    newSearchParams.delete('createdBefore')
+
+    router.push(`?${newSearchParams.toString()}`)
+
+    if (onFilterChange) {
+      onFilterChange(emptyFilters)
+    }
+  }
+
+  return {
+    filters,
+    applyFilters,
+    resetFilters,
+  }
+}
 
 export const useVerificationList = ({
+  subjects,
   issuers,
   isRevoked,
   createdAfter,
   createdBefore,
-}: {
-  issuers?: string[]
-  isRevoked?: boolean
-  createdBefore?: string
-  createdAfter?: string
-}) => {
+}: VerificationFilterOptions) => {
   const serverConfig = useServerConfig()
   const labelerAgent = useLabelerAgent()
   return useInfiniteQuery({
     enabled: !!serverConfig.verifierDid,
-    queryKey: ['verification-list', issuers, createdBefore, createdAfter],
-    queryFn: async () => {
+    queryKey: [
+      'verification-list',
+      issuers,
+      createdBefore,
+      createdAfter,
+      subjects,
+      isRevoked,
+    ],
+    queryFn: async ({ pageParam }) => {
       const { data } = await labelerAgent.tools.ozone.verification.list({
-        issuers,
+        issuers: issuers,
         isRevoked,
         createdAfter,
         createdBefore,
         limit: 100,
+        subjects,
+        cursor: pageParam,
       })
       return data
     },

--- a/components/verification/useVerificationList.tsx
+++ b/components/verification/useVerificationList.tsx
@@ -168,7 +168,7 @@ export const useVerificationList = ({
       isRevoked,
     ],
     queryFn: async ({ pageParam }) => {
-      const { data } = await labelerAgent.tools.ozone.verification.list({
+      const { data } = await labelerAgent.tools.ozone.verification.listVerifications({
         issuers: issuers,
         isRevoked,
         createdAfter,

--- a/components/verification/useVerificationList.tsx
+++ b/components/verification/useVerificationList.tsx
@@ -1,0 +1,32 @@
+import { useLabelerAgent, useServerConfig } from '@/shell/ConfigurationContext'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+export const useVerificationList = ({
+  issuers,
+  isRevoked,
+  createdAfter,
+  createdBefore,
+}: {
+  issuers?: string[]
+  isRevoked?: boolean
+  createdBefore?: string
+  createdAfter?: string
+}) => {
+  const serverConfig = useServerConfig()
+  const labelerAgent = useLabelerAgent()
+  return useInfiniteQuery({
+    enabled: !!serverConfig.verifierDid,
+    queryKey: ['verification-list', issuers, createdBefore, createdAfter],
+    queryFn: async () => {
+      const { data } = await labelerAgent.tools.ozone.verification.list({
+        issuers,
+        isRevoked,
+        createdAfter,
+        createdBefore,
+        limit: 100,
+      })
+      return data
+    },
+    getNextPageParam: (lastPage) => lastPage.cursor,
+  })
+}

--- a/components/verification/useVerifier.tsx
+++ b/components/verification/useVerifier.tsx
@@ -1,0 +1,95 @@
+import { chunkArray, pluralize } from '@/lib/util'
+import { useLabelerAgent } from '@/shell/ConfigurationContext'
+import { ToolsOzoneVerificationGrant } from '@atproto/api'
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'react-toastify'
+
+export const useVerifier = () => {
+  const labelerAgent = useLabelerAgent()
+
+  const grant = useMutation({
+    mutationFn: async (
+      verifications: ToolsOzoneVerificationGrant.VerificationInput[],
+    ) => {
+      let verified = 0
+      let failed = 0
+
+      for (const chunk of chunkArray(verifications, 100)) {
+        const { data } = await labelerAgent.tools.ozone.verification.grant({
+          verifications: chunk,
+        })
+
+        for (const verification of data.verifications) {
+          if (
+            verification.$type ===
+            'tools.ozone.verification.defs#verificationView'
+          ) {
+            verified++
+          } else {
+            failed++
+          }
+        }
+      }
+
+      return { verified, failed }
+    },
+    onSuccess: ({ verified, failed }) => {
+      const text: string[] = []
+      if (failed > 0) {
+        text.push(`${pluralize(failed, 'user')} failed to verify`)
+      }
+      if (verified > 0) {
+        text.push(`${pluralize(verified, 'user')} verified`)
+      }
+      toast.success(text.join(','))
+    },
+    onError: (err) => {
+      toast.error(`Error verifying user: ${(err as Error).message}`)
+    },
+  })
+
+  const revoke = useMutation({
+    mutationFn: async (uris: string[]) => {
+      const data: {
+        revokedVerifications: string[]
+        failedRevocations: string[]
+      } = {
+        revokedVerifications: [],
+        failedRevocations: [],
+      }
+
+      for (const chunk of chunkArray(uris, 100)) {
+        const { data: chunkData } =
+          await labelerAgent.tools.ozone.verification.revoke({
+            uris: chunk,
+          })
+        data.revokedVerifications.push(...chunkData.revokedVerifications)
+        data.failedRevocations.push(...chunkData.failedRevocations)
+      }
+
+      return data
+    },
+    onSuccess: ({ revokedVerifications, failedRevocations }) => {
+      const text: string[] = []
+      if (failedRevocations.length > 0) {
+        text.push(
+          `${pluralize(
+            failedRevocations.length,
+            'verification',
+          )} failed to revoke`,
+        )
+      }
+      if (revokedVerifications.length > 0) {
+        text.push(
+          `${pluralize(revokedVerifications.length, 'verification')} revoked`,
+        )
+      }
+      toast.success(text.join(', '))
+    },
+    onError: (err) => {
+      toast.error(`Error revoking verifications: ${(err as Error).message}`)
+    },
+  })
+
+  return { grant, revoke }
+}

--- a/components/verification/useVerifier.tsx
+++ b/components/verification/useVerifier.tsx
@@ -15,20 +15,12 @@ export const useVerifier = () => {
       let failed = 0
 
       for (const chunk of chunkArray(verifications, 100)) {
-        const { data } = await labelerAgent.tools.ozone.verification.grant({
-          verifications: chunk,
-        })
-
-        for (const verification of data.verifications) {
-          if (
-            verification.$type ===
-            'tools.ozone.verification.defs#verificationView'
-          ) {
-            verified++
-          } else {
-            failed++
-          }
-        }
+        const { data } =
+          await labelerAgent.tools.ozone.verification.grantVerifications({
+            verifications: chunk,
+          })
+        verified += data.verifications.length
+        failed += data.failedVerifications.length
       }
 
       return { verified, failed }
@@ -60,11 +52,13 @@ export const useVerifier = () => {
 
       for (const chunk of chunkArray(uris, 100)) {
         const { data: chunkData } =
-          await labelerAgent.tools.ozone.verification.revoke({
+          await labelerAgent.tools.ozone.verification.revokeVerifications({
             uris: chunk,
           })
         data.revokedVerifications.push(...chunkData.revokedVerifications)
-        data.failedRevocations.push(...chunkData.failedRevocations)
+        data.failedRevocations.push(
+          ...chunkData.failedRevocations.map((item) => item.uri),
+        )
       }
 
       return data

--- a/components/verification/useVerifier.tsx
+++ b/components/verification/useVerifier.tsx
@@ -1,6 +1,6 @@
 import { chunkArray, pluralize } from '@/lib/util'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { ToolsOzoneVerificationGrant } from '@atproto/api'
+import { ToolsOzoneVerificationGrantVerifications } from '@atproto/api'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'react-toastify'
 
@@ -9,7 +9,7 @@ export const useVerifier = () => {
 
   const grant = useMutation({
     mutationFn: async (
-      verifications: ToolsOzoneVerificationGrant.VerificationInput[],
+      verifications: ToolsOzoneVerificationGrantVerifications.VerificationInput[],
     ) => {
       let verified = 0
       let failed = 0

--- a/components/verification/utils.ts
+++ b/components/verification/utils.ts
@@ -1,0 +1,18 @@
+import {
+  isValidProfileViewDetailed,
+  isValidRepoViewDetailed,
+} from '@/repositories/helpers'
+import { ToolsOzoneVerificationDefs } from '@atproto/api'
+
+export const getVerificationIssuerHandle = (
+  verification: ToolsOzoneVerificationDefs.VerificationView,
+) => {
+  const { issuerRepo, issuerProfile, issuer } = verification
+  if (isValidRepoViewDetailed(issuerRepo)) {
+    return issuerRepo.handle
+  }
+  if (issuerProfile && isValidProfileViewDetailed(issuerProfile)) {
+    return issuerProfile.handle
+  }
+  return issuer
+}

--- a/components/workspace/FilterSelector.tsx
+++ b/components/workspace/FilterSelector.tsx
@@ -49,6 +49,7 @@ const availableFilters: (Omit<WorkspaceFilterItem, 'value'> &
   { field: 'reviewState', operator: 'neq', text: 'Not In Review State' },
   { field: 'takendown', operator: 'eq', text: 'Is Takendown' },
   { field: 'takendown', operator: 'neq', text: 'Not Takendown' },
+  { field: 'verifier', operator: 'eq', text: 'Verifier' },
 ]
 const booleanFields = ['emailConfirmed', 'accountDeactivated', 'takendown']
 const isBooleanFilter = (field: string) => booleanFields.includes(field)

--- a/components/workspace/FilterView.tsx
+++ b/components/workspace/FilterView.tsx
@@ -3,6 +3,11 @@ import { WorkspaceFilterItem } from './types'
 import { SubjectTag } from 'components/tags/SubjectTag'
 
 export const FilterView = ({ filter }: { filter: WorkspaceFilterItem }) => {
+  if (filter.field === 'verifier') {
+    return (
+      <div>{filter.operator === 'eq' ? 'Verified By' : 'Not Verified By'}</div>
+    )
+  }
   if (filter.field === 'tag') {
     return (
       <div>

--- a/components/workspace/List.tsx
+++ b/components/workspace/List.tsx
@@ -22,6 +22,7 @@ import { ModerationLabel } from '@/common/labels'
 import { WorkspaceExportPanel } from './ExportPanel'
 import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'
 import { isValidProfileViewDetailed } from '@/repositories/helpers'
+import { VerificationBadge } from 'components/verification/Badge'
 
 interface WorkspaceListProps {
   list: string[]
@@ -193,6 +194,7 @@ const ListItem = <ItemType extends string>({
   const displayLabels = isSubjectRecord
     ? itemData?.record?.labels
     : itemData?.repo?.labels
+  const hasValidProfile = isValidProfileViewDetailed(itemData?.profile)
 
   return (
     <Card key={item}>
@@ -219,14 +221,22 @@ const ListItem = <ItemType extends string>({
                 omitQueryParamsInLinks={['workspaceOpen']}
                 subjectRepoHandle={itemData.repo?.handle}
               />
-              {isValidProfileViewDetailed(itemData.profile) &&
-                (itemData.profile.followersCount || 0) >
-                  HIGH_PROFILE_FOLLOWER_THRESHOLD && (
-                  <StarIcon
-                    className="w-4 h-4 ml-1 text-orange-300"
-                    title={`High profile user with ${itemData.profile.followersCount} followers`}
+              {isValidProfileViewDetailed(itemData.profile) && (
+                <>
+                  {(itemData.profile.followersCount || 0) >
+                    HIGH_PROFILE_FOLLOWER_THRESHOLD && (
+                    <StarIcon
+                      className="w-4 h-4 ml-1 text-orange-300"
+                      title={`High profile user with ${itemData.profile.followersCount} followers`}
+                    />
+                  )}
+                  <VerificationBadge
+                    profile={itemData.profile}
+                    className="ml-1"
+                    size="sm"
                   />
-                )}
+                </>
+              )}
               {itemData.status && (
                 <ReviewStateIcon
                   subjectStatus={itemData.status}

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -421,7 +421,6 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                         setShowItemCreator={setShowItemCreator}
                         showActionForm={showActionForm}
                         workspaceList={workspaceList}
-                        getSelectedItems={getSelectedItems}
                       />
                     </div>
                   )}

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -193,11 +193,12 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
       : undefined
 
   const { data: workspaceList } = useWorkspaceList()
-  const { data: workspaceListStatuses } = useWorkspaceListData({
-    subjects: workspaceList || [],
-    // Make sure we aren't constantly refreshing the data unless the panel is open
-    enabled: props.open,
-  })
+  const { data: workspaceListStatuses, refetch: refetchWorkspaceListData } =
+    useWorkspaceListData({
+      subjects: workspaceList || [],
+      // Make sure we aren't constantly refreshing the data unless the panel is open
+      enabled: props.open,
+    })
 
   // on form submit
   const onFormSubmit = async (
@@ -421,6 +422,7 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                         setShowItemCreator={setShowItemCreator}
                         showActionForm={showActionForm}
                         workspaceList={workspaceList}
+                        onVerification={refetchWorkspaceListData}
                       />
                     </div>
                   )}

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -421,6 +421,7 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                         setShowItemCreator={setShowItemCreator}
                         showActionForm={showActionForm}
                         workspaceList={workspaceList}
+                        getSelectedItems={getSelectedItems}
                       />
                     </div>
                   )}

--- a/components/workspace/PanelActions.tsx
+++ b/components/workspace/PanelActions.tsx
@@ -65,7 +65,7 @@ export const WorkspacePanelActions = ({
         </ActionButton>
       )}
 
-      <BulkVerificationActionButton subjects={listData} size="xs" />
+      <BulkVerificationActionButton subjects={listData} />
 
       <ActionButton
         appearance="outlined"

--- a/components/workspace/PanelActions.tsx
+++ b/components/workspace/PanelActions.tsx
@@ -9,6 +9,7 @@ export const WorkspacePanelActions = ({
   handleRemoveSelected,
   handleEmptyWorkspace,
   handleFindCorrelation,
+  onVerification,
   setShowActionForm,
   setShowItemCreator,
   showActionForm,
@@ -18,6 +19,7 @@ export const WorkspacePanelActions = ({
   handleRemoveSelected: () => void
   handleEmptyWorkspace: () => void
   handleFindCorrelation?: () => void
+  onVerification?: () => void
   setShowActionForm: React.Dispatch<React.SetStateAction<boolean>>
   setShowItemCreator: React.Dispatch<React.SetStateAction<boolean>>
   showActionForm: boolean
@@ -65,7 +67,10 @@ export const WorkspacePanelActions = ({
         </ActionButton>
       )}
 
-      <BulkVerificationActionButton subjects={listData} />
+      <BulkVerificationActionButton
+        subjects={listData}
+        onVerification={onVerification}
+      />
 
       <ActionButton
         appearance="outlined"

--- a/components/workspace/PanelActions.tsx
+++ b/components/workspace/PanelActions.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from '@/common/CopyButton'
 import { NoSymbolIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/solid'
 import { WorkspaceFilterSelector } from './FilterSelector'
 import { WorkspaceListData } from './useWorkspaceListData'
+import { BulkVerificationActionButton } from 'components/verification/ActionButton'
 
 export const WorkspacePanelActions = ({
   handleRemoveSelected,
@@ -63,6 +64,8 @@ export const WorkspacePanelActions = ({
           Find correlation
         </ActionButton>
       )}
+
+      <BulkVerificationActionButton subjects={listData} size="xs" />
 
       <ActionButton
         appearance="outlined"

--- a/components/workspace/types.ts
+++ b/components/workspace/types.ts
@@ -2,6 +2,11 @@ export type DurationUnit = 'days' | 'weeks' | 'months' | 'years'
 
 export type WorkspaceFilterItem =
   | {
+      field: 'verifier'
+      operator: 'eq' | 'neq'
+      value: string
+    }
+  | {
       field: 'tag'
       operator: 'eq' | 'neq'
       value: string

--- a/components/workspace/utils.ts
+++ b/components/workspace/utils.ts
@@ -158,6 +158,12 @@ export const checkFilterMatchForWorkspaceItem = (
       return filter.operator === 'eq'
         ? !!data.status?.takendown
         : !data.status?.takendown
+    case 'verifier':
+      if (!isValidProfileViewDetailed(data.profile)) return false
+      const verification = data.profile?.verification?.verifications?.find(
+        (v) => v.issuer === filter.value && v.isValid,
+      )
+      return filter.operator === 'eq' ? !!verification : !verification
     default:
       return false
   }

--- a/components/workspace/utils.ts
+++ b/components/workspace/utils.ts
@@ -1,7 +1,7 @@
 import { CollectionId, EmbedTypes } from '@/reports/helpers/subject'
 import { pluralize } from '@/lib/util'
 import { DurationUnit, WorkspaceFilterItem } from './types'
-import { AppBskyActorDefs, ToolsOzoneModerationDefs } from '@atproto/api'
+import { ToolsOzoneModerationDefs } from '@atproto/api'
 import { addDays, addMonths, addWeeks, addYears } from 'date-fns'
 import { WorkspaceListData } from './useWorkspaceListData'
 import { HIGH_PROFILE_FOLLOWER_THRESHOLD } from '@/lib/constants'

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,6 +13,7 @@ export const PLC_DIRECTORY_URL =
     : 'https://plc.directory')
 
 export const QUEUE_CONFIG = process.env.NEXT_PUBLIC_QUEUE_CONFIG || '{}'
+export const OPT_IN_FEATURES = process.env.NEXT_PUBLIC_OPT_IN_FEATURES || '{}'
 
 export const QUEUE_SEED = process.env.NEXT_PUBLIC_QUEUE_SEED || ''
 
@@ -30,6 +31,7 @@ export const HANDLE_RESOLVER_URL =
 
 export const DM_DISABLE_TAG = 'chat-disabled'
 export const VIDEO_UPLOAD_DISABLE_TAG = 'video-upload-disabled'
+export const TRUSTED_VERIFIER_TAG = 'trusted-verifier'
 
 export const STARTER_PACK_OG_CARD_URL = `https://ogcard.cdn.bsky.app/start`
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,7 +13,6 @@ export const PLC_DIRECTORY_URL =
     : 'https://plc.directory')
 
 export const QUEUE_CONFIG = process.env.NEXT_PUBLIC_QUEUE_CONFIG || '{}'
-export const OPT_IN_FEATURES = process.env.NEXT_PUBLIC_OPT_IN_FEATURES || '{}'
 
 export const QUEUE_SEED = process.env.NEXT_PUBLIC_QUEUE_SEED || ''
 

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -6,6 +6,7 @@ export type ServerConfig = {
   blobDivert?: string
   chat?: string
   role?: ToolsOzoneServerGetConfig.ViewerConfig['role']
+  verifierDid?: string
   permissions: {
     canManageTemplates: boolean
     canTakedown: boolean
@@ -16,6 +17,7 @@ export type ServerConfig = {
     canTakedownFeedGenerators: boolean
     canDivertBlob: boolean
     canManageSets: boolean
+    canVerify: boolean
   }
 }
 
@@ -34,6 +36,7 @@ export const parseServerConfig = (
     appview: config.appview?.url,
     chat: config.chat?.url,
     role: config.viewer?.role,
+    verifierDid: config.verifierDid,
     permissions: {
       canManageTemplates: isModerator,
       canTakedown: !!config.pds?.url && isModerator,
@@ -44,6 +47,7 @@ export const parseServerConfig = (
       canTakedownFeedGenerators: isAdmin,
       canManageSets: isAdmin,
       canDivertBlob: !!config.blobDivert?.url && isModerator,
+      canVerify: !!config.verifierDid && isAdmin,
     },
   }
 }

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -29,6 +29,8 @@ export const parseServerConfig = (
   const isAdmin = config.viewer?.role === ToolsOzoneTeamDefs.ROLEADMIN
   const isModerator =
     isAdmin || config.viewer?.role === ToolsOzoneTeamDefs.ROLEMODERATOR
+  const isVerifier =
+    isAdmin || config.viewer?.role === ToolsOzoneTeamDefs.ROLEVERIFIER
 
   return {
     pds: config.pds?.url,
@@ -47,7 +49,7 @@ export const parseServerConfig = (
       canTakedownFeedGenerators: isAdmin,
       canManageSets: isAdmin,
       canDivertBlob: !!config.blobDivert?.url && isModerator,
-      canVerify: !!config.verifierDid && isAdmin,
+      canVerify: !!config.verifierDid && isVerifier,
     },
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    missingSuspenseWithCSRBailout: false,
-  },
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "0.15.3",
+    "@atproto/api": "0.15.5",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/service/package.json
+++ b/service/package.json
@@ -3,7 +3,7 @@
   "description": "Ozone service entrypoint",
   "main": "index.js",
   "dependencies": {
-    "@atproto/ozone": "0.1.88",
+    "@atproto/ozone": "0.1.108",
     "next": "15.2.4"
   }
 }

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -5,31 +5,31 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@atproto/api@npm:^0.14.9":
-  version: 0.14.9
-  resolution: "@atproto/api@npm:0.14.9"
+"@atproto/api@npm:^0.15.5":
+  version: 0.15.5
+  resolution: "@atproto/api@npm:0.15.5"
   dependencies:
-    "@atproto/common-web": "npm:^0.4.0"
-    "@atproto/lexicon": "npm:^0.4.8"
-    "@atproto/syntax": "npm:^0.3.4"
-    "@atproto/xrpc": "npm:^0.6.10"
+    "@atproto/common-web": "npm:^0.4.1"
+    "@atproto/lexicon": "npm:^0.4.10"
+    "@atproto/syntax": "npm:^0.4.0"
+    "@atproto/xrpc": "npm:^0.6.12"
     await-lock: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/e853a16183c9391401d82c2bdd3432e580fff4925a5d815d5ff50f62b1b11032c29200e199997cb6da6477fcde3602ce45698f8004eec653863461c073c20f8e
+  checksum: 10c0/9dfc4045b51170e26bcc25db9fb8421f8227fdfb799d1cc0da71cb4bb4f7bc04cc314b9b293087aa4846076b6aaac5621bfde9bf2211c452d65f58ed8dc1ad26
   languageName: node
   linkType: hard
 
-"@atproto/common-web@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@atproto/common-web@npm:0.4.0"
+"@atproto/common-web@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@atproto/common-web@npm:0.4.1"
   dependencies:
     graphemer: "npm:^1.4.0"
     multiformats: "npm:^9.9.0"
     uint8arrays: "npm:3.0.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/136c3d7ca600f73261f8ddeec5e0a542ac8affc1afc6c449612b3777f647bd67354c47d3746366f12a9bfefa51e438e661010d99b025b733bee6305898aa491a
+  checksum: 10c0/38036956d1cca4bc950321db74c7587f40df930cfe2f08ab84c1eabd8c7982fbb19af0622fee23ddd52329e223511fa7488db85c773d36fb944b6f8282a8f2af
   languageName: node
   linkType: hard
 
@@ -45,17 +45,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/common@npm:^0.4.8":
-  version: 0.4.8
-  resolution: "@atproto/common@npm:0.4.8"
+"@atproto/common@npm:^0.4.10":
+  version: 0.4.10
+  resolution: "@atproto/common@npm:0.4.10"
   dependencies:
-    "@atproto/common-web": "npm:^0.4.0"
+    "@atproto/common-web": "npm:^0.4.1"
     "@ipld/dag-cbor": "npm:^7.0.3"
     cbor-x: "npm:^1.5.1"
     iso-datestring-validator: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     pino: "npm:^8.21.0"
-  checksum: 10c0/895c38fe3faf757924fb4c805b6f02c345cb6d4d8d298183808cb2997fd0b0e53ba196cc1dfe8ead1e956e2e24b2cdb45a91ab444d9ee260233d495e5eeedacb
+  checksum: 10c0/0d72046d120fa8926b26ca6feb9497288f0428a3bb5a7736470055cbc38cbc79369c9ecb7fa1f969ca14f42e417c0ce06dc1fd61412f614033e64608f8ae6736
   languageName: node
   linkType: hard
 
@@ -83,41 +83,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/identity@npm:^0.4.6":
-  version: 0.4.6
-  resolution: "@atproto/identity@npm:0.4.6"
+"@atproto/identity@npm:^0.4.7":
+  version: 0.4.7
+  resolution: "@atproto/identity@npm:0.4.7"
   dependencies:
-    "@atproto/common-web": "npm:^0.4.0"
+    "@atproto/common-web": "npm:^0.4.1"
     "@atproto/crypto": "npm:^0.4.4"
-  checksum: 10c0/a94a3141918f3282481190d3ef5d804f6c9304d8e462ef41970661a33d1bd28704dcea00dfe0236b944de3797bc7a04f288db76b500f20b2f8200af9a174aec1
+  checksum: 10c0/d6b61dd9f02cd77c4b3e1d0db4e613cf73e9365cb7fd4d5a96cf6295b2ea6fcc122a7ed195dc7ddbefbc1b621a876d21ea3a99b96b5953d0b9b03a3dadf40f02
   languageName: node
   linkType: hard
 
-"@atproto/lexicon@npm:^0.4.8":
-  version: 0.4.8
-  resolution: "@atproto/lexicon@npm:0.4.8"
+"@atproto/lexicon@npm:^0.4.10":
+  version: 0.4.10
+  resolution: "@atproto/lexicon@npm:0.4.10"
   dependencies:
-    "@atproto/common-web": "npm:^0.4.0"
-    "@atproto/syntax": "npm:^0.3.4"
+    "@atproto/common-web": "npm:^0.4.1"
+    "@atproto/syntax": "npm:^0.4.0"
     iso-datestring-validator: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/cd6a1dd021accfa9f7866f192eaa7d59279740528b35f683b03148b6153dba6c5ce4e6541df4cb54cb4f96b9678a0bb221a62004b29e28d67d7cdbcd6bff978f
+  checksum: 10c0/c5cec77b02e07a586783afa87ea12a85c3c041eab3fe49df602c05e0900885781b8a19e10b61d7e8986eaea35a9540c24a0c7dd1a6b849da474072d38ce0d3ae
   languageName: node
   linkType: hard
 
-"@atproto/ozone@npm:0.1.88":
-  version: 0.1.88
-  resolution: "@atproto/ozone@npm:0.1.88"
+"@atproto/ozone@npm:0.1.108":
+  version: 0.1.108
+  resolution: "@atproto/ozone@npm:0.1.108"
   dependencies:
-    "@atproto/api": "npm:^0.14.9"
-    "@atproto/common": "npm:^0.4.8"
+    "@atproto/api": "npm:^0.15.5"
+    "@atproto/common": "npm:^0.4.10"
     "@atproto/crypto": "npm:^0.4.4"
-    "@atproto/identity": "npm:^0.4.6"
-    "@atproto/lexicon": "npm:^0.4.8"
-    "@atproto/syntax": "npm:^0.3.4"
-    "@atproto/xrpc": "npm:^0.6.10"
-    "@atproto/xrpc-server": "npm:^0.7.12"
+    "@atproto/identity": "npm:^0.4.7"
+    "@atproto/lexicon": "npm:^0.4.10"
+    "@atproto/syntax": "npm:^0.4.0"
+    "@atproto/xrpc": "npm:^0.6.12"
+    "@atproto/xrpc-server": "npm:^0.7.17"
     "@did-plc/lib": "npm:^0.0.1"
     compression: "npm:^1.7.4"
     cors: "npm:^2.8.5"
@@ -133,27 +133,26 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     uint8arrays: "npm:3.0.0"
     undici: "npm:^6.14.1"
-  bin:
-    ozone: dist/bin.js
-  checksum: 10c0/8f289b06648f6b8650c9126275dcd2d35b11fc57d7d535f85543240cbaaa6d23ce6ae00d8d594237fd7c52423887dff5888ad2b6daf6bf5e075210bcbb67613d
+    ws: "npm:^8.12.0"
+  checksum: 10c0/f43c56466e2cae6c1825e6520587a1b61852f1255cf496b9065bc84064cb6944981e54c3b00e0209cf806f8ac4dfdc0aa745cc63427a36ddd6386fcc8c39fd68
   languageName: node
   linkType: hard
 
-"@atproto/syntax@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "@atproto/syntax@npm:0.3.4"
-  checksum: 10c0/8aab98d0aa601268cd9a9d184228fea019f7149bc3a246fc73aab280c6bc910b35603bc278de3f36e470152f9163bf267822c98f9d01e74172ff459a6f33f0a4
+"@atproto/syntax@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@atproto/syntax@npm:0.4.0"
+  checksum: 10c0/a1d19bf7d5ea3b08380e8ca6b57db311db2bc7ec4733b88896578c950c57a86dc2f4b44ebcfd60d98eb44550f5c4ab36cc560618f19dc98ef61e849c945a3946
   languageName: node
   linkType: hard
 
-"@atproto/xrpc-server@npm:^0.7.12":
-  version: 0.7.12
-  resolution: "@atproto/xrpc-server@npm:0.7.12"
+"@atproto/xrpc-server@npm:^0.7.17":
+  version: 0.7.17
+  resolution: "@atproto/xrpc-server@npm:0.7.17"
   dependencies:
-    "@atproto/common": "npm:^0.4.8"
+    "@atproto/common": "npm:^0.4.10"
     "@atproto/crypto": "npm:^0.4.4"
-    "@atproto/lexicon": "npm:^0.4.8"
-    "@atproto/xrpc": "npm:^0.6.10"
+    "@atproto/lexicon": "npm:^0.4.10"
+    "@atproto/xrpc": "npm:^0.6.12"
     cbor-x: "npm:^1.5.1"
     express: "npm:^4.17.2"
     http-errors: "npm:^2.0.0"
@@ -162,17 +161,17 @@ __metadata:
     uint8arrays: "npm:3.0.0"
     ws: "npm:^8.12.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/76fe7d802aeff295b3207cd0791e25904658bb03e2d16c857ecce863046b4271030a6a2a110973f5daa2cb98a02d56d4367d289c07559436f36926c3e1078131
+  checksum: 10c0/58be0318a39a2645797ca10337c7cc3834ffa508f0648637ae0ae93e8da1f938eb2df585ea3d42ac290af91e9efec5a10fba67bd2fe95de2fde51e4882bcbd1b
   languageName: node
   linkType: hard
 
-"@atproto/xrpc@npm:^0.6.10":
-  version: 0.6.10
-  resolution: "@atproto/xrpc@npm:0.6.10"
+"@atproto/xrpc@npm:^0.6.12":
+  version: 0.6.12
+  resolution: "@atproto/xrpc@npm:0.6.12"
   dependencies:
-    "@atproto/lexicon": "npm:^0.4.8"
+    "@atproto/lexicon": "npm:^0.4.10"
     zod: "npm:^3.23.8"
-  checksum: 10c0/8526a539999e346625cb9639c4bb77a09407307d6c35df50b2184ca6f207454896b8305d8033f4b3cc59fb18b5642d28001826800d7cb1c8b88334ba7258fdd7
+  checksum: 10c0/06f62fd44ce6ef545bd1f422eb93b760e4ea8660990338a48ad65c6398e39d5900e43b7366a31ed1e36a2f1bb989b6e273fa11b0efd9ba6a95082cccf9204538
   languageName: node
   linkType: hard
 
@@ -1972,7 +1971,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone-service@workspace:."
   dependencies:
-    "@atproto/ozone": "npm:0.1.88"
+    "@atproto/ozone": "npm:0.1.108"
     next: "npm:15.2.4"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,9 +79,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/api@npm:0.15.3":
-  version: 0.15.3
-  resolution: "@atproto/api@npm:0.15.3"
+"@atproto/api@npm:0.15.5":
+  version: 0.15.5
+  resolution: "@atproto/api@npm:0.15.5"
   dependencies:
     "@atproto/common-web": "npm:^0.4.1"
     "@atproto/lexicon": "npm:^0.4.10"
@@ -91,7 +91,7 @@ __metadata:
     multiformats: "npm:^9.9.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/326c39266e0514aee5d1b4762fe14b9ebd7b681fac2165ec42306536e43eb6060bb5669d020042f4e93b92ee3867423ba378591d1a1791806354ac72b1499351
+  checksum: 10c0/9dfc4045b51170e26bcc25db9fb8421f8227fdfb799d1cc0da71cb4bb4f7bc04cc314b9b293087aa4846076b6aaac5621bfde9bf2211c452d65f58ed8dc1ad26
   languageName: node
   linkType: hard
 
@@ -7293,7 +7293,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone@workspace:."
   dependencies:
-    "@atproto/api": "npm:0.15.3"
+    "@atproto/api": "npm:0.15.5"
     "@atproto/oauth-client-browser": "npm:^0.2.0"
     "@atproto/oauth-types": "npm:^0.1.4"
     "@atproto/xrpc": "npm:^0.6.1"


### PR DESCRIPTION
This PR adds verification feature support to ozone UI.

A few bigger pieces in here are 

1. verification based filtering in workspace
2. granting and revoking verifications
3. viewing verification history
4. verification badge in all places where applicable

<img width="336" alt="Screenshot 2025-04-19 at 23 03 14" src="https://github.com/user-attachments/assets/357071ee-e1f5-4240-a957-7ea910cae806" />

> Workspace verification action popup

<img width="526" alt="Screenshot 2025-04-18 at 16 56 31" src="https://github.com/user-attachments/assets/7f975625-7639-4bdb-82c8-f034f3bfa451" />

> Action panel verified/verifier user warning

<img width="623" alt="Screenshot 2025-04-21 at 21 59 01" src="https://github.com/user-attachments/assets/785992c4-daf5-418e-9a60-76bf7615793e" />

> Verification badge in profile card

<img width="597" alt="Screenshot 2025-04-21 at 21 59 18" src="https://github.com/user-attachments/assets/8a5bba06-6888-41d3-875a-2e41ff1bf787" />

> Verifier badge in profile card

<img width="1445" alt="Screenshot 2025-04-21 at 22 00 10" src="https://github.com/user-attachments/assets/04df5cd3-6d68-4798-97da-5173ccf999cb" />

> Verifier badge in repo page header

<img width="256" alt="Screenshot 2025-04-21 at 22 00 45" src="https://github.com/user-attachments/assets/dd8dfa38-9724-4e3e-a7db-0409271cac0b" />

> Verified user badge in workspace item


<img width="677" alt="Screenshot 2025-04-21 at 22 11 34" src="https://github.com/user-attachments/assets/2ab0df53-0e2c-4330-994b-a4389b7555d7" />

> Verification page
