### PR TITLE
:bug: Fix filter dropdown getting cut off

### DIFF
--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -410,6 +410,8 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
                   ref={formRef}
                   id={WORKSPACE_FORM_ID}
                   onSubmit={onFormSubmit}
+                  // The overflow here allows dropdowns in the form filter to adjust height of the window accordingly
+                  className='overflow-y-auto'
                 >
                   {!showItemCreator && (
                     <div className="mb-2 flex space-x-2">


### PR DESCRIPTION
Continuously growing, long list of filters in workspace started to cause some items to get cut off on smaller screens. This fix ensures that we get a scrollable area when that happens.