### PR TITLE
Fix the build for GHCR

### DIFF
--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -25,6 +25,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Yarn install
+        run: yarn
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
The Docker build has been failing since [09 April](https://github.com/bluesky-social/ozone/actions/runs/14331039613). This means anybody relying on the container from GHCR (including any users that followed the instructions in [HOSTING.md](HOSTING.md)) have been stuck on Ozone v0.1.84.

I was able to reproduce the issue locally by running `docker buildx build .` without installing any dependencies. Installing dependencies before running `docker buildx build .` resolves the issue.