### PR TITLE
:sparkles: Add batchId filter for events panel and dedicated batch action viewer

### DIFF
--- a/app/events/batch/[batchId]/page.tsx
+++ b/app/events/batch/[batchId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { use } from 'react'
 import { ModEventList } from '@/mod-event/EventList'
+import { CopyButton } from '@/common/CopyButton'
 
 export default function BatchActions(props: {
   params: Promise<{ batchId: string }>
@@ -14,6 +15,11 @@ export default function BatchActions(props: {
         <div className="mb-6">
           <h1 className="text-base font-bold text-gray-900 dark:text-gray-100">
             Batch ID: {batchId}
+            <CopyButton
+              text={batchId}
+              className="ml-1"
+              title={`Copy batch id to clipboard`}
+            />
           </h1>
         </div>
         <ModEventList batchId={batchId} />

--- a/app/events/batch/[batchId]/page.tsx
+++ b/app/events/batch/[batchId]/page.tsx
@@ -16,7 +16,7 @@ export default function BatchActions(props: {
             Batch ID: {batchId}
           </h1>
         </div>
-        <ModEventList batchId={batchId} disableBatchIdFilter={true} />
+        <ModEventList batchId={batchId} />
       </div>
     </div>
   )

--- a/app/events/batch/[batchId]/page.tsx
+++ b/app/events/batch/[batchId]/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { use } from 'react'
+import { ModEventList } from '@/mod-event/EventList'
+
+export default function BatchActions(props: {
+  params: Promise<{ batchId: string }>
+}) {
+  const params = use(props.params)
+  const batchId = decodeURIComponent(params.batchId)
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="pt-4 max-w-3xl w-full mx-auto dark:text-gray-100">
+        <div className="mb-6">
+          <h1 className="text-base font-bold text-gray-900 dark:text-gray-100">
+            Batch ID: {batchId}
+          </h1>
+        </div>
+        <ModEventList batchId={batchId} disableBatchIdFilter={true} />
+      </div>
+    </div>
+  )
+}

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -134,7 +134,6 @@ export const ModEventList = (
     subject?: string
     createdBy?: string
     batchId?: string
-    disableBatchIdFilter?: boolean
     stats?: {
       accountStats?: ToolsOzoneModerationDefs.AccountStats
       recordsStats?: ToolsOzoneModerationDefs.RecordsStats
@@ -347,7 +346,7 @@ export const ModEventList = (
             createdBy,
             subject,
             batchId,
-            disableBatchIdFilter: props.disableBatchIdFilter,
+            isBatchIdFromProp: !!props.batchId,
             oldestFirst,
             createdAfter,
             createdBefore,

--- a/components/mod-event/EventList.tsx
+++ b/components/mod-event/EventList.tsx
@@ -133,6 +133,8 @@ export const ModEventList = (
   props: {
     subject?: string
     createdBy?: string
+    batchId?: string
+    disableBatchIdFilter?: boolean
     stats?: {
       accountStats?: ToolsOzoneModerationDefs.AccountStats
       recordsStats?: ToolsOzoneModerationDefs.RecordsStats
@@ -162,6 +164,7 @@ export const ModEventList = (
     setCommentFilterKeyword,
     createdBy,
     subject,
+    batchId,
     oldestFirst,
     createdAfter,
     createdBefore,
@@ -209,6 +212,9 @@ export const ModEventList = (
         }
         if (props.createdBy) {
           changeListFilter({ field: 'createdBy', value: props.createdBy })
+        }
+        if (props.batchId) {
+          changeListFilter({ field: 'batchId', value: props.batchId })
         }
       },
     })
@@ -340,6 +346,8 @@ export const ModEventList = (
             setCommentFilterKeyword,
             createdBy,
             subject,
+            batchId,
+            disableBatchIdFilter: props.disableBatchIdFilter,
             oldestFirst,
             createdAfter,
             createdBefore,

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -31,7 +31,6 @@ export const EventFilterPanel = ({
   createdBy,
   subject,
   batchId,
-  disableBatchIdFilter,
   oldestFirst,
   createdAfter,
   createdBefore,
@@ -42,8 +41,9 @@ export const EventFilterPanel = ({
   subjectType,
   selectedCollections,
   ageAssuranceState,
+  isBatchIdFromProp = false,
 }: Omit<EventListState, 'includeAllUserRecords' | 'showContentPreview'> & {
-  disableBatchIdFilter?: boolean
+  isBatchIdFromProp?: boolean
 } & Pick<
     ReturnType<typeof useModEventList>,
     | 'changeListFilter'
@@ -328,6 +328,7 @@ export const EventFilterPanel = ({
               value: ev.target.value,
             })
           }
+          disabled={isBatchIdFromProp}
           autoComplete="off"
         />
       </FormLabel>

--- a/components/mod-event/FilterPanel.tsx
+++ b/components/mod-event/FilterPanel.tsx
@@ -30,6 +30,8 @@ export const EventFilterPanel = ({
   commentFilter,
   createdBy,
   subject,
+  batchId,
+  disableBatchIdFilter,
   oldestFirst,
   createdAfter,
   createdBefore,
@@ -40,8 +42,9 @@ export const EventFilterPanel = ({
   subjectType,
   selectedCollections,
   ageAssuranceState,
-}: Omit<EventListState, 'includeAllUserRecords' | 'showContentPreview'> &
-  Pick<
+}: Omit<EventListState, 'includeAllUserRecords' | 'showContentPreview'> & {
+  disableBatchIdFilter?: boolean
+} & Pick<
     ReturnType<typeof useModEventList>,
     | 'changeListFilter'
     | 'applyFilterMacro'
@@ -311,6 +314,24 @@ export const EventFilterPanel = ({
           </FormLabel>
         </div>
       </div>
+      <FormLabel label="Batch ID" htmlFor="batchId" className="flex-1 mt-2">
+        <Input
+          type="text"
+          id="batchId"
+          name="batchId"
+          placeholder="Batch identifier"
+          className="block w-full"
+          value={batchId}
+          onChange={(ev) =>
+            changeListFilter({
+              field: 'batchId',
+              value: ev.target.value,
+            })
+          }
+          autoComplete="off"
+        />
+      </FormLabel>
+
       {types.includes(MOD_EVENTS.TAKEDOWN) && (
         <div className="flex flex-row gap-2 mt-2">
           <FormLabel label="Policy" className="flex-1">
@@ -472,6 +493,7 @@ export const EventFilterPanel = ({
                   commentFilter,
                   createdBy,
                   subject,
+                  batchId,
                   oldestFirst,
                   createdAfter,
                   createdBefore,

--- a/components/mod-event/ModToolInfo.tsx
+++ b/components/mod-event/ModToolInfo.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDownIcon,
 } from '@heroicons/react/20/solid'
 import { useModToolContext } from './ModToolContext'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 
 type ModToolInfoProps = {
   modTool: {
@@ -26,6 +27,15 @@ export const ModToolInfo = ({ modTool }: ModToolInfoProps) => {
           <span className="font-mono text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">
             {modTool.name}
           </span>
+          {hasMetadata && modTool.meta?.batchId && (
+            <a
+              href={`/events/batch/${modTool.meta.batchId}`}
+              title="View Batch Actions"
+              target="_blank"
+            >
+              <ArrowTopRightOnSquareIcon className="h-3 w-3 text-gray-700 dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-200 transition-colors" />
+            </a>
+          )}
         </div>
         {hasMetadata && (
           <button

--- a/components/mod-event/useModEventList.tsx
+++ b/components/mod-event/useModEventList.tsx
@@ -59,6 +59,7 @@ const initialListState = {
   commentFilter: { enabled: false, keyword: '' },
   createdBy: undefined,
   subject: undefined,
+  batchId: undefined,
   oldestFirst: false,
   createdBefore: formatDateForInput(addDays(new Date(), 1)),
   createdAfter: FIRST_EVENT_TIMESTAMP,
@@ -139,13 +140,14 @@ const getReposAndRecordsForEvents = async (
   return { repos, records }
 }
 
-// The 2 fields need overriding because in the initialState, they are set as undefined so the alternative string type is not accepted without override
+// The 3 fields need overriding because in the initialState, they are set as undefined so the alternative string type is not accepted without override
 export type EventListState = Omit<
   typeof initialListState,
-  'subject' | 'createdBy' | 'subjectType'
+  'subject' | 'createdBy' | 'batchId' | 'subjectType'
 > & {
   subject?: string
   createdBy?: string
+  batchId?: string
   reportTypes: string[]
   addedLabels: string[]
   removedLabels: string[]
@@ -161,6 +163,7 @@ type EventListFilterPayload =
   | { field: 'commentFilter'; value: CommentFilter }
   | { field: 'createdBy'; value: string | undefined }
   | { field: 'subject'; value: string | undefined }
+  | { field: 'batchId'; value: string | undefined }
   | { field: 'oldestFirst'; value: boolean }
   | { field: 'createdBefore'; value: string }
   | { field: 'createdAfter'; value: string }
@@ -232,6 +235,7 @@ const getModEvents =
       commentFilter,
       createdBy,
       subject,
+      batchId,
       oldestFirst,
       createdBefore,
       createdAfter,
@@ -258,6 +262,10 @@ const getModEvents =
 
     if (createdBy?.trim()) {
       queryParams.createdBy = createdBy
+    }
+
+    if (batchId?.trim()) {
+      queryParams.batchId = batchId.trim()
     }
 
     if (createdAfter) {
@@ -381,6 +389,7 @@ export const useModEventList = (
     subject?: string
     createdBy?: string
     eventType?: string
+    batchId?: string
   } & ModEventListQueryOptions,
 ) => {
   const [showWorkspaceConfirmation, setShowWorkspaceConfirmation] =
@@ -419,6 +428,15 @@ export const useModEventList = (
       })
     }
   }, [props.eventType])
+
+  useEffect(() => {
+    if (props.batchId !== listState.batchId) {
+      dispatch({
+        type: 'SET_FILTER',
+        payload: { field: 'batchId', value: props.batchId },
+      })
+    }
+  }, [props.batchId])
 
   useEffect(() => {
     if (!showWorkspaceConfirmation) {
@@ -477,6 +495,7 @@ export const useModEventList = (
     listState.commentFilter.enabled ||
     listState.createdBy ||
     listState.subject ||
+    listState.batchId ||
     listState.oldestFirst ||
     listState.policies.length > 0 ||
     listState.reportTypes.length > 0 ||

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -13,6 +13,7 @@ import { getBatchId, regenerateBatchId } from '@/lib/batchId'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { ArrowPathIcon } from '@heroicons/react/24/solid'
+import { CopyButton } from '@/common/CopyButton'
 
 export const WorkspacePanelActionForm = ({
   handleEmailSubmit,
@@ -30,7 +31,7 @@ export const WorkspacePanelActionForm = ({
   const handleRegenerateBatchId = () => {
     const newBatchId = regenerateBatchId()
     setCurrentBatchId(newBatchId)
-    toast.success('Batch ID regenerated successfully')
+    toast.success('Workspace Batch ID updated')
   }
   const isAckEvent = modEventType === MOD_EVENTS.ACKNOWLEDGE
   const isEmailEvent = modEventType === MOD_EVENTS.EMAIL
@@ -207,7 +208,7 @@ export const WorkspacePanelActionForm = ({
             </FormLabel>
           </div>
 
-          <div className="mb-3 p-3 bg-gray-50 dark:bg-gray-800 rounded border">
+          <div className="mb-3 p-2 bg-gray-50 dark:bg-gray-800 rounded border">
             <div className="flex items-center justify-between">
               <div>
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -217,14 +218,22 @@ export const WorkspacePanelActionForm = ({
                   {currentBatchId}
                 </span>
               </div>
-              <button
-                type="button"
-                onClick={handleRegenerateBatchId}
-                className="px-2 py-1 text-xs bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded transition-colors"
-                title="Regenerate Batch ID"
-              >
-                <ArrowPathIcon className="h-3 w-3 text-gray-500 dark:text-gray-300" />
-              </button>
+              <div>
+                <CopyButton
+                  text={currentBatchId}
+                  className="mr-2"
+                  labelText="Batch ID "
+                  title={`Copy batch id to clipboard`}
+                />
+                <button
+                  type="button"
+                  onClick={handleRegenerateBatchId}
+                  className="text-xs text-white transition-colors"
+                  title="Regenerate Batch ID"
+                >
+                  <ArrowPathIcon className="h-3 w-3 text-gray-500 dark:text-gray-300" />
+                </button>
+              </div>
             </div>
           </div>
 

--- a/components/workspace/hooks.tsx
+++ b/components/workspace/hooks.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/lib/csv'
 import { getLocalStorageData, setLocalStorageData } from '@/lib/local-storage'
 import { buildBlueSkyAppUrl, isNonNullable, pluralize } from '@/lib/util'
+import { regenerateBatchId } from '@/lib/batchId'
 import { useServerConfig } from '@/shell/ConfigurationContext'
 import {
   AtUri,
@@ -275,5 +276,7 @@ const removeFromList = (items: string[]) => {
 
 const emptyList = () => {
   setLocalStorageData(WORKSPACE_LIST_KEY, null)
+  // Clearing workspace needs to regenerate Batch ID to avoid accidental duplicate batch ids
+  regenerateBatchId()
   return []
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:run": "$(yarn bin)/cypress run --browser chrome"
   },
   "dependencies": {
-    "@atproto/api": "0.15.24",
+    "@atproto/api": "0.16.3",
     "@atproto/oauth-client-browser": "^0.2.0",
     "@atproto/oauth-types": "^0.1.4",
     "@atproto/xrpc": "^0.6.1",

--- a/service/package.json
+++ b/service/package.json
@@ -3,7 +3,7 @@
   "description": "Ozone service entrypoint",
   "main": "index.js",
   "dependencies": {
-    "@atproto/ozone": "0.1.129",
+    "@atproto/ozone": "0.1.136",
     "next": "15.2.4",
     "react": "19.1.0"
   }

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -5,19 +5,19 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@atproto/api@npm:^0.15.24":
-  version: 0.15.24
-  resolution: "@atproto/api@npm:0.15.24"
+"@atproto/api@npm:^0.16.3":
+  version: 0.16.3
+  resolution: "@atproto/api@npm:0.16.3"
   dependencies:
     "@atproto/common-web": "npm:^0.4.2"
-    "@atproto/lexicon": "npm:^0.4.12"
+    "@atproto/lexicon": "npm:^0.4.13"
     "@atproto/syntax": "npm:^0.4.0"
-    "@atproto/xrpc": "npm:^0.7.1"
+    "@atproto/xrpc": "npm:^0.7.2"
     await-lock: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/4e75f9c1bdd211693e9ef52e554bbb70254f7fe1b6d29eb939c352c4014ce7924dce18f33c8744b1004064425508045d031476fe25e16d16c8e0f0ea52202648
+  checksum: 10c0/6033fbd28ee6118c951f548baf6c2a6b1486112c2523d6c30d841f2067c0a8def56ab8b2ee832a25ca9fce620fe2e00def7bd42fb6cb01275ce1b6ea0df014e6
   languageName: node
   linkType: hard
 
@@ -93,31 +93,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/lexicon@npm:^0.4.12":
-  version: 0.4.12
-  resolution: "@atproto/lexicon@npm:0.4.12"
+"@atproto/lexicon@npm:^0.4.13":
+  version: 0.4.13
+  resolution: "@atproto/lexicon@npm:0.4.13"
   dependencies:
     "@atproto/common-web": "npm:^0.4.2"
     "@atproto/syntax": "npm:^0.4.0"
     iso-datestring-validator: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/b851c06040d7a2b6e5105b6b8a52452daa708097f8bb43515614c08773ca79188ee9351130f45df13f9ff92619d85bc1afeaa6e082e3fe1f12dfc51dc91bc5f0
+  checksum: 10c0/98199b20a33ed1146014d2882b27ae49ca10e52fdde9bb3cea112219805c288e47deebb0f79c1a7a3d8f2e2b4f8b628b5577bb330a908f6c4691681aa43766e8
   languageName: node
   linkType: hard
 
-"@atproto/ozone@npm:0.1.129":
-  version: 0.1.129
-  resolution: "@atproto/ozone@npm:0.1.129"
+"@atproto/ozone@npm:0.1.136":
+  version: 0.1.136
+  resolution: "@atproto/ozone@npm:0.1.136"
   dependencies:
-    "@atproto/api": "npm:^0.15.24"
+    "@atproto/api": "npm:^0.16.3"
     "@atproto/common": "npm:^0.4.11"
     "@atproto/crypto": "npm:^0.4.4"
     "@atproto/identity": "npm:^0.4.8"
-    "@atproto/lexicon": "npm:^0.4.12"
+    "@atproto/lexicon": "npm:^0.4.13"
     "@atproto/syntax": "npm:^0.4.0"
-    "@atproto/xrpc": "npm:^0.7.1"
-    "@atproto/xrpc-server": "npm:^0.9.0"
+    "@atproto/xrpc": "npm:^0.7.2"
+    "@atproto/xrpc-server": "npm:^0.9.2"
     "@did-plc/lib": "npm:^0.0.1"
     compression: "npm:^1.7.4"
     cors: "npm:^2.8.5"
@@ -134,7 +134,7 @@ __metadata:
     uint8arrays: "npm:3.0.0"
     undici: "npm:^6.14.1"
     ws: "npm:^8.12.0"
-  checksum: 10c0/43f3139f6f94d515586a2d3ae09b0400bdf5be6cd155448e58e9f01f4f4617e36e779d46fa147fafce0819c2e38b610cc6341cb52e1950762cd687a5748dd1d1
+  checksum: 10c0/400732c69e18a6607ff304f23e7d8d98935acc94ad918b24ed0683c2c6702021c74d710b7ba92ccbdb22ba784bdacf297709dddc28463c1af871f53cda896db3
   languageName: node
   linkType: hard
 
@@ -145,14 +145,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/xrpc-server@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@atproto/xrpc-server@npm:0.9.0"
+"@atproto/xrpc-server@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@atproto/xrpc-server@npm:0.9.2"
   dependencies:
     "@atproto/common": "npm:^0.4.11"
     "@atproto/crypto": "npm:^0.4.4"
-    "@atproto/lexicon": "npm:^0.4.12"
-    "@atproto/xrpc": "npm:^0.7.1"
+    "@atproto/lexicon": "npm:^0.4.13"
+    "@atproto/xrpc": "npm:^0.7.2"
     cbor-x: "npm:^1.5.1"
     express: "npm:^4.17.2"
     http-errors: "npm:^2.0.0"
@@ -161,17 +161,17 @@ __metadata:
     uint8arrays: "npm:3.0.0"
     ws: "npm:^8.12.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/9657c2b0e7a425b76f7d760be99ed1971081dcbfbf1dfbe2bd36630ddc03de5281433111dbddac2a1e55d2383e07ad1e37121dee4b33433d9b14125163e1e56c
+  checksum: 10c0/00f7536343f2be045d1c220cff58b0e79e7e576cd1fd8add9f7238c6ee6ee0716b101bc4fd1a83e525076ebed8e7934a7e2eb180a34a1d90ab4bb1de375abcef
   languageName: node
   linkType: hard
 
-"@atproto/xrpc@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@atproto/xrpc@npm:0.7.1"
+"@atproto/xrpc@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@atproto/xrpc@npm:0.7.2"
   dependencies:
-    "@atproto/lexicon": "npm:^0.4.12"
+    "@atproto/lexicon": "npm:^0.4.13"
     zod: "npm:^3.23.8"
-  checksum: 10c0/2e0c6b522ec1b145880ac471ba9f103950d5574260c2427541f5378876db9aafe88bc86481631ba85ff9a5faec93091eb56ff3ed2f03d61c2ed19c0e9461c366
+  checksum: 10c0/549d66b7ed652df5aefe730e495d9e772d23ff2af3c046eb63b88b6d6678680ce9499f39d6881f48be392ed0d248c220d2d09e07f262a47c2066b2a0f1a2a04f
   languageName: node
   linkType: hard
 
@@ -1971,7 +1971,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone-service@workspace:."
   dependencies:
-    "@atproto/ozone": "npm:0.1.129"
+    "@atproto/ozone": "npm:0.1.136"
     next: "npm:15.2.4"
     react: "npm:19.1.0"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,19 +79,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/api@npm:0.15.24":
-  version: 0.15.24
-  resolution: "@atproto/api@npm:0.15.24"
+"@atproto/api@npm:0.16.3":
+  version: 0.16.3
+  resolution: "@atproto/api@npm:0.16.3"
   dependencies:
     "@atproto/common-web": "npm:^0.4.2"
-    "@atproto/lexicon": "npm:^0.4.12"
+    "@atproto/lexicon": "npm:^0.4.13"
     "@atproto/syntax": "npm:^0.4.0"
-    "@atproto/xrpc": "npm:^0.7.1"
+    "@atproto/xrpc": "npm:^0.7.2"
     await-lock: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/4e75f9c1bdd211693e9ef52e554bbb70254f7fe1b6d29eb939c352c4014ce7924dce18f33c8744b1004064425508045d031476fe25e16d16c8e0f0ea52202648
+  checksum: 10c0/6033fbd28ee6118c951f548baf6c2a6b1486112c2523d6c30d841f2067c0a8def56ab8b2ee832a25ca9fce620fe2e00def7bd42fb6cb01275ce1b6ea0df014e6
   languageName: node
   linkType: hard
 
@@ -171,16 +171,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/lexicon@npm:^0.4.12":
-  version: 0.4.12
-  resolution: "@atproto/lexicon@npm:0.4.12"
+"@atproto/lexicon@npm:^0.4.13":
+  version: 0.4.13
+  resolution: "@atproto/lexicon@npm:0.4.13"
   dependencies:
     "@atproto/common-web": "npm:^0.4.2"
     "@atproto/syntax": "npm:^0.4.0"
     iso-datestring-validator: "npm:^2.2.2"
     multiformats: "npm:^9.9.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/b851c06040d7a2b6e5105b6b8a52452daa708097f8bb43515614c08773ca79188ee9351130f45df13f9ff92619d85bc1afeaa6e082e3fe1f12dfc51dc91bc5f0
+  checksum: 10c0/98199b20a33ed1146014d2882b27ae49ca10e52fdde9bb3cea112219805c288e47deebb0f79c1a7a3d8f2e2b4f8b628b5577bb330a908f6c4691681aa43766e8
   languageName: node
   linkType: hard
 
@@ -254,13 +254,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/xrpc@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "@atproto/xrpc@npm:0.7.1"
+"@atproto/xrpc@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@atproto/xrpc@npm:0.7.2"
   dependencies:
-    "@atproto/lexicon": "npm:^0.4.12"
+    "@atproto/lexicon": "npm:^0.4.13"
     zod: "npm:^3.23.8"
-  checksum: 10c0/2e0c6b522ec1b145880ac471ba9f103950d5574260c2427541f5378876db9aafe88bc86481631ba85ff9a5faec93091eb56ff3ed2f03d61c2ed19c0e9461c366
+  checksum: 10c0/549d66b7ed652df5aefe730e495d9e772d23ff2af3c046eb63b88b6d6678680ce9499f39d6881f48be392ed0d248c220d2d09e07f262a47c2066b2a0f1a2a04f
   languageName: node
   linkType: hard
 
@@ -7311,7 +7311,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone@workspace:."
   dependencies:
-    "@atproto/api": "npm:0.15.24"
+    "@atproto/api": "npm:0.16.3"
     "@atproto/oauth-client-browser": "npm:^0.2.0"
     "@atproto/oauth-types": "npm:^0.1.4"
     "@atproto/xrpc": "npm:^0.6.1"


### PR DESCRIPTION
Depends on https://github.com/bluesky-social/atproto/pull/4109

- Allows filtering event stream for specific `batchId`
- Adds dedicated page on `/events/batch/[batchId]` route to show all events for a batchId


https://github.com/user-attachments/assets/110579f9-520b-42eb-a79b-b75d0e582cb0

