### PR TITLE
:lipstick: Add reply context when reviewing a post which is a reply to a post

### DIFF
--- a/app/actions/ModActionPanel/BlobList.tsx
+++ b/app/actions/ModActionPanel/BlobList.tsx
@@ -103,7 +103,7 @@ export const BlobListFormField = ({
         <button
           type="button"
           className="flex flex-row items-center"
-          onClick={() => setShowBlobList(!showBlobList)}
+          onClick={() => setShowBlobList((show) => !show)}
         >
           {pluralize(blobs.length, 'Blob', {
             includeCount: false,

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -594,21 +594,24 @@ function Form(
                 </div>
               )}
 
-              {record?.blobs && (
+              {!!record?.blobs?.length && (
                 <BlobListFormField
                   blobs={record.blobs}
                   authorDid={record.repo.did}
-                  className="mb-3"
+                  className="mb-2"
                 />
               )}
               {isSubjectDid && canManageChat && (
-                <div className="mb-3">
+                <div className="mb-2">
                   <MessageActorMeta did={subject} />
                 </div>
               )}
-              <div className={`mb-3`}>
-                <FormLabel label="Labels">
-                  <LabelList className="-ml-1 flex-wrap">
+              <div className={`mb-2`}>
+                <FormLabel
+                  label="Labels"
+                  className="flex flex-row items-center gap-2"
+                >
+                  <LabelList className="-ml-1 -mt-1 flex-wrap">
                     {!currentLabels.length && (
                       <LabelListEmpty className="ml-1" />
                     )}
@@ -625,14 +628,49 @@ function Form(
                 </FormLabel>
               </div>
               {!!subjectStatus?.tags?.length && (
-                <div className={`mb-3`}>
-                  <FormLabel label="Tags">
-                    <LabelList className="-ml-1 flex-wrap gap-1">
+                <div className={`mb-2`}>
+                  <FormLabel
+                    label="Tags"
+                    className="flex flex-row items-center gap-2"
+                  >
+                    <LabelList className="-mt-1 -ml-1 flex-wrap gap-1">
                       {subjectStatus.tags.sort().map((tag) => {
                         return <SubjectTag key={tag} tag={tag} />
                       })}
                     </LabelList>
                   </FormLabel>
+                </div>
+              )}
+
+              {!isSubjectDid && !!profile?.labels?.length && (
+                <div className="mb-2">
+                  <div className="flex flex-row items-center">
+                    <div className='mr-1'>Account Labels</div>
+                    {profile.labels.map((label) => {
+                      return (
+                        <ModerationLabel
+                          label={label}
+                          key={label.val}
+                          recordAuthorDid={profile.did}
+                        />
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {!!record?.repo.moderation.subjectStatus?.tags?.length && (
+                <div className="mb-2">
+                  <div className="flex flex-row items-center">
+                    <div className='mr-2'>Account Tags</div>
+                    <LabelList className="-ml-1 flex-wrap gap-1">
+                      {record.repo.moderation.subjectStatus?.tags
+                        .sort()
+                        .map((tag) => {
+                          return <SubjectTag key={tag} tag={tag} />
+                        })}
+                    </LabelList>
+                  </div>
                 </div>
               )}
 

--- a/app/actions/ModActionPanel/QuickAction.tsx
+++ b/app/actions/ModActionPanel/QuickAction.tsx
@@ -645,7 +645,7 @@ function Form(
               {!isSubjectDid && !!profile?.labels?.length && (
                 <div className="mb-2">
                   <div className="flex flex-row items-center">
-                    <div className='mr-1'>Account Labels</div>
+                    <div className="mr-1">Account Labels</div>
                     {profile.labels.map((label) => {
                       return (
                         <ModerationLabel
@@ -662,7 +662,7 @@ function Form(
               {!!record?.repo.moderation.subjectStatus?.tags?.length && (
                 <div className="mb-2">
                   <div className="flex flex-row items-center">
-                    <div className='mr-2'>Account Tags</div>
+                    <div className="mr-2">Account Tags</div>
                     <LabelList className="-ml-1 flex-wrap gap-1">
                       {record.repo.moderation.subjectStatus?.tags
                         .sort()

--- a/components/common/RecordCard.tsx
+++ b/components/common/RecordCard.tsx
@@ -175,6 +175,7 @@ function PostCard({
     <PostAsCard
       dense
       showLabels={showLabels}
+      parent={data.thread.parent}
       item={{ post: data.thread.post }}
       isAuthorTakendown={isAuthorTakendown}
       isAuthorDeactivated={isAuthorDeactivated}

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -9,6 +9,7 @@ import {
   AppBskyEmbedImages,
   AppBskyEmbedExternal,
   AppBskyGraphDefs,
+  $Typed,
 } from '@atproto/api'
 import Link from 'next/link'
 import {
@@ -97,6 +98,7 @@ export const PostControlOptions = [
 export function PostAsCard({
   item,
   dense,
+  parent,
   onReport,
   className = '',
   showLabels = true,
@@ -111,6 +113,11 @@ export function PostAsCard({
   controls?: PostControl[]
   onReport?: (uri: string) => void
   className?: string
+  parent?:
+    | $Typed<AppBskyFeedDefs.ThreadViewPost>
+    | $Typed<AppBskyFeedDefs.NotFoundPost>
+    | $Typed<AppBskyFeedDefs.BlockedPost>
+    | { $type: string }
   showLabels?: boolean
 }) {
   return (
@@ -123,6 +130,11 @@ export function PostAsCard({
         isAuthorDeactivated={isAuthorDeactivated}
       />
       {showLabels && <PostLabels item={item} dense={dense} />}
+      {!!parent && (
+        <div className="pl-10">
+          <ReplyParent parent={parent} />
+        </div>
+      )}
       {!!controls?.length && (
         <PostControls item={item} onReport={onReport} controls={controls} />
       )}
@@ -196,7 +208,7 @@ function PostHeader({
               Peek
             </a>
           </p>
-          {item.reply ? <ReplyParent reply={item.reply} /> : undefined}
+          {item.reply ? <ReplyParent parent={item.reply.parent} /> : undefined}
         </div>
       </div>
     </div>

--- a/components/common/posts/PostsTable.tsx
+++ b/components/common/posts/PostsTable.tsx
@@ -118,7 +118,9 @@ function PostContent({ item }: { item: AppBskyFeedDefs.FeedViewPost }) {
   // TODO entities
   return (
     <>
-      {item.reply ? <ReplyParent reply={item.reply} inline /> : undefined}
+      {item.reply ? (
+        <ReplyParent parent={item.reply.parent} inline />
+      ) : undefined}
       <span className="block dark:text-gray-300">
         {item.post.record.text as string}
       </span>

--- a/components/common/posts/ReplyParent.tsx
+++ b/components/common/posts/ReplyParent.tsx
@@ -4,13 +4,12 @@ import { ReactNode } from 'react'
 import { useActionPanelLink } from '../useActionPanelLink'
 
 export const ReplyParent = ({
-  reply,
+  parent,
   inline = false,
 }: {
-  reply: AppBskyFeedDefs.ReplyRef
+  parent: AppBskyFeedDefs.ReplyRef['parent'] | AppBskyFeedDefs.ThreadViewPost
   inline?: boolean
 }) => {
-  const { parent } = reply
   const Wrapper = inline ? 'span' : 'p'
 
   if (AppBskyFeedDefs.isNotFoundPost(parent)) {
@@ -59,6 +58,27 @@ export const ReplyParent = ({
     )
   }
 
+  if (AppBskyFeedDefs.isThreadViewPost(parent)) {
+    const { post } = parent
+    return (
+      <Wrapper className="text-gray-500 dark:text-gray-50 text-sm">
+        {post.author ? (
+          <>
+            <LinkToPost post={parent.post} /> to{' '}
+            <LinkToPostAuthor post={parent.post}>
+              @{parent.post.author.handle}
+            </LinkToPostAuthor>
+          </>
+        ) : (
+          <>
+            <LinkToPost post={parent.post} /> to an anonymous user
+          </>
+        )}
+      </Wrapper>
+    )
+  }
+
+  console.log('here', parent.$type)
   return null
 }
 

--- a/components/common/posts/ReplyParent.tsx
+++ b/components/common/posts/ReplyParent.tsx
@@ -78,7 +78,6 @@ export const ReplyParent = ({
     )
   }
 
-  console.log('here', parent.$type)
   return null
 }
 

--- a/components/labeler/DefinitionEditor.tsx
+++ b/components/labeler/DefinitionEditor.tsx
@@ -156,7 +156,6 @@ const LabelFullDefinitionEditor: React.FC<{
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    console.log(formState)
     onUpdate(formState)
   }
 


### PR DESCRIPTION

<img width="652" alt="Screenshot 2025-05-28 at 16 28 24" src="https://github.com/user-attachments/assets/2481ea88-c497-4c33-897a-35b94723a2ad" />

> Reply context link

Along with reply context, this PR also improves vertical spacing in the quick action panel and adds account level tag/label display when reviewing a record to provide additional context about the account without having to switch to account view.

<img width="635" alt="Screenshot 2025-05-28 at 16 27 01" src="https://github.com/user-attachments/assets/fe42e5b4-f749-4f5a-b18f-80676051b7c5" />

> Account level labels and tags display
