### PR TITLE
Resolve appeal on ack

### DIFF
--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -180,6 +180,7 @@ function Form(
     subjectStatus?.reviewState === ToolsOzoneModerationDefs.REVIEWCLOSED
   const isEscalated =
     subjectStatus?.reviewState === ToolsOzoneModerationDefs.REVIEWESCALATED
+  const isAppealed = !!subjectStatus?.appealed
 
   const allLabels = getLabelsForSubject({ repo, record })
   const currentLabels = allLabels.map((label) =>
@@ -837,7 +838,7 @@ function Form(
                     />
                   )}
 
-                  {isAckEvent && (
+                  {isAckEvent && isAppealed && (
                     <Checkbox
                       defaultChecked
                       value="true"

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -384,6 +384,18 @@ function Form(
         })
       }
 
+      if (formData.get('additionalResolveAppealEvent')) {
+        await onSubmit({
+          subject: subjectInfo,
+          createdBy: accountDid,
+          subjectBlobCids,
+          event: {
+            $type: MOD_EVENTS.RESOLVE_APPEAL,
+            comment: '[RESOLVING_APPEAL_DUE_TO_PREVIOUS_ACK_ACTION]',
+          },
+        })
+      }
+
       refetchSubjectStatus()
       refetchSubject()
       queryClient.invalidateQueries(['modEventList'])
@@ -820,6 +832,21 @@ function Form(
                         <span className="leading-4">
                           Acknowledge all open/escalated/appealed reports on
                           subjects created by this user
+                        </span>
+                      }
+                    />
+                  )}
+
+                  {isAckEvent && (
+                    <Checkbox
+                      defaultChecked
+                      value="true"
+                      id="additionalResolveAppealEvent"
+                      name="additionalResolveAppealEvent"
+                      className="mb-3 flex items-center leading-3"
+                      label={
+                        <span className="leading-4">
+                          Resolve appeal from the user
                         </span>
                       }
                     />


### PR DESCRIPTION
From time to time, we find moderators acknowledging an appealed subject and forget to resolve the appeal. By design, an ack event does not resolve an appeal but that is usually the intended action. So, the UI here gives a helping hand to the mods by automatically resolving appeals by default on ack event while allowing the user to opt-out of it if needed.

<img width="459" alt="Screenshot 2025-05-02 at 19 31 04" src="https://github.com/user-attachments/assets/6b3e84a9-5f0f-4266-99da-317c746b89e4" />
