### PR TITLE
:zap: Reduce query for workspace action by fetching from react-query cache

### DIFF
--- a/components/reports/helpers/subject.ts
+++ b/components/reports/helpers/subject.ts
@@ -2,7 +2,7 @@ import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { ComAtprotoRepoStrongRef, ToolsOzoneModerationDefs } from '@atproto/api'
 import { useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { WorkspaceListData } from '@/components/workspace/useWorkspaceListData'
+import { WorkspaceListData } from '@/workspace/useWorkspaceListData'
 
 export const isIdRecord = (id: string) => id.startsWith('at://')
 


### PR DESCRIPTION
When actioning records from workspace, we need the `cid` for each record to build the subject for the event being emitted. however, in most cases, we have this in the workspace data cache already so fetching it from there reduces a bunch of additional queries to the server, reducing chances of hitting any rate limit.