### PR TITLE
❇️ Mod tool metadata support

### DIFF
--- a/app/configure/page-content.tsx
+++ b/app/configure/page-content.tsx
@@ -5,7 +5,12 @@ import { LabelerConfig } from 'components/config/Labeler'
 import { MemberConfig } from 'components/config/Member'
 import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
 import { ToolsOzoneModerationEmitEvent } from '@atproto/api'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { usePathname, useSearchParams, useRouter } from 'next/navigation'
 import { useConfigurationContext } from '@/shell/ConfigurationContext'
 import { WorkspacePanel } from '@/workspace/Panel'
@@ -116,7 +121,11 @@ export default function ConfigurePageContent() {
         subjectOptions={[quickOpenParam]}
         isInitialLoading={false}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/configure',
+            }),
+          )
         }}
       />
       <WorkspacePanel

--- a/app/configure/page-content.tsx
+++ b/app/configure/page-content.tsx
@@ -122,9 +122,7 @@ export default function ConfigurePageContent() {
         isInitialLoading={false}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/configure',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
         }}
       />

--- a/app/configure/page-content.tsx
+++ b/app/configure/page-content.tsx
@@ -8,7 +8,6 @@ import { ToolsOzoneModerationEmitEvent } from '@atproto/api'
 import {
   ActionPanelNames,
   hydrateModToolInfo,
-  hydrateModToolInfo,
   useEmitEvent,
 } from '@/mod-event/helpers/emitEvent'
 import { usePathname, useSearchParams, useRouter } from 'next/navigation'

--- a/app/events/page-content.tsx
+++ b/app/events/page-content.tsx
@@ -45,9 +45,7 @@ export default function EventListPageContent() {
         isInitialLoading={false}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/events',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
         }}
       />

--- a/app/events/page-content.tsx
+++ b/app/events/page-content.tsx
@@ -1,6 +1,10 @@
 import { useTitle } from 'react-use'
 import { ModEventList } from '@/mod-event/EventList'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { ToolsOzoneModerationEmitEvent } from '@atproto/api'
 import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -40,7 +44,11 @@ export default function EventListPageContent() {
         subjectOptions={[quickOpenParam]}
         isInitialLoading={false}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/events',
+            }),
+          )
         }}
       />
       <WorkspacePanel

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -23,7 +23,11 @@ import { SubjectTable } from 'components/subject/table'
 import { useTitle } from 'react-use'
 import { QueueSelector } from '@/reports/QueueSelector'
 import { unique } from '@/lib/util'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { useFluentReportSearchParams } from '@/reports/useFluentReportSearch'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { WorkspacePanel } from 'components/workspace/Panel'
@@ -272,7 +276,11 @@ export const ReportsPageContent = () => {
         subjectOptions={subjectOptions}
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/reports',
+            }),
+          )
           refetch()
         }}
       />

--- a/app/reports/page-content.tsx
+++ b/app/reports/page-content.tsx
@@ -277,9 +277,7 @@ export const ReportsPageContent = () => {
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/reports',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
           refetch()
         }}

--- a/app/repositories/[id]/[...record]/page-content.tsx
+++ b/app/repositories/[id]/[...record]/page-content.tsx
@@ -184,9 +184,7 @@ export default function RecordViewPageContent({
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/repositories/[id]/[...record]',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
           refetch()
         }}

--- a/app/repositories/[id]/[...record]/page-content.tsx
+++ b/app/repositories/[id]/[...record]/page-content.tsx
@@ -11,7 +11,11 @@ import { useTitle } from 'react-use'
 import { Loading, LoadingFailed } from '@/common/Loader'
 import { getDidFromHandle } from '@/lib/identity'
 import { createAtUri } from '@/lib/util'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { ReportPanel } from '@/reports/ReportPanel'
 import { CollectionId } from '@/reports/helpers/subject'
 import { RecordView } from '@/repositories/RecordView'
@@ -179,7 +183,11 @@ export default function RecordViewPageContent({
         subjectOptions={[quickOpenParam]}
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/repositories/[id]/[...record]',
+            }),
+          )
           refetch()
         }}
       />

--- a/app/repositories/[id]/page-content.tsx
+++ b/app/repositories/[id]/page-content.tsx
@@ -84,9 +84,7 @@ export function RepositoryViewPageContent({ id }: { id: string }) {
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/repositories/[id]',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
           refetch()
         }}

--- a/app/repositories/[id]/page-content.tsx
+++ b/app/repositories/[id]/page-content.tsx
@@ -6,7 +6,11 @@ import { useTitle } from 'react-use'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { WorkspacePanel } from '@/workspace/Panel'
 
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { AccountView } from '@/repositories/AccountView'
 import { useCreateReport } from '@/repositories/createReport'
 import { useRepoAndProfile } from '@/repositories/useRepoAndProfile'
@@ -79,7 +83,11 @@ export function RepositoryViewPageContent({ id }: { id: string }) {
         subjectOptions={[quickOpenParam]}
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/repositories/[id]',
+            }),
+          )
           refetch()
         }}
       />

--- a/app/repositories/page-content.tsx
+++ b/app/repositories/page-content.tsx
@@ -19,7 +19,11 @@ import { WorkspacePanel } from '@/workspace/Panel'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { chunkArray } from '@/lib/util'
 import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 
 const isEmailSearch = (q: string) => q.startsWith('email:')
 const isSignatureSearch = (q: string) => q.startsWith('sig:')
@@ -307,7 +311,11 @@ export default function RepositoriesListPage() {
         }
         isInitialLoading={isLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/repositories',
+            }),
+          )
           refetch()
         }}
       />

--- a/app/repositories/page-content.tsx
+++ b/app/repositories/page-content.tsx
@@ -312,9 +312,7 @@ export default function RepositoriesListPage() {
         isInitialLoading={isLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/repositories',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
           refetch()
         }}

--- a/app/verification/page-content.tsx
+++ b/app/verification/page-content.tsx
@@ -3,7 +3,11 @@ import { EmptyDataset } from '@/common/feeds/EmptyFeed'
 import { Loading } from '@/common/Loader'
 import { LoadMoreButton } from '@/common/LoadMoreButton'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
-import { useEmitEvent } from '@/mod-event/helpers/emitEvent'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+  useEmitEvent,
+} from '@/mod-event/helpers/emitEvent'
 import { useWorkspaceAddItemsMutation } from '@/workspace/hooks'
 import { WorkspacePanel } from '@/workspace/Panel'
 import {
@@ -161,7 +165,11 @@ export const VerificationPageContent = () => {
         subjectOptions={[quickOpenParam]}
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-          await emitEvent(vals)
+          await emitEvent(
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
+              route: '/verification',
+            }),
+          )
         }}
       />
       <WorkspacePanel

--- a/app/verification/page-content.tsx
+++ b/app/verification/page-content.tsx
@@ -166,9 +166,7 @@ export const VerificationPageContent = () => {
         isInitialLoading={isInitialLoading}
         onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
           await emitEvent(
-            hydrateModToolInfo(vals, ActionPanelNames.QuickAction, {
-              route: '/verification',
-            }),
+            hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
         }}
       />

--- a/components/email/Composer.tsx
+++ b/components/email/Composer.tsx
@@ -19,6 +19,10 @@ import { TemplateSelector } from './template-selector'
 import { availableLanguageCodes } from '@/common/LanguagePicker'
 import { ToolsOzoneModerationDefs } from '@atproto/api'
 import { useEmailComposer } from './useComposer'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+} from '@/mod-event/helpers/emitEvent'
 
 const MDEditor = dynamic(() => import('@uiw/react-md-editor'), { ssr: false })
 
@@ -115,11 +119,16 @@ export const EmailComposer = ({
         await handleSubmit(event)
       } else {
         await toast.promise(
-          labelerAgent.tools.ozone.moderation.emitEvent({
-            event,
-            createdBy: labelerAgent.assertDid,
-            subject: { $type: 'com.atproto.admin.defs#repoRef', did },
-          }),
+          labelerAgent.tools.ozone.moderation.emitEvent(
+            hydrateModToolInfo(
+              {
+                event,
+                createdBy: labelerAgent.assertDid,
+                subject: { $type: 'com.atproto.admin.defs#repoRef', did },
+              },
+              ActionPanelNames.EmailComposer,
+            ),
+          ),
           {
             pending: 'Sending email...',
             success: {

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -20,6 +20,7 @@ import { ClockIcon, DocumentTextIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 import { pluralize } from '@/lib/util'
 import { TextWithLinks } from '@/common/TextWithLinks'
+import { ModToolInfo } from './ModToolInfo'
 
 import type { JSX } from 'react'
 
@@ -475,6 +476,9 @@ export const ModEventItem = ({
       <ItemTitle {...{ modEvent, showContentDetails, showContentAuthor }} />
       <Card>
         {eventItem}
+        {(modEvent.event as any).modTool && (
+          <ModToolInfo modTool={(modEvent.event as any).modTool} />
+        )}
         {typeof previewSubject === 'string' && showContentPreview && (
           <div className="border-t dark:border-gray-500 mt-2">
             <PreviewCard subject={previewSubject} />

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -476,9 +476,7 @@ export const ModEventItem = ({
       <ItemTitle {...{ modEvent, showContentDetails, showContentAuthor }} />
       <Card>
         {eventItem}
-        {(modEvent.event as any).modTool && (
-          <ModToolInfo modTool={(modEvent.event as any).modTool} />
-        )}
+        {modEvent.modTool && <ModToolInfo modTool={modEvent.modTool} />}
         {typeof previewSubject === 'string' && showContentPreview && (
           <div className="border-t dark:border-gray-500 mt-2">
             <PreviewCard subject={previewSubject} />

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -24,6 +24,7 @@ import { ConfirmationModal } from '@/common/modals/confirmation'
 import { ToolsOzoneModerationDefs } from '@atproto/api'
 import { SubjectSummary } from '@/subject/Summary'
 import { MOD_EVENTS } from './constants'
+import { ModToolProvider } from './ModToolContext'
 
 const getConfirmWorkspaceTitle = (
   showWorkspaceConfirmation: WorkspaceConfirmationOptions,
@@ -370,25 +371,27 @@ export const ModEventList = (
             )}
           </div>
         ) : (
-          modEvents.map((modEvent) => {
-            return (
-              <ModEventItem
-                key={modEvent.id}
-                modEvent={modEvent}
-                showContentAuthor={
-                  // isEntireHistoryView means user is viewing the events page so
-                  // we need to provide context for each event and link to content details
-                  // Same when we are showing events by a certain author to since the author
-                  // may be reporting different subjects
-                  isEntireHistoryView || isShowingEventsByCreator
-                }
-                // When the event history is being displayed for a single record/subject
-                // there's no point showing the preview in each event
-                showContentPreview={showContentPreview && isMultiSubjectView}
-                showContentDetails={isMultiSubjectView}
-              />
-            )
-          })
+          <ModToolProvider>
+            {modEvents.map((modEvent) => {
+              return (
+                <ModEventItem
+                  key={modEvent.id}
+                  modEvent={modEvent}
+                  showContentAuthor={
+                    // isEntireHistoryView means user is viewing the events page so
+                    // we need to provide context for each event and link to content details
+                    // Same when we are showing events by a certain author to since the author
+                    // may be reporting different subjects
+                    isEntireHistoryView || isShowingEventsByCreator
+                  }
+                  // When the event history is being displayed for a single record/subject
+                  // there's no point showing the preview in each event
+                  showContentPreview={showContentPreview && isMultiSubjectView}
+                  showContentDetails={isMultiSubjectView}
+                />
+              )
+            })}
+          </ModToolProvider>
         )}
       </div>
       {hasMoreModEvents && (

--- a/components/mod-event/ModToolContext.tsx
+++ b/components/mod-event/ModToolContext.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface ModToolContextType {
+  showModToolMeta: boolean
+  setShowModToolMeta: (show: boolean) => void
+}
+
+const ModToolContext = createContext<ModToolContextType | undefined>(undefined)
+
+export const ModToolProvider = ({ children }: { children: ReactNode }) => {
+  const [showModToolMeta, setShowModToolMeta] = useState(false)
+
+  return (
+    <ModToolContext.Provider value={{ showModToolMeta, setShowModToolMeta }}>
+      {children}
+    </ModToolContext.Provider>
+  )
+}
+
+export const useModToolContext = () => {
+  const context = useContext(ModToolContext)
+  if (context === undefined) {
+    throw new Error('useModToolContext must be used within a ModToolProvider')
+  }
+  return context
+}

--- a/components/mod-event/ModToolInfo.tsx
+++ b/components/mod-event/ModToolInfo.tsx
@@ -46,7 +46,7 @@ export const ModToolInfo = ({ modTool }: ModToolInfoProps) => {
       {hasMetadata && showModToolMeta && (
         <div className="rounded bg-gray-50 dark:bg-gray-800">
           <div className="bg-gray-50 dark:bg-slate-700 dark:bg-slate-700 px-1 py-2 sm:p-2 font-mono whitespace-pre overflow-x-auto text-xs dark:text-gray-300">
-            {JSON.stringify(modTool.meta, null, 2)}
+            <pre>{JSON.stringify(modTool.meta, null, 2)}</pre>
           </div>
         </div>
       )}

--- a/components/mod-event/ModToolInfo.tsx
+++ b/components/mod-event/ModToolInfo.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { WrenchIcon, ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
+import { useModToolContext } from './ModToolContext'
+import { classNames } from '@/lib/util'
+
+interface ModToolInfoProps {
+  modTool: {
+    name: string
+    meta?: Record<string, any>
+  }
+}
+
+export const ModToolInfo = ({ modTool }: ModToolInfoProps) => {
+  const { showModToolMeta, setShowModToolMeta } = useModToolContext()
+
+  const hasMetadata = modTool.meta && Object.keys(modTool.meta).length > 0
+
+  return (
+    <div className="mt-2 border-t border-gray-200 dark:border-gray-600 pt-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+          <WrenchIcon className="h-4 w-4" />
+          <span className="font-medium">Tool:</span>
+          <span className="font-mono text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
+            {modTool.name}
+          </span>
+        </div>
+        {hasMetadata && (
+          <button
+            type="button"
+            onClick={() => setShowModToolMeta(!showModToolMeta)}
+            className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          >
+            {showModToolMeta ? (
+              <ChevronDownIcon className="h-3 w-3" />
+            ) : (
+              <ChevronRightIcon className="h-3 w-3" />
+            )}
+            <span>Metadata</span>
+          </button>
+        )}
+      </div>
+      
+      {hasMetadata && showModToolMeta && (
+        <div className="mt-2 rounded bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 px-3 py-2">
+          <div className="text-xs text-gray-600 dark:text-gray-400 mb-1 font-medium">
+            Tool Metadata:
+          </div>
+          <div className="font-mono text-xs whitespace-pre overflow-x-auto text-gray-800 dark:text-gray-200">
+            {JSON.stringify(modTool.meta, null, 2)}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/mod-event/ModToolInfo.tsx
+++ b/components/mod-event/ModToolInfo.tsx
@@ -1,9 +1,12 @@
 'use client'
-import { WrenchIcon, ChevronRightIcon, ChevronDownIcon } from '@heroicons/react/20/solid'
+import {
+  WrenchIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+} from '@heroicons/react/20/solid'
 import { useModToolContext } from './ModToolContext'
-import { classNames } from '@/lib/util'
 
-interface ModToolInfoProps {
+type ModToolInfoProps = {
   modTool: {
     name: string
     meta?: Record<string, any>
@@ -19,8 +22,7 @@ export const ModToolInfo = ({ modTool }: ModToolInfoProps) => {
     <div className="mt-2 border-t border-gray-200 dark:border-gray-600 pt-2">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
-          <WrenchIcon className="h-4 w-4" />
-          <span className="font-medium">Tool:</span>
+          <WrenchIcon className="h-3 w-3" />
           <span className="font-mono text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
             {modTool.name}
           </span>
@@ -40,13 +42,10 @@ export const ModToolInfo = ({ modTool }: ModToolInfoProps) => {
           </button>
         )}
       </div>
-      
+
       {hasMetadata && showModToolMeta && (
-        <div className="mt-2 rounded bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-600 px-3 py-2">
-          <div className="text-xs text-gray-600 dark:text-gray-400 mb-1 font-medium">
-            Tool Metadata:
-          </div>
-          <div className="font-mono text-xs whitespace-pre overflow-x-auto text-gray-800 dark:text-gray-200">
+        <div className="rounded bg-gray-50 dark:bg-gray-800">
+          <div className="bg-gray-50 dark:bg-slate-700 dark:bg-slate-700 px-1 py-2 sm:p-2 font-mono whitespace-pre overflow-x-auto text-xs dark:text-gray-300">
             {JSON.stringify(modTool.meta, null, 2)}
           </div>
         </div>

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -28,6 +28,23 @@ import {
 
 const DELAY_DURATION_MS = 10000 // 10 seconds
 
+export enum ActionPanelNames {
+  Workspace = 'workspace',
+  QuickAction = 'quick-action',
+}
+
+const getModToolContext = (
+  panel: ActionPanelNames,
+  meta?: {
+    batchSize?: number
+    batchId?: string
+  },
+) => {
+  const name = `ozone-ui/${panel}`
+
+  return { name, meta }
+}
+
 export function useEmitEvent() {
   const labelerAgent = useLabelerAgent()
   const queryClient = useQueryClient()

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -31,18 +31,21 @@ const DELAY_DURATION_MS = 10000 // 10 seconds
 export enum ActionPanelNames {
   Workspace = 'workspace',
   QuickAction = 'quick-action',
+  EmailComposer = 'email-composer',
 }
 
-const getModToolContext = (
+export const hydrateModToolInfo = (
+  event: ToolsOzoneModerationEmitEvent.InputSchema,
   panel: ActionPanelNames,
   meta?: {
+    route?: string
     batchSize?: number
     batchId?: string
   },
 ) => {
   const name = `ozone-ui/${panel}`
-
-  return { name, meta }
+  const modTool = { name, meta }
+  return { ...event, modTool }
 }
 
 export function useEmitEvent() {

--- a/components/repositories/MuteReporting.tsx
+++ b/components/repositories/MuteReporting.tsx
@@ -6,6 +6,10 @@ import { ConfirmationModal } from '@/common/modals/confirmation'
 import { MOD_EVENTS } from '@/mod-event/constants'
 import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
+import {
+  ActionPanelNames,
+  hydrateModToolInfo,
+} from '@/mod-event/helpers/emitEvent'
 
 const useMuteReporting = ({
   did,
@@ -27,19 +31,24 @@ const useMuteReporting = ({
     unknown
   >(
     async (params) => {
-      const result = await labelerAgent.api.tools.ozone.moderation.emitEvent({
-        event: {
-          $type: isReportingMuted
-            ? `tools.ozone.moderation.defs#modEventUnmuteReporter`
-            : `tools.ozone.moderation.defs#modEventMuteReporter`,
-          ...params,
-        },
-        subject: {
-          $type: 'com.atproto.admin.defs#repoRef',
-          did,
-        },
-        createdBy: labelerAgent.assertDid,
-      })
+      const result = await labelerAgent.api.tools.ozone.moderation.emitEvent(
+        hydrateModToolInfo(
+          {
+            event: {
+              $type: isReportingMuted
+                ? `tools.ozone.moderation.defs#modEventUnmuteReporter`
+                : `tools.ozone.moderation.defs#modEventMuteReporter`,
+              ...params,
+            },
+            subject: {
+              $type: 'com.atproto.admin.defs#repoRef',
+              did,
+            },
+            createdBy: labelerAgent.assertDid,
+          },
+          ActionPanelNames.QuickAction,
+        ),
+      )
 
       return result
     },

--- a/components/workspace/Panel.tsx
+++ b/components/workspace/Panel.tsx
@@ -251,10 +251,12 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
       }
 
       // No need to break if one of the requests fail, continue on with others
+      const externalUrl = String(formData.get('externalUrl') || '')
       const results = await actionSubjects(
         { event: coreEvent },
         Array.from(formData.getAll('workspaceItem') as string[]),
         workspaceListStatuses || {},
+        externalUrl,
       )
 
       // After successful submission, reset the form state to clear inputs for previous submission
@@ -284,6 +286,7 @@ export function WorkspacePanel(props: PropsOf<typeof ActionPanel>) {
         // Emails can only be sent to DID subjects so filter out anything that's not a did
         getSelectedItems().filter(isValidDid),
         workspaceListStatuses || {},
+        '', // No external URL for email events
       )
 
       // If there are any item that failed to action, we want to keep them checked so users know which ones to retry

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -9,6 +9,10 @@ import { WORKSPACE_FORM_ID } from './constants'
 import { EmailComposer } from 'components/email/Composer'
 import { EmailComposerData } from 'components/email/helpers'
 import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
+import { getBatchId, regenerateBatchId } from '@/lib/batchId'
+import { useState } from 'react'
+import { toast } from 'react-toastify'
+import { ArrowPathIcon } from '@heroicons/react/24/solid'
 
 export const WorkspacePanelActionForm = ({
   handleEmailSubmit,
@@ -21,6 +25,13 @@ export const WorkspacePanelActionForm = ({
   setModEventType: (action: string) => void
   onCancel: () => void
 }) => {
+  const [currentBatchId, setCurrentBatchId] = useState(getBatchId())
+
+  const handleRegenerateBatchId = () => {
+    const newBatchId = regenerateBatchId()
+    setCurrentBatchId(newBatchId)
+    toast.success('Batch ID regenerated successfully')
+  }
   const isAckEvent = modEventType === MOD_EVENTS.ACKNOWLEDGE
   const isEmailEvent = modEventType === MOD_EVENTS.EMAIL
   const isTakedownEvent = modEventType === MOD_EVENTS.TAKEDOWN
@@ -182,6 +193,40 @@ export const WorkspacePanelActionForm = ({
               }
             />
           )}
+
+          <div className="mt-2 mb-3">
+            <FormLabel label="External URL" htmlFor="externalUrl">
+              <Input
+                type="url"
+                id="externalUrl"
+                name="externalUrl"
+                form={WORKSPACE_FORM_ID}
+                className="block w-full"
+                placeholder="https://example.com (optional)"
+              />
+            </FormLabel>
+          </div>
+
+          <div className="mb-3 p-3 bg-gray-50 dark:bg-gray-800 rounded border">
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Batch ID:
+                </span>
+                <span className="ml-2 text-sm text-gray-600 dark:text-gray-400 font-mono">
+                  {currentBatchId}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleRegenerateBatchId}
+                className="px-2 py-1 text-xs bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded transition-colors"
+                title="Regenerate Batch ID"
+              >
+                <ArrowPathIcon className="h-3 w-3 text-gray-500 dark:text-gray-300" />
+              </button>
+            </div>
+          </div>
 
           <div className="flex flex-row gap-2">
             <ActionButton

--- a/lib/batchId.ts
+++ b/lib/batchId.ts
@@ -1,0 +1,25 @@
+import { v4 as uuidv4 } from 'uuid'
+
+const BATCH_ID_KEY = 'ozone-workspace-batch-id'
+
+export const generateBatchId = (): string => {
+  // Generate a unique ID with timestamp to ensure uniqueness across users
+  const timestamp = Date.now()
+  const uuid = uuidv4()
+  return `${timestamp}-${uuid}`
+}
+
+export const getBatchId = (): string => {
+  let batchId = localStorage.getItem(BATCH_ID_KEY)
+  if (!batchId) {
+    batchId = generateBatchId()
+    localStorage.setItem(BATCH_ID_KEY, batchId)
+  }
+  return batchId
+}
+
+export const regenerateBatchId = (): string => {
+  const newBatchId = generateBatchId()
+  localStorage.setItem(BATCH_ID_KEY, newBatchId)
+  return newBatchId
+}


### PR DESCRIPTION
Ozone backend already allows storing mod tool metadata. This PR displays that info in the UI In a readable way and attaches relevant metadata when events are emitted using ozone client app.

<img width="821" height="239" alt="Screenshot 2025-07-17 at 10 39 23" src="https://github.com/user-attachments/assets/7915a735-d9a3-426c-9093-b9399cb14446" />

> Workspace event expanded with batch metadata

<img width="828" height="140" alt="Screenshot 2025-07-17 at 10 39 35" src="https://github.com/user-attachments/assets/117d644c-ba18-40f4-b828-2cff418593b6" />

> Workspace event with metadata collapsed

<img width="665" height="349" alt="Screenshot 2025-07-17 at 10 40 05" src="https://github.com/user-attachments/assets/5451af8d-2980-4378-abd0-8f02e91a7393" />

> Workspace action field for metadata input

<img width="836" height="142" alt="Screenshot 2025-07-17 at 10 39 52" src="https://github.com/user-attachments/assets/d2860e32-4892-44d2-8456-b36aa984690e" />

> Quick action event