### PR TITLE
:sparkles: Support expanded custom reporting categories

### DIFF
--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -7,13 +7,40 @@ import {
 import { MOD_EVENTS, MOD_EVENT_TITLES } from './constants'
 import { addDays } from 'date-fns'
 import { Checkbox, FormLabel, Input } from '@/common/forms'
-import { reasonTypeOptions } from '@/reports/helpers/getType'
+import { reasonTypeOptions, groupedReasonTypes } from '@/reports/helpers/getType'
+import Select from 'react-tailwindcss-select'
+import { classNames } from '@/lib/util'
 import { LabelSelector } from '@/common/labels/Selector'
 import { ReasonBadgeButton } from '@/reports/ReasonBadge'
 import { CreateMacroForm } from './CreateMacroForm'
 import { useFilterMacroUpsertMutation } from './useFilterMacrosList'
 import { MacroList } from './MacroPicker'
 import { useState } from 'react'
+
+const selectClassNames = {
+  menuButton: ({ isDisabled }: { isDisabled?: boolean } = {}) =>
+    classNames(
+      isDisabled ? 'bg-gray-200' : 'bg-white hover:border-gray-400 focus:ring',
+      'flex text-sm text-gray-500 border border-gray-300 rounded shadow-sm transition-all duration-300 focus:outline-none dark:bg-slate-700 dark:text-gray-100',
+    ),
+  menu: 'absolute z-10 w-full bg-white shadow-lg border rounded py-1 mt-1.5 text-sm text-gray-700 dark:bg-slate-700 dark:text-gray-100',
+  searchBox:
+    'w-full py-2 pl-8 text-sm text-gray-500 bg-gray-100 border border-gray-200 rounded focus:border-gray-200 focus:ring-0 focus:outline-none dark:bg-slate-800 dark:text-gray-100',
+  listGroupLabel:
+    'pr-2 py-2 cursor-default select-none truncate text-gray-700 dark:text-gray-100 font-semibold bg-gray-50 dark:bg-slate-600',
+  listItem: ({ isSelected }: { isSelected?: boolean } = {}) => {
+    const baseClass =
+      'block transition duration-200 px-2 py-2 cursor-pointer select-none truncate rounded dark:hover:bg-slate-800 dark:hover:text-gray-200'
+    const selectedClass = isSelected
+      ? `bg-indigo-600 text-white`
+      : `text-gray-500 dark:text-gray-300 hover:bg-gray-100`
+
+    return classNames(baseClass, selectedClass)
+  },
+  tagItemText: `text-gray-600 text-xs truncate cursor-default select-none`,
+  tagItemIconContainer:
+    'flex items-center px-1 cursor-pointer rounded-r-sm hover:bg-red-200 hover:text-red-600 dark:text-slate-900',
+}
 import { RepoFinder } from '@/repositories/Finder'
 import { Dropdown } from '@/common/Dropdown'
 import { ChevronDownIcon } from '@heroicons/react/24/solid'
@@ -387,27 +414,35 @@ export const EventFilterPanel = ({
             htmlFor="reasonType"
             className="mt-2"
           >
-            {Object.keys(reasonTypeOptions).map((typeValue) => {
-              const isSelected = reportTypes.includes(typeValue)
-              return (
-                <ReasonBadgeButton
-                  key={typeValue}
-                  className={`mr-1 ${isSelected ? 'font-bold' : ''}`}
-                  reasonType={typeValue}
-                  isHighlighted={isSelected}
-                  onClick={(e) => {
-                    e.preventDefault()
-                    const value: string[] = isSelected
-                      ? reportTypes.filter((t) => t !== typeValue)
-                      : [...reportTypes, typeValue]
-                    changeListFilter({
-                      field: 'reportTypes',
-                      value,
-                    })
-                  }}
-                />
-              )
-            })}
+            <Select
+              primaryColor="indigo"
+              isMultiple
+              isSearchable
+              isClearable
+              classNames={selectClassNames}
+              placeholder="Select report reasons..."
+              value={reportTypes.map((reasonType) => ({
+                label: reasonTypeOptions[reasonType] || reasonType,
+                value: reasonType,
+              }))}
+              onChange={(selections) => {
+                const selectedValues = Array.isArray(selections)
+                  ? selections.map((s) => s.value)
+                  : []
+                changeListFilter({
+                  field: 'reportTypes',
+                  value: selectedValues,
+                })
+              }}
+              options={Object.entries(groupedReasonTypes).map(([categoryName, reasonTypes]) => ({
+                label: categoryName,
+                options: reasonTypes.map((reasonType) => ({
+                  label: reasonTypeOptions[reasonType] || reasonType,
+                  value: reasonType,
+                  isSelected: reportTypes.includes(reasonType),
+                })),
+              }))}
+            />
           </FormLabel>
         )}
       </div>

--- a/components/reports/ReasonBadge.tsx
+++ b/components/reports/ReasonBadge.tsx
@@ -1,5 +1,5 @@
-import { ComAtprotoModerationDefs } from '@atproto/api'
 import { ComponentProps } from 'react'
+import { reasonTypeOptions, groupedReasonTypes } from './helpers/getType'
 
 export function ReasonBadgeButton(
   props: {
@@ -9,13 +9,14 @@ export function ReasonBadgeButton(
   } & ComponentProps<'button'>,
 ) {
   const { reasonType, className = '', isHighlighted = false, ...rest } = props
-  const readable = reasonType.replace('com.atproto.moderation.defs#reason', '')
+  const readable = reasonTypeOptions[reasonType] || getReadableReasonType(reasonType)
   const color = isHighlighted
     ? 'bg-indigo-600 border-indigo-500 text-white dark:bg-teal-600 dark:border-teal-500'
-    : reasonColors[reasonType] ?? reasonColors.default
+    : getReasonColor(reasonType)
   return (
     <button
       className={`${color} inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${className}`}
+      title={reasonType}
       {...rest}
     >
       {readable}
@@ -25,22 +26,57 @@ export function ReasonBadgeButton(
 
 export function ReasonBadge(props: { reasonType: string; className?: string }) {
   const { reasonType, className = '' } = props
-  const readable = reasonType.replace('com.atproto.moderation.defs#reason', '')
-  const color = reasonColors[reasonType] ?? reasonColors.default
+  const readable = reasonTypeOptions[reasonType] || getReadableReasonType(reasonType)
+  const color = getReasonColor(reasonType)
   return (
     <span
       className={`${color} inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${className}`}
+      title={reasonType}
     >
       {readable}
     </span>
   )
 }
-const reasonColors: Record<string, string> = {
-  [ComAtprotoModerationDefs.REASONSPAM]: 'bg-amber-100 text-amber-800',
-  [ComAtprotoModerationDefs.REASONOTHER]: 'bg-violet-100 text-violet-800',
-  [ComAtprotoModerationDefs.REASONVIOLATION]: 'bg-red-100 text-red-800',
-  [ComAtprotoModerationDefs.REASONMISLEADING]: 'bg-amber-100 text-amber-800',
-  [ComAtprotoModerationDefs.REASONSEXUAL]: 'bg-amber-100 text-amber-800',
-  [ComAtprotoModerationDefs.REASONRUDE]: 'bg-orange-100 text-orange-800',
-  default: 'bg-gray-200 text-gray-800',
+// Group-based colors for consistent category styling
+const groupColors: Record<string, string> = {
+  'Legacy': 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  'Appeal': 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  'Violence': 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  'Sexual': 'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
+  'Child Safety': 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  'Harassment': 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+  'Misleading': 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  'Rule Violations': 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+  'Civic': 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
+  'default': 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+}
+
+// Find which category a reason type belongs to
+function getReasonCategory(reasonType: string): string {
+  for (const [category, reasonTypes] of Object.entries(groupedReasonTypes)) {
+    if (reasonTypes.includes(reasonType)) {
+      return category
+    }
+  }
+  return 'default'
+}
+
+// Get the color class for a reason type based on its category
+function getReasonColor(reasonType: string): string {
+  const category = getReasonCategory(reasonType)
+  return groupColors[category] || groupColors.default
+}
+
+// Fallback function to create readable text for unknown reason types
+function getReadableReasonType(reasonType: string): string {
+  // Remove namespace prefixes and make more readable
+  return reasonType
+    .replace('com.atproto.moderation.defs#reason', '')
+    .replace('tools.ozone.report.defs#reason', '')
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    .toLowerCase()
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }

--- a/components/reports/ReasonBadge.tsx
+++ b/components/reports/ReasonBadge.tsx
@@ -68,15 +68,11 @@ function getReasonColor(reasonType: string): string {
 }
 
 // Fallback function to create readable text for unknown reason types
+// For input "com.atproto.moderation.defs#reasonBanEvasion" output "Ban Evasion"
 function getReadableReasonType(reasonType: string): string {
-  // Remove namespace prefixes and make more readable
   return reasonType
     .replace('com.atproto.moderation.defs#reason', '')
     .replace('tools.ozone.report.defs#reason', '')
     .replace(/([A-Z])/g, ' $1')
     .trim()
-    .toLowerCase()
-    .split(' ')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
 }

--- a/components/reports/ReportPanel.tsx
+++ b/components/reports/ReportPanel.tsx
@@ -173,7 +173,7 @@ function ReasonTypeCombobox({
   onQueryChange: (query: string) => void
 }) {
   const [isFocused, setIsFocused] = useState(false)
-  
+
   // Create a flat list of all reason types with their categories for searching
   const allReasonTypes = Object.entries(groupedReasonTypes).flatMap(
     ([categoryName, reasonTypes]) =>
@@ -181,7 +181,7 @@ function ReasonTypeCombobox({
         value: reasonType,
         label: reasonTypeOptions[reasonType] || reasonType,
         category: categoryName,
-      }))
+      })),
   )
 
   const filteredReasonTypes = allReasonTypes.filter((reason) => {
@@ -196,9 +196,7 @@ function ReasonTypeCombobox({
 
   // Group filtered results by category
   const groupedFilteredResults = filteredReasonTypes.reduce((acc, reason) => {
-    if (!acc[reason.category]) {
-      acc[reason.category] = []
-    }
+    acc[reason.category] ??= []
     acc[reason.category].push(reason)
     return acc
   }, {} as Record<string, typeof filteredReasonTypes>)
@@ -243,51 +241,53 @@ function ReasonTypeCombobox({
                 No reason types found {query ? `matching "${query}"` : ''}.
               </div>
             ) : (
-              Object.entries(groupedFilteredResults).map(([categoryName, reasons]) => (
-                <div key={categoryName}>
-                  <div className="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-gray-50 dark:bg-slate-600">
-                    {categoryName}
-                  </div>
-                  {reasons.map((reason) => (
-                    <ComboboxOption
-                      key={reason.value}
-                      className={({ focus }) =>
-                        `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                          focus
-                            ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
-                            : 'text-gray-900 dark:text-gray-200'
-                        }`
-                      }
-                      value={reason.value}
-                      onClick={() => setIsFocused(false)}
-                    >
-                      {({ selected, focus }) => (
-                        <>
-                          {selected ? (
+              Object.entries(groupedFilteredResults).map(
+                ([categoryName, reasons]) => (
+                  <div key={categoryName}>
+                    <div className="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-gray-50 dark:bg-slate-600">
+                      {categoryName}
+                    </div>
+                    {reasons.map((reason) => (
+                      <ComboboxOption
+                        key={reason.value}
+                        className={({ focus }) =>
+                          `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                            focus
+                              ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
+                              : 'text-gray-900 dark:text-gray-200'
+                          }`
+                        }
+                        value={reason.value}
+                        onClick={() => setIsFocused(false)}
+                      >
+                        {({ selected, focus }) => (
+                          <>
+                            {selected ? (
+                              <span
+                                className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                                  focus ? 'text-indigo-900' : 'text-indigo-600'
+                                }`}
+                              >
+                                <CheckIcon
+                                  className="h-5 w-5 dark:text-gray-50"
+                                  aria-hidden="true"
+                                />
+                              </span>
+                            ) : null}
                             <span
-                              className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                                focus ? 'text-indigo-900' : 'text-indigo-600'
+                              className={`block truncate ${
+                                selected ? 'font-medium' : 'font-normal'
                               }`}
                             >
-                              <CheckIcon
-                                className="h-5 w-5 dark:text-gray-50"
-                                aria-hidden="true"
-                              />
+                              {reason.label}
                             </span>
-                          ) : null}
-                          <span
-                            className={`block truncate ${
-                              selected ? 'font-medium' : 'font-normal'
-                            }`}
-                          >
-                            {reason.label}
-                          </span>
-                        </>
-                      )}
-                    </ComboboxOption>
-                  ))}
-                </div>
-              ))
+                          </>
+                        )}
+                      </ComboboxOption>
+                    ))}
+                  </div>
+                ),
+              )
             )}
           </ComboboxOptions>
         </Transition>

--- a/components/reports/ReportPanel.tsx
+++ b/components/reports/ReportPanel.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useState } from 'react'
 import { ActionPanel } from '../common/ActionPanel'
 import { ButtonPrimary, ButtonSecondary } from '../common/buttons'
-import { FormLabel, Input, Select, Textarea } from '../common/forms'
+import { FormLabel, Input, Textarea } from '../common/forms'
 import { RecordCard, RepoCard } from '../common/RecordCard'
 import { PropsOf } from '@/lib/types'
 import { useQueryClient } from '@tanstack/react-query'
 import { SubjectSwitchButton } from '@/common/SubjectSwitchButton'
-import { reasonTypeOptions } from './helpers/getType'
+import { reasonTypeOptions, groupedReasonTypes } from './helpers/getType'
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxButton,
+  ComboboxOptions,
+  ComboboxOption,
+  Transition,
+} from '@headlessui/react'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/solid'
+import { Fragment } from 'react'
 
 export function ReportPanel(
   props: PropsOf<typeof ActionPanel> & {
@@ -43,6 +53,8 @@ function Form(props: {
   } = props
   const [subject, setSubject] = useState(fixedSubject ?? '')
   const [submitting, setSubmitting] = useState(false)
+  const [selectedReason, setSelectedReason] = useState('')
+  const [reasonQuery, setReasonQuery] = useState('')
   const queryClient = useQueryClient()
 
   // Update the subject when parent renderer wants to update it
@@ -61,7 +73,7 @@ function Form(props: {
           const formData = new FormData(ev.currentTarget)
           await onSubmit({
             subject: formData.get('subject')!.toString(),
-            reasonType: formData.get('reasonType')!.toString(),
+            reasonType: selectedReason,
             reason: formData.get('reason')!.toString() || undefined,
           })
           onCancel() // Close
@@ -115,16 +127,12 @@ function Form(props: {
         </div>
       )}
       <FormLabel label="Reason" htmlFor="reasonType" className="mb-3">
-        <Select id="reasonType" name="reasonType" required>
-          <option hidden selected value="">
-            Reason
-          </option>
-          {Object.entries(reasonTypeOptions).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </Select>
+        <ReasonTypeCombobox
+          selectedReason={selectedReason}
+          onSelect={setSelectedReason}
+          query={reasonQuery}
+          onQueryChange={setReasonQuery}
+        />
       </FormLabel>
       <Textarea
         name="reason"
@@ -151,4 +159,139 @@ export type ReportFormValues = {
   subject: string
   reasonType: string
   reason?: string
+}
+
+function ReasonTypeCombobox({
+  selectedReason,
+  onSelect,
+  query,
+  onQueryChange,
+}: {
+  selectedReason: string
+  onSelect: (reason: string) => void
+  query: string
+  onQueryChange: (query: string) => void
+}) {
+  const [isFocused, setIsFocused] = useState(false)
+  
+  // Create a flat list of all reason types with their categories for searching
+  const allReasonTypes = Object.entries(groupedReasonTypes).flatMap(
+    ([categoryName, reasonTypes]) =>
+      reasonTypes.map((reasonType) => ({
+        value: reasonType,
+        label: reasonTypeOptions[reasonType] || reasonType,
+        category: categoryName,
+      }))
+  )
+
+  const filteredReasonTypes = allReasonTypes.filter((reason) => {
+    if (!query) return true
+    const searchText = query.toLowerCase()
+    return (
+      reason.label.toLowerCase().includes(searchText) ||
+      reason.category.toLowerCase().includes(searchText) ||
+      reason.value.toLowerCase().includes(searchText)
+    )
+  })
+
+  // Group filtered results by category
+  const groupedFilteredResults = filteredReasonTypes.reduce((acc, reason) => {
+    if (!acc[reason.category]) {
+      acc[reason.category] = []
+    }
+    acc[reason.category].push(reason)
+    return acc
+  }, {} as Record<string, typeof filteredReasonTypes>)
+
+  return (
+    <Combobox
+      value={selectedReason}
+      onChange={(value) => {
+        onSelect(value || '')
+        setIsFocused(false)
+      }}
+    >
+      <div className="relative mt-1 w-full">
+        <div className="relative w-full cursor-default overflow-hidden rounded-md bg-white dark:bg-slate-700 text-left shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
+          <ComboboxInput
+            className="w-full rounded-md border-gray-300 dark:border-teal-500 dark:bg-slate-700 shadow-sm dark:shadow-slate-700 focus:border-indigo-500 focus:ring-indigo-500 dark:focus:ring-teal-500 sm:text-sm dark:text-gray-100"
+            onChange={(event) => onQueryChange(event.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            displayValue={(value: string) => {
+              return isFocused ? '' : reasonTypeOptions[value] || value || ''
+            }}
+            placeholder="Select reason type. Type to search..."
+          />
+          <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-2">
+            <ChevronUpDownIcon
+              className="h-5 w-5 text-gray-400"
+              aria-hidden="true"
+            />
+          </ComboboxButton>
+        </div>
+        <Transition
+          as={Fragment}
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+          afterLeave={() => onQueryChange('')}
+        >
+          <ComboboxOptions className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-slate-700 py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+            {Object.keys(groupedFilteredResults).length === 0 ? (
+              <div className="relative cursor-default select-none px-4 py-2 text-gray-700 dark:text-gray-100">
+                No reason types found {query ? `matching "${query}"` : ''}.
+              </div>
+            ) : (
+              Object.entries(groupedFilteredResults).map(([categoryName, reasons]) => (
+                <div key={categoryName}>
+                  <div className="px-4 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-gray-50 dark:bg-slate-600">
+                    {categoryName}
+                  </div>
+                  {reasons.map((reason) => (
+                    <ComboboxOption
+                      key={reason.value}
+                      className={({ focus }) =>
+                        `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                          focus
+                            ? 'bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-gray-200'
+                            : 'text-gray-900 dark:text-gray-200'
+                        }`
+                      }
+                      value={reason.value}
+                      onClick={() => setIsFocused(false)}
+                    >
+                      {({ selected, focus }) => (
+                        <>
+                          {selected ? (
+                            <span
+                              className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                                focus ? 'text-indigo-900' : 'text-indigo-600'
+                              }`}
+                            >
+                              <CheckIcon
+                                className="h-5 w-5 dark:text-gray-50"
+                                aria-hidden="true"
+                              />
+                            </span>
+                          ) : null}
+                          <span
+                            className={`block truncate ${
+                              selected ? 'font-medium' : 'font-normal'
+                            }`}
+                          >
+                            {reason.label}
+                          </span>
+                        </>
+                      )}
+                    </ComboboxOption>
+                  ))}
+                </div>
+              ))
+            )}
+          </ComboboxOptions>
+        </Transition>
+      </div>
+    </Combobox>
+  )
 }

--- a/components/reports/helpers/getType.ts
+++ b/components/reports/helpers/getType.ts
@@ -8,11 +8,153 @@ export function getType(obj: unknown): string {
 }
 
 export const reasonTypeOptions = {
+  // Legacy constant-based reasons
   [ComAtprotoModerationDefs.REASONSPAM]: 'Spam',
   [ComAtprotoModerationDefs.REASONVIOLATION]: 'Violation of Terms',
   [ComAtprotoModerationDefs.REASONMISLEADING]: 'Misleading',
   [ComAtprotoModerationDefs.REASONSEXUAL]: 'Sexual',
   [ComAtprotoModerationDefs.REASONRUDE]: 'Rude or Harassment',
+  [ComAtprotoModerationDefs.REASONOTHER]: 'Other',
   [ComAtprotoModerationDefs.REASONAPPEAL]: 'Appeal',
-  [ComAtprotoModerationDefs.REASONOTHER]: 'Other Reason',
+
+  // tools.ozone.report.defs - Appeal
+  'tools.ozone.report.defs#reasonAppeal': 'Appeal',
+
+  // Violence and Welfare
+  'tools.ozone.report.defs#reasonViolenceAnimalWelfare':
+    'Animal Welfare Violation',
+  'tools.ozone.report.defs#reasonViolenceThreats': 'Violent Threats',
+  'tools.ozone.report.defs#reasonViolenceGraphicContent':
+    'Graphic Violent Content',
+  'tools.ozone.report.defs#reasonViolenceSelfHarm': 'Self-Harm Content',
+  'tools.ozone.report.defs#reasonViolenceGlorification':
+    'Violence Glorification',
+  'tools.ozone.report.defs#reasonViolenceExtremistContent': 'Extremist Content',
+  'tools.ozone.report.defs#reasonViolenceTrafficking': 'Human Trafficking',
+  'tools.ozone.report.defs#reasonViolenceOther': 'Other Violence',
+
+  // Sexual Content
+  'tools.ozone.report.defs#reasonSexualAbuseContent': 'Sexual Abuse Content',
+  'tools.ozone.report.defs#reasonSexualNCII': 'Non-Consensual Intimate Images',
+  'tools.ozone.report.defs#reasonSexualSextortion': 'Sextortion',
+  'tools.ozone.report.defs#reasonSexualDeepfake': 'Sexual Deepfake',
+  'tools.ozone.report.defs#reasonSexualAnimal':
+    'Sexual Content Involving Animals',
+  'tools.ozone.report.defs#reasonSexualUnlabeled': 'Unlabeled Sexual Content',
+  'tools.ozone.report.defs#reasonSexualOther': 'Other Sexual Content',
+
+  // Child Safety
+  'tools.ozone.report.defs#reasonChildSafetyCSAM':
+    'Child Sexual Abuse Material',
+  'tools.ozone.report.defs#reasonChildSafetyGroom': 'Child Grooming',
+  'tools.ozone.report.defs#reasonChildSafetyMinorPrivacy':
+    'Minor Privacy Violation',
+  'tools.ozone.report.defs#reasonChildSafetyEndangerment': 'Child Endangerment',
+  'tools.ozone.report.defs#reasonChildSafetyHarassment': 'Child Harassment',
+  'tools.ozone.report.defs#reasonChildSafetyPromotion':
+    'Promotion of Child Abuse',
+  'tools.ozone.report.defs#reasonChildSafetyOther': 'Other Child Safety Issue',
+
+  // Harassment
+  'tools.ozone.report.defs#reasonHarassmentTroll': 'Trolling',
+  'tools.ozone.report.defs#reasonHarassmentTargeted': 'Targeted Harassment',
+  'tools.ozone.report.defs#reasonHarassmentHateSpeech': 'Hate Speech',
+  'tools.ozone.report.defs#reasonHarassmentDoxxing': 'Doxxing',
+  'tools.ozone.report.defs#reasonHarassmentOther': 'Other Harassment',
+
+  // Misleading Content
+  'tools.ozone.report.defs#reasonMisleadingBot': 'Bot Account',
+  'tools.ozone.report.defs#reasonMisleadingImpersonation': 'Impersonation',
+  'tools.ozone.report.defs#reasonMisleadingSpam': 'Spam',
+  'tools.ozone.report.defs#reasonMisleadingScam': 'Scam',
+  'tools.ozone.report.defs#reasonMisleadingSyntheticContent':
+    'Synthetic Content',
+  'tools.ozone.report.defs#reasonMisleadingMisinformation': 'Misinformation',
+  'tools.ozone.report.defs#reasonMisleadingOther': 'Other Misleading Content',
+
+  // Rule Violations
+  'tools.ozone.report.defs#reasonRuleSiteSecurity': 'Site Security Violation',
+  'tools.ozone.report.defs#reasonRuleStolenContent': 'Stolen Content',
+  'tools.ozone.report.defs#reasonRuleProhibitedSales': 'Prohibited Sales',
+  'tools.ozone.report.defs#reasonRuleBanEvasion': 'Ban Evasion',
+  'tools.ozone.report.defs#reasonRuleOther': 'Other Rule Violation',
+
+  // Civic Issues
+  'tools.ozone.report.defs#reasonCivicElectoralProcess':
+    'Electoral Process Interference',
+  'tools.ozone.report.defs#reasonCivicDisclosure': 'Missing Civic Disclosure',
+  'tools.ozone.report.defs#reasonCivicInterference': 'Civic Interference',
+  'tools.ozone.report.defs#reasonCivicMisinformation': 'Civic Misinformation',
+  'tools.ozone.report.defs#reasonCivicImpersonation': 'Civic Impersonation',
+}
+
+export const groupedReasonTypes = {
+  Legacy: [
+    ComAtprotoModerationDefs.REASONSPAM,
+    ComAtprotoModerationDefs.REASONVIOLATION,
+    ComAtprotoModerationDefs.REASONMISLEADING,
+    ComAtprotoModerationDefs.REASONSEXUAL,
+    ComAtprotoModerationDefs.REASONRUDE,
+    ComAtprotoModerationDefs.REASONOTHER,
+    ComAtprotoModerationDefs.REASONAPPEAL,
+  ],
+  Appeal: ['tools.ozone.report.defs#reasonAppeal'],
+  Violence: [
+    'tools.ozone.report.defs#reasonViolenceAnimalWelfare',
+    'tools.ozone.report.defs#reasonViolenceThreats',
+    'tools.ozone.report.defs#reasonViolenceGraphicContent',
+    'tools.ozone.report.defs#reasonViolenceSelfHarm',
+    'tools.ozone.report.defs#reasonViolenceGlorification',
+    'tools.ozone.report.defs#reasonViolenceExtremistContent',
+    'tools.ozone.report.defs#reasonViolenceTrafficking',
+    'tools.ozone.report.defs#reasonViolenceOther',
+  ],
+  Sexual: [
+    'tools.ozone.report.defs#reasonSexualAbuseContent',
+    'tools.ozone.report.defs#reasonSexualNCII',
+    'tools.ozone.report.defs#reasonSexualSextortion',
+    'tools.ozone.report.defs#reasonSexualDeepfake',
+    'tools.ozone.report.defs#reasonSexualAnimal',
+    'tools.ozone.report.defs#reasonSexualUnlabeled',
+    'tools.ozone.report.defs#reasonSexualOther',
+  ],
+  'Child Safety': [
+    'tools.ozone.report.defs#reasonChildSafetyCSAM',
+    'tools.ozone.report.defs#reasonChildSafetyGroom',
+    'tools.ozone.report.defs#reasonChildSafetyMinorPrivacy',
+    'tools.ozone.report.defs#reasonChildSafetyEndangerment',
+    'tools.ozone.report.defs#reasonChildSafetyHarassment',
+    'tools.ozone.report.defs#reasonChildSafetyPromotion',
+    'tools.ozone.report.defs#reasonChildSafetyOther',
+  ],
+  Harassment: [
+    'tools.ozone.report.defs#reasonHarassmentTroll',
+    'tools.ozone.report.defs#reasonHarassmentTargeted',
+    'tools.ozone.report.defs#reasonHarassmentHateSpeech',
+    'tools.ozone.report.defs#reasonHarassmentDoxxing',
+    'tools.ozone.report.defs#reasonHarassmentOther',
+  ],
+  Misleading: [
+    'tools.ozone.report.defs#reasonMisleadingBot',
+    'tools.ozone.report.defs#reasonMisleadingImpersonation',
+    'tools.ozone.report.defs#reasonMisleadingSpam',
+    'tools.ozone.report.defs#reasonMisleadingScam',
+    'tools.ozone.report.defs#reasonMisleadingSyntheticContent',
+    'tools.ozone.report.defs#reasonMisleadingMisinformation',
+    'tools.ozone.report.defs#reasonMisleadingOther',
+  ],
+  'Rule Violations': [
+    'tools.ozone.report.defs#reasonRuleSiteSecurity',
+    'tools.ozone.report.defs#reasonRuleStolenContent',
+    'tools.ozone.report.defs#reasonRuleProhibitedSales',
+    'tools.ozone.report.defs#reasonRuleBanEvasion',
+    'tools.ozone.report.defs#reasonRuleOther',
+  ],
+  Civic: [
+    'tools.ozone.report.defs#reasonCivicElectoralProcess',
+    'tools.ozone.report.defs#reasonCivicDisclosure',
+    'tools.ozone.report.defs#reasonCivicInterference',
+    'tools.ozone.report.defs#reasonCivicMisinformation',
+    'tools.ozone.report.defs#reasonCivicImpersonation',
+  ],
 }


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/3881

<img width="527" height="678" alt="Screenshot 2025-07-22 at 16 47 32" src="https://github.com/user-attachments/assets/f96adf2e-51fa-4fd0-b03d-54aaf247e307" />

> New reporting types in event filter panel

<img width="478" height="229" alt="Screenshot 2025-07-22 at 16 47 59" src="https://github.com/user-attachments/assets/f691c8bd-9513-4a94-a25a-45f3b8d05e72" />

> New reporting types in event and tag view

<img width="504" height="662" alt="Screenshot 2025-07-22 at 16 48 22" src="https://github.com/user-attachments/assets/4a5656c1-0ad8-4546-be93-649a0ef850f3" />

> New reporting types in report panel