### PR TITLE
:bug: Add missing prop when saving filter macro

### DIFF
--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -445,6 +445,8 @@ export const EventFilterPanel = ({
                   oldestFirst,
                   createdAfter,
                   createdBefore,
+                  subjectType,
+                  selectedCollections,
                 },
               })
               return true


### PR DESCRIPTION
Some newly added filter params in event stream filter were not being stored in filter macros. This PR adds those missing params.