### PR TITLE
❇️ Quick takedown escalation appeal filter

### DIFF
--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -200,7 +200,15 @@ export const ModEventList = (
   if (hasFilter) {
     eventActions.push({
       text: 'Clear filters',
-      onClick: () => resetListFilters(),
+      onClick: () => {
+        resetListFilters()
+        if (props.subject) {
+          changeListFilter({ field: 'subject', value: props.subject })
+        }
+        if (props.createdBy) {
+          changeListFilter({ field: 'createdBy', value: props.createdBy })
+        }
+      },
     })
   }
 
@@ -226,7 +234,24 @@ export const ModEventList = (
       {!!props.stats && (
         <SubjectSummary
           onAccountTakedownClick={() => {
-            changeListFilter({ field: 'types', value: [MOD_EVENTS.TAKEDOWN] })
+            changeListFilter({ field: 'types', value: [MOD_EVENTS.APPEAL] })
+          }}
+          onAccountAppealClick={() => {
+            changeListFilter({ field: 'types', value: [MOD_EVENTS.ESCALATE] })
+          }}
+          onRecordTakedownClick={() => {
+            applyFilterMacro({
+              includeAllUserRecords: true,
+              types: [MOD_EVENTS.TAKEDOWN],
+              subjectType: 'record',
+            })
+          }}
+          onRecordEscalationClick={() => {
+            applyFilterMacro({
+              includeAllUserRecords: true,
+              types: [MOD_EVENTS.ESCALATE],
+              subjectType: 'record',
+            })
           }}
           stats={props.stats}
         />

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -137,7 +137,7 @@ const getReposAndRecordsForEvents = async (
 // The 2 fields need overriding because in the initialState, they are set as undefined so the alternative string type is not accepted without override
 export type EventListState = Omit<
   typeof initialListState,
-  'subject' | 'createdBy'
+  'subject' | 'createdBy' | 'subjectType'
 > & {
   subject?: string
   createdBy?: string
@@ -331,6 +331,10 @@ const getModEvents =
 
     if (filterTypes.includes(MOD_EVENTS.TAKEDOWN) && policies) {
       queryParams.policies = policies
+    }
+
+    if (subjectType) {
+      queryParams.subjectType = subjectType
     }
 
     const { data } = await labelerAgent.tools.ozone.moderation.queryEvents(

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -57,9 +57,11 @@ export const AccountStats = ({
   stats,
   showAll,
   onAccountTakedownClick,
+  onAccountAppealClick,
 }: {
   showAll: boolean
   onAccountTakedownClick?: () => void
+  onAccountAppealClick?: () => void
   stats: ToolsOzoneModerationDefs.AccountStats
 }) => {
   const { takedownCount, suspendCount, appealCount, reportCount } = stats
@@ -112,7 +114,7 @@ export const AccountStats = ({
         <StatView
           appearance="warning"
           count={appealCount}
-          onClick={onAccountTakedownClick}
+          onClick={onAccountAppealClick}
           text={
             showAll
               ? pluralize(appealCount, 'Appeal', { includeCount: false })
@@ -142,11 +144,13 @@ export const AccountStats = ({
 export const RecordsStats = ({
   stats,
   showAll,
-  onlyNumbers,
+  onRecordTakedownClick,
+  onRecordEscalationClick,
 }: {
   showAll: boolean
-  onlyNumbers?: boolean
   stats: ToolsOzoneModerationDefs.RecordsStats
+  onRecordTakedownClick?: () => void
+  onRecordEscalationClick?: () => void
 }) => {
   const {
     totalReports,
@@ -184,6 +188,7 @@ export const RecordsStats = ({
             takendownCount,
             'record',
           )} authored by this account has been taken down`}
+          onClick={onRecordTakedownClick}
         />
       )}
       {!!escalatedCount && (
@@ -195,6 +200,7 @@ export const RecordsStats = ({
               ? pluralize(escalatedCount, 'Escalation', { includeCount: false })
               : ''
           }
+          onClick={onRecordEscalationClick}
           Icon={ExclamationTriangleIcon}
           title={`${pluralize(
             escalatedCount,
@@ -248,8 +254,14 @@ export const RecordsStats = ({
 export const SubjectSummary = ({
   stats,
   onAccountTakedownClick,
+  onRecordTakedownClick,
+  onAccountAppealClick,
+  onRecordEscalationClick,
 }: {
   onAccountTakedownClick?: () => void
+  onRecordTakedownClick?: () => void
+  onAccountAppealClick?: () => void
+  onRecordEscalationClick?: () => void
   stats: {
     accountStats?: ToolsOzoneModerationDefs.AccountStats
     recordsStats?: ToolsOzoneModerationDefs.RecordsStats
@@ -265,11 +277,17 @@ export const SubjectSummary = ({
           showAll={showAll}
           stats={stats.accountStats}
           onAccountTakedownClick={onAccountTakedownClick}
+          onAccountAppealClick={onAccountAppealClick}
         />
       )}
       {showAll && stats.recordsStats && <div className="w-full" />}
       {stats.recordsStats && (
-        <RecordsStats showAll={showAll} stats={stats.recordsStats} />
+        <RecordsStats
+          showAll={showAll}
+          stats={stats.recordsStats}
+          onRecordTakedownClick={onRecordTakedownClick}
+          onRecordEscalationClick={onRecordEscalationClick}
+        />
       )}
       {stats.recordsStats && stats.accountStats && (
         <button type="button" onClick={() => setShowAll((current) => !current)}>

--- a/components/subject/Summary.tsx
+++ b/components/subject/Summary.tsx
@@ -75,7 +75,7 @@ export const AccountStats = ({
 
   return (
     <>
-      {hasStats && <UserCircleIcon className="w-4 h-4 dark:text-gray-200" />}
+      {!!hasStats && <UserCircleIcon className="w-4 h-4 dark:text-gray-200" />}
       {!!suspendCount && (
         <StatView
           appearance="danger"
@@ -173,7 +173,9 @@ export const RecordsStats = ({
 
   return (
     <>
-      {hasStats && <PencilSquareIcon className="w-4 h-4 dark:text-gray-200" />}
+      {!!hasStats && (
+        <PencilSquareIcon className="w-4 h-4 dark:text-gray-200" />
+      )}
       {!!takendownCount && (
         <StatView
           appearance="danger"


### PR DESCRIPTION
This PR applies relevant event stream filters when the following subject summary buttons are clicked

1. record takedown count
2. record escalated count
3. account appeal count