### PR TITLE
❇️ Label Group Configuration

### DIFF
--- a/components/common/labels/LabelChip.tsx
+++ b/components/common/labels/LabelChip.tsx
@@ -17,10 +17,10 @@ export const getLabelColorConfig = (
 ): LabelColorConfig => {
   // Group color has the highest priority
   if (labelGroups) {
-    const labelGroup = Object.entries(labelGroups).find(([_, group]) =>
+    const labelGroup = Object.values(labelGroups).find((group) =>
       group.labels.includes(labelValue),
     )
-    const groupColor = labelGroup?.[1]?.color
+    const groupColor = labelGroup?.color
 
     if (groupColor) {
       return {
@@ -77,11 +77,8 @@ export const getGroupInfo = (
 
   if (!labelGroup) return null
 
-  return {
-    name: labelGroup[0],
-    color: labelGroup[1]?.color,
-    note: labelGroup[1]?.note,
-  }
+  const [name, group] = labelGroup
+  return { name, ...group }
 }
 
 export const getLabelWrapperClasses = (

--- a/components/common/labels/List.tsx
+++ b/components/common/labels/List.tsx
@@ -18,7 +18,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { ComponentProps, Fragment } from 'react'
 import { useLabelerDefinitionQuery } from './useLabelerDefinition'
-import { isSelfLabel, toLabelVal } from './util'
+import { DEFAULT_LABEL_GROUP_COLOR, isSelfLabel, toLabelVal } from './util'
 import { useLabelGroups } from '@/config/useLabelGroups'
 import { getLabelColorConfig, getGroupInfo } from './LabelChip'
 
@@ -274,7 +274,7 @@ export const LabelDefinition = ({
     <div className="flex flex-row items-start leading-4">
       <div
         className="h-4 w-4 mr-1 mt-0.5 rounded-sm border border-gray-300"
-        style={{ backgroundColor: groupColor || '#6366f1' }}
+        style={{ backgroundColor: groupColor || DEFAULT_LABEL_GROUP_COLOR }}
       />
       <p className="italic">
         This label belongs to the{' '}

--- a/components/common/labels/List.tsx
+++ b/components/common/labels/List.tsx
@@ -20,7 +20,7 @@ import { ComponentProps, Fragment } from 'react'
 import { useLabelerDefinitionQuery } from './useLabelerDefinition'
 import { isSelfLabel, toLabelVal } from './util'
 import { useLabelGroups } from '@/config/useLabelGroups'
-import { getLabelColorConfig, getGroupInfo } from './SharedLabelChip'
+import { getLabelColorConfig, getGroupInfo } from './LabelChip'
 
 export function LabelList(props: ComponentProps<'div'>) {
   const { className = '', ...others } = props
@@ -44,9 +44,13 @@ export function LabelListEmpty(props: ComponentProps<'div'>) {
 
 export function LabelChip(props: ComponentProps<'span'>) {
   const { className = '', ...others } = props
+
   return (
     <span
-      className={`inline-flex mx-1 items-center rounded-md px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 font-semibold ${className}`}
+      className={classNames(
+        `inline-flex mx-1 items-center rounded-md px-2 py-0.5 text-xs font-medium bg-gray-100 font-semibold ${className}`,
+        !className.includes('text-') ? 'text-gray-600' : '',
+      )}
       {...others}
     />
   )
@@ -68,9 +72,11 @@ const getLabelChipClassNames = ({
     label.val,
     isSelfLabeled,
     labelDefFromService,
-    groupColor ? { [label.val]: { labels: [label.val], color: groupColor } } : undefined
+    groupColor
+      ? { [label.val]: { labels: [label.val], color: groupColor } }
+      : undefined,
   )
-  
+
   // Build wrapper classes for non-group colors
   const wrapper: string[] = []
   if (!colorConfig.hasGroupColor) {
@@ -119,7 +125,7 @@ export const ModerationLabel = ({
   const labelDefFromService =
     labelerServiceDef?.policies.definitionById?.[label.val]
   const labelerProfile = labelerServiceDef?.creator
-  
+
   // Use shared utility to get group info
   const groupInfo = getGroupInfo(label.val, labelGroups)
 
@@ -136,29 +142,31 @@ export const ModerationLabel = ({
         <>
           <PopoverButton className="ring-none">
             <LabelChip
-              className={classNames(...[labelClassNames.wrapper, className])}
-              style={labelClassNames.hasGroupColor ? { backgroundColor: labelClassNames.groupColor } : undefined}
+              className={classNames(
+                labelClassNames.wrapper,
+                labelClassNames.text,
+                className,
+              )}
+              style={
+                labelClassNames.hasGroupColor
+                  ? { backgroundColor: labelClassNames.groupColor }
+                  : undefined
+              }
               {...props}
             >
               {isFromCurrentService && (
                 <HomeIcon
-                  className={classNames(
-                    ...['h-3 w-3 mr-1', labelClassNames.text],
-                  )}
+                  className={classNames('h-3 w-3 mr-1', labelClassNames.text)}
                 />
               )}
               {isSelfLabeled && (
                 <TagIcon
-                  className={classNames(
-                    ...['h-3 w-3 mr-1', labelClassNames.text],
-                  )}
+                  className={classNames('h-3 w-3 mr-1', labelClassNames.text)}
                 />
               )}
               {label.exp && (
                 <ClockIcon
-                  className={classNames(
-                    ...['h-3 w-3 mr-1', labelClassNames.text],
-                  )}
+                  className={classNames('h-3 w-3 mr-1', labelClassNames.text)}
                 />
               )}
               {labelVal}
@@ -264,12 +272,20 @@ export const LabelDefinition = ({
 
   const groupInfo = groupName && (
     <div className="flex flex-row items-start leading-4">
-      <div 
+      <div
         className="h-4 w-4 mr-1 mt-0.5 rounded-sm border border-gray-300"
         style={{ backgroundColor: groupColor || '#6366f1' }}
       />
       <p className="italic">
-        This label belongs to the <strong>{groupName}</strong> group
+        This label belongs to the{' '}
+        <a
+          target="_blank"
+          className="underline"
+          href={`/configure#configure-label-groups`}
+        >
+          {groupName}
+        </a>{' '}
+        group
       </p>
     </div>
   )

--- a/components/common/labels/List.tsx
+++ b/components/common/labels/List.tsx
@@ -56,7 +56,6 @@ export function LabelChip(props: ComponentProps<'span'>) {
   )
 }
 
-// Legacy function kept for backward compatibility - now uses shared utilities
 const getLabelChipClassNames = ({
   label,
   isSelfLabeled = false,

--- a/components/common/labels/Selector.tsx
+++ b/components/common/labels/Selector.tsx
@@ -44,7 +44,7 @@ export const LabelSelector = (props: LabelsProps) => {
 
   const organizedLabels = useMemo(() => {
     if (!labelGroups || !selectorOptions.length) {
-      return { ungrouped: selectorOptions }
+      return { Ungrouped: selectorOptions }
     }
 
     const grouped: Record<string, string[]> = {}
@@ -65,20 +65,15 @@ export const LabelSelector = (props: LabelsProps) => {
     const remainingLabels = selectorOptions.filter(
       (label) => !groupedLabels.has(label),
     )
-    if (remainingLabels.length > 0 && Object.keys(grouped).length > 0) {
+    if (remainingLabels.length > 0) {
       grouped['Ungrouped'] = remainingLabels
     }
 
-    // return all as ungrouped when no groups are found
-    if (Object.keys(grouped).length === 0) {
-      return { ungrouped: selectorOptions }
-    }
-
-    return { grouped }
+    return grouped
   }, [labelGroups, selectorOptions])
 
   const toggleLabel = (label: string) => {
-    const isSelected = selectedLabels.find((l) => l === label)
+    const isSelected = selectedLabels.some((l) => l === label)
     let newSelectedLabels: string[] = []
     if (isSelected) {
       newSelectedLabels = selectedLabels.filter((l) => l !== label)
@@ -108,65 +103,40 @@ export const LabelSelector = (props: LabelsProps) => {
       />
       <div data-cy="label-selector-buttons">
         {selectorOptions?.length ? (
-          organizedLabels.ungrouped ? (
-            // Render ungrouped labels (when no groups or labelGroups is null)
-            <div className="flex flex-wrap">
-              {organizedLabels.ungrouped.map((label) => {
-                const isSelected = !!selectedLabels.find((l) => l === label)
+          Object.entries(organizedLabels).map(([groupName, groupLabels]) => (
+            <div key={groupName} className="mb-2">
+              <div className="mb-1">
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-100">
+                  {groupName}
 
-                return (
-                  <LabelChip
-                    key={label}
-                    labelValue={label}
-                    labelGroups={null}
-                    isSelected={isSelected}
-                    interactive={true}
-                    onClick={() => toggleLabel(label)}
-                  />
-                )
-              })}
+                  {labelGroups?.[groupName]?.note && (
+                    <button
+                      type="button"
+                      title={labelGroups[groupName].note}
+                    >
+                      <QuestionMarkCircleIcon className="inline-block ml-1 h-4 w-4 text-gray-700 dark:text-gray-300" />
+                    </button>
+                  )}
+                </h3>
+              </div>
+              <div className="flex flex-wrap">
+                {groupLabels.map((label) => {
+                  const isSelected = selectedLabels.some((l) => l === label)
+
+                  return (
+                    <LabelChip
+                      key={label}
+                      labelValue={label}
+                      labelGroups={labelGroups}
+                      isSelected={isSelected}
+                      interactive={true}
+                      onClick={() => toggleLabel(label)}
+                    />
+                  )
+                })}
+              </div>
             </div>
-          ) : (
-            organizedLabels.grouped &&
-            Object.entries(organizedLabels.grouped).map(
-              ([groupName, groupLabels]) => (
-                <div key={groupName} className="mb-2">
-                  <div className="mb-1">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-100">
-                      {groupName}
-
-                      {labelGroups?.[groupName]?.note && (
-                        <button
-                          type="button"
-                          title={labelGroups[groupName].note}
-                        >
-                          <QuestionMarkCircleIcon className="inline-block ml-1 h-4 w-4 text-gray-700 dark:text-gray-300" />
-                        </button>
-                      )}
-                    </h3>
-                  </div>
-                  <div className="flex flex-wrap">
-                    {groupLabels.map((label) => {
-                      const isSelected = !!selectedLabels.find(
-                        (l) => l === label,
-                      )
-
-                      return (
-                        <LabelChip
-                          key={label}
-                          labelValue={label}
-                          labelGroups={labelGroups}
-                          isSelected={isSelected}
-                          interactive={true}
-                          onClick={() => toggleLabel(label)}
-                        />
-                      )
-                    })}
-                  </div>
-                </div>
-              ),
-            )
-          )
+          ))
         ) : (
           <div className="text-gray-500 dark:text-gray-400">
             No labels found.{' '}

--- a/components/common/labels/Selector.tsx
+++ b/components/common/labels/Selector.tsx
@@ -6,7 +6,7 @@ import { useLabelGroups, type LabelGroup } from '@/config/useLabelGroups'
 import { Input } from '../forms'
 import { ALL_LABELS } from './util'
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/solid'
-import { SharedLabelChip } from './SharedLabelChip'
+import { LabelChip } from './LabelChip'
 
 const EMPTY_ARR = []
 
@@ -115,14 +115,13 @@ export const LabelSelector = (props: LabelsProps) => {
                 const isSelected = !!selectedLabels.find((l) => l === label)
 
                 return (
-                  <SharedLabelChip
+                  <LabelChip
                     key={label}
                     labelValue={label}
                     labelGroups={null}
                     isSelected={isSelected}
                     interactive={true}
                     onClick={() => toggleLabel(label)}
-                    style={{ cursor: 'pointer' }}
                   />
                 )
               })}
@@ -153,14 +152,13 @@ export const LabelSelector = (props: LabelsProps) => {
                       )
 
                       return (
-                        <SharedLabelChip
+                        <LabelChip
                           key={label}
                           labelValue={label}
                           labelGroups={labelGroups}
                           isSelected={isSelected}
                           interactive={true}
                           onClick={() => toggleLabel(label)}
-                          style={{ cursor: 'pointer' }}
                         />
                       )
                     })}

--- a/components/common/labels/Selector.tsx
+++ b/components/common/labels/Selector.tsx
@@ -2,8 +2,11 @@ import { useMemo, useState } from 'react'
 
 import { unique } from '@/lib/util'
 import { useConfigurationContext } from '@/shell/ConfigurationContext'
+import { useLabelGroups, type LabelGroup } from '@/config/useLabelGroups'
 import { Input } from '../forms'
 import { ALL_LABELS } from './util'
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/solid'
+import { SharedLabelChip } from './SharedLabelChip'
 
 const EMPTY_ARR = []
 
@@ -19,6 +22,7 @@ export const LabelSelector = (props: LabelsProps) => {
   const { config } = useConfigurationContext()
   const [query, setQuery] = useState<string>('')
   const [selectedLabels, setSelectedLabels] = useState<string[]>(defaultLabels)
+  const labelGroups = useLabelGroups()
 
   const selectorOptions = useMemo(
     () =>
@@ -38,8 +42,42 @@ export const LabelSelector = (props: LabelsProps) => {
     [config, query, selectedLabels],
   )
 
-  // Function to toggle label selection
-  const toggleLabel = (label) => {
+  const organizedLabels = useMemo(() => {
+    if (!labelGroups || !selectorOptions.length) {
+      return { ungrouped: selectorOptions }
+    }
+
+    const grouped: Record<string, string[]> = {}
+    const groupedLabels = new Set<string>()
+
+    // show labels in configured groups
+    Object.entries(labelGroups).forEach(([groupName, groupData]) => {
+      const groupLabels = selectorOptions.filter((label) =>
+        (groupData as LabelGroup).labels.includes(label),
+      )
+      if (groupLabels.length > 0) {
+        grouped[groupName] = groupLabels
+        groupLabels.forEach((label) => groupedLabels.add(label))
+      }
+    })
+
+    // when grouping exists, put remaining labels to "Ungrouped" option
+    const remainingLabels = selectorOptions.filter(
+      (label) => !groupedLabels.has(label),
+    )
+    if (remainingLabels.length > 0 && Object.keys(grouped).length > 0) {
+      grouped['Ungrouped'] = remainingLabels
+    }
+
+    // return all as ungrouped when no groups are found
+    if (Object.keys(grouped).length === 0) {
+      return { ungrouped: selectorOptions }
+    }
+
+    return { grouped }
+  }, [labelGroups, selectorOptions])
+
+  const toggleLabel = (label: string) => {
     const isSelected = selectedLabels.find((l) => l === label)
     let newSelectedLabels: string[] = []
     if (isSelected) {
@@ -47,7 +85,7 @@ export const LabelSelector = (props: LabelsProps) => {
     } else {
       newSelectedLabels = [...selectedLabels, label]
     }
-    // Update the label list and call the onChange function to allow the parent component know about the change
+    // update the label listthen call the onChange function to allow the parent component know about the change
     setSelectedLabels(newSelectedLabels)
     onChange?.(newSelectedLabels)
   }
@@ -68,27 +106,69 @@ export const LabelSelector = (props: LabelsProps) => {
         placeholder="Search or add your own label"
         onChange={(e) => setQuery(e.currentTarget.value)}
       />
-      <div className="flex flex-wrap" data-cy="label-selector-buttons">
+      <div data-cy="label-selector-buttons">
         {selectorOptions?.length ? (
-          selectorOptions.map((label) => {
-            const selectedLabel = selectedLabels.find((l) => l === label)
-            const isSelected = !!selectedLabel
+          organizedLabels.ungrouped ? (
+            // Render ungrouped labels (when no groups or labelGroups is null)
+            <div className="flex flex-wrap">
+              {organizedLabels.ungrouped.map((label) => {
+                const isSelected = !!selectedLabels.find((l) => l === label)
 
-            return (
-              <button
-                key={label}
-                type="button"
-                className={`mr-1 my-1 px-2 py-0.5 text-xs rounded-md ${
-                  isSelected
-                    ? 'bg-indigo-600 border-indigo-500 text-white dark:bg-teal-600 dark:border-teal-500'
-                    : 'bg-white dark:bg-gray-600 dark:border-slate-500'
-                } inline-flex items-center border`}
-                onClick={() => toggleLabel(label)}
-              >
-                {label}
-              </button>
+                return (
+                  <SharedLabelChip
+                    key={label}
+                    labelValue={label}
+                    labelGroups={null}
+                    isSelected={isSelected}
+                    interactive={true}
+                    onClick={() => toggleLabel(label)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                )
+              })}
+            </div>
+          ) : (
+            organizedLabels.grouped &&
+            Object.entries(organizedLabels.grouped).map(
+              ([groupName, groupLabels]) => (
+                <div key={groupName} className="mb-2">
+                  <div className="mb-1">
+                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-100">
+                      {groupName}
+
+                      {labelGroups?.[groupName]?.note && (
+                        <button
+                          type="button"
+                          title={labelGroups[groupName].note}
+                        >
+                          <QuestionMarkCircleIcon className="inline-block ml-1 h-4 w-4 text-gray-700 dark:text-gray-300" />
+                        </button>
+                      )}
+                    </h3>
+                  </div>
+                  <div className="flex flex-wrap">
+                    {groupLabels.map((label) => {
+                      const isSelected = !!selectedLabels.find(
+                        (l) => l === label,
+                      )
+
+                      return (
+                        <SharedLabelChip
+                          key={label}
+                          labelValue={label}
+                          labelGroups={labelGroups}
+                          isSelected={isSelected}
+                          interactive={true}
+                          onClick={() => toggleLabel(label)}
+                          style={{ cursor: 'pointer' }}
+                        />
+                      )
+                    })}
+                  </div>
+                </div>
+              ),
             )
-          })
+          )
         ) : (
           <div className="text-gray-500 dark:text-gray-400">
             No labels found.{' '}

--- a/components/common/labels/Selector.tsx
+++ b/components/common/labels/Selector.tsx
@@ -85,7 +85,7 @@ export const LabelSelector = (props: LabelsProps) => {
     } else {
       newSelectedLabels = [...selectedLabels, label]
     }
-    // update the label listthen call the onChange function to allow the parent component know about the change
+    // Update the label list and call the onChange function to allow the parent component know about the change
     setSelectedLabels(newSelectedLabels)
     onChange?.(newSelectedLabels)
   }

--- a/components/common/labels/SharedLabelChip.tsx
+++ b/components/common/labels/SharedLabelChip.tsx
@@ -1,0 +1,179 @@
+import { ComponentProps } from 'react'
+import { ComAtprotoLabelDefs } from '@atproto/api'
+import { classNames, getReadableTextColor } from '@/lib/util'
+import { useLabelGroups } from '@/config/useLabelGroups'
+
+interface LabelColorConfig {
+  backgroundColor?: string
+  textColor: string
+  hasGroupColor: boolean
+}
+
+export const getLabelColorConfig = (
+  labelValue: string,
+  isSelfLabeled = false,
+  labelDefFromService?: ComAtprotoLabelDefs.LabelValueDefinition,
+  labelGroups?: Record<string, any>
+): LabelColorConfig => {
+  // Group color has the highest priority
+  if (labelGroups) {
+    const labelGroup = Object.entries(labelGroups).find(
+      ([_, group]) => group.labels.includes(labelValue)
+    )
+    const groupColor = labelGroup?.[1]?.color
+    
+    if (groupColor) {
+      return {
+        backgroundColor: groupColor,
+        textColor: getReadableTextColor(groupColor),
+        hasGroupColor: true,
+      }
+    }
+  }
+
+  // Fallback to existing service definition logic
+  if (isSelfLabeled) {
+    return {
+      textColor: 'text-green-700',
+      hasGroupColor: false,
+    }
+  }
+  
+  if (labelDefFromService) {
+    if (labelDefFromService.severity === 'alert') {
+      return {
+        textColor: 'text-red-700',
+        hasGroupColor: false,
+      }
+    } else if (labelDefFromService.blurs === 'content') {
+      return {
+        textColor: 'text-indigo-700',
+        hasGroupColor: false,
+      }
+    } else if (labelDefFromService.blurs === 'media') {
+      return {
+        textColor: 'text-yellow-700',
+        hasGroupColor: false,
+      }
+    }
+  }
+
+  // Default
+  return {
+    textColor: 'text-gray-600',
+    hasGroupColor: false,
+  }
+}
+
+export const getGroupInfo = (labelValue: string, labelGroups?: Record<string, any>) => {
+  if (!labelGroups) return null
+  
+  const labelGroup = Object.entries(labelGroups).find(
+    ([_, group]) => group.labels.includes(labelValue)
+  )
+  
+  if (!labelGroup) return null
+  
+  return {
+    name: labelGroup[0],
+    color: labelGroup[1]?.color,
+    note: labelGroup[1]?.note,
+  }
+}
+
+export const getLabelWrapperClasses = (
+  isSelfLabeled = false,
+  labelDefFromService?: ComAtprotoLabelDefs.LabelValueDefinition,
+  hasGroupColor = false
+): string => {
+  if (hasGroupColor) {
+    return '' // No wrapper classes when using group colors (inline style instead)
+  }
+
+  const classes: string[] = []
+  
+  if (isSelfLabeled) {
+    classes.push('bg-green-200 text-green-700')
+  } else if (labelDefFromService) {
+    if (labelDefFromService.severity === 'alert') {
+      classes.push('bg-red-200 text-red-700')
+    } else if (labelDefFromService.blurs === 'content') {
+      classes.push('bg-indigo-200 text-indigo-700')
+    } else if (labelDefFromService.blurs === 'media') {
+      classes.push('bg-yellow-200 text-yellow-700')
+    }
+  }
+  
+  return classNames(...classes)
+}
+
+export interface SharedLabelChipProps extends ComponentProps<'span'> {
+  labelValue: string
+  isSelfLabeled?: boolean
+  labelDefFromService?: ComAtprotoLabelDefs.LabelValueDefinition
+  labelGroups?: Record<string, any> | null
+  isSelected?: boolean
+  interactive?: boolean
+}
+
+export const SharedLabelChip = ({
+  labelValue,
+  isSelfLabeled = false,
+  labelDefFromService,
+  labelGroups = null,
+  isSelected = false,
+  interactive = false,
+  className = '',
+  children,
+  ...props
+}: SharedLabelChipProps) => {
+  const colorConfig = getLabelColorConfig(
+    labelValue,
+    isSelfLabeled,
+    labelDefFromService,
+    labelGroups || undefined
+  )
+  
+  const wrapperClasses = getLabelWrapperClasses(
+    isSelfLabeled,
+    labelDefFromService,
+    colorConfig.hasGroupColor
+  )
+  
+  const baseClasses = interactive
+    ? `mr-1 my-1 px-2 py-0.5 text-xs rounded-md inline-flex items-center border transition-opacity ${
+        isSelected
+          ? colorConfig.hasGroupColor
+            ? `${colorConfig.textColor} border-gray-400 hover:opacity-80`
+            : 'bg-indigo-600 border-indigo-500 text-white dark:bg-teal-600 dark:border-teal-500'
+          : 'bg-white dark:bg-gray-600 dark:border-slate-500 text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-500'
+      }`
+    : `inline-flex mx-1 items-center rounded-md px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 font-semibold ${wrapperClasses}`
+
+  const style = colorConfig.hasGroupColor && (interactive ? isSelected : true)
+    ? { backgroundColor: colorConfig.backgroundColor }
+    : undefined
+
+  return (
+    <span
+      className={classNames(baseClasses, className)}
+      style={style}
+      {...props}
+    >
+      {children || labelValue}
+    </span>
+  )
+}
+
+// Hook to get both label groups and color configuration
+export const useLabelColorConfig = (labelValue: string) => {
+  const labelGroups = useLabelGroups()
+  const colorConfig = getLabelColorConfig(labelValue, false, undefined, labelGroups)
+  const groupInfo = getGroupInfo(labelValue, labelGroups)
+  
+  return {
+    colorConfig,
+    groupInfo,
+    labelGroups,
+  }
+}

--- a/components/common/labels/util.ts
+++ b/components/common/labels/util.ts
@@ -115,3 +115,5 @@ export const getLabelsForSubject = ({
 }) => {
   return record?.labels ?? repo?.labels ?? []
 }
+
+export const DEFAULT_LABEL_GROUP_COLOR = '#6366f1'

--- a/components/config/LabelGroups.tsx
+++ b/components/config/LabelGroups.tsx
@@ -1,0 +1,378 @@
+import { useState, useMemo } from 'react'
+import { useConfigurationContext } from '@/shell/ConfigurationContext'
+import { useLabelGroupsEditor, type LabelGroup } from './useLabelGroups'
+import { unique, getReadableTextColor } from '@/lib/util'
+import { ALL_LABELS } from '../common/labels/util'
+import { Card } from '@/common/Card'
+import { ActionButton } from '@/common/buttons'
+import { TrashIcon } from '@heroicons/react/24/solid'
+import { FormLabel, Input } from '@/common/forms'
+
+
+interface GroupDropZoneProps {
+  groupTitle: string
+  group: LabelGroup
+  draggedLabel: string | null
+  onAddLabelToGroup: (groupTitle: string, label: string) => void
+  onRemoveLabelFromGroup: (groupTitle: string, label: string) => void
+  onRemoveGroup: (groupTitle: string) => void
+  onUpdateGroup: (groupTitle: string, updates: { color?: string }) => void
+  onDragStart: (e: React.DragEvent, label: string) => void
+  onDragEnd: () => void
+}
+
+const GroupDropZone = ({
+  groupTitle,
+  group,
+  draggedLabel,
+  onAddLabelToGroup,
+  onRemoveLabelFromGroup,
+  onRemoveGroup,
+  onUpdateGroup,
+  onDragStart,
+  onDragEnd,
+}: GroupDropZoneProps) => {
+  const [isDragOver, setIsDragOver] = useState(false)
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+
+    const label = e.dataTransfer.getData('text/plain')
+    if (label && label !== '') {
+      onAddLabelToGroup(groupTitle, label)
+      onDragEnd()
+    }
+  }
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={`py-2 border-b transition-colors ${
+        isDragOver
+          ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900'
+          : 'border-gray-200 dark:border-gray-700'
+      }`}
+    >
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex-1">
+          <h3 className="text-sm capitalize text-gray-900 dark:text-gray-100">
+            {groupTitle}
+          </h3>
+          {group.note && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {group.note}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-row gap-2">
+          <input
+            type="color"
+            value={group.color || '#6366f1'}
+            onChange={(e) =>
+              onUpdateGroup(groupTitle, { color: e.target.value })
+            }
+            className="w-6 h-6 border-none cursor-pointer"
+          />
+          <ActionButton
+            size="sm"
+            appearance="outlined"
+            onClick={() => onRemoveGroup(groupTitle)}
+          >
+            <TrashIcon className="h-3 w-3" />
+          </ActionButton>
+        </div>
+      </div>
+
+      <div>
+        <div className="flex justify-between items-center mb-2">
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Labels ({group.labels.length})
+          </p>
+          {isDragOver && (
+            <p className="text-sm text-indigo-600 dark:text-indigo-400">
+              Drop here to add label
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {group.labels.map((label) => {
+            const groupColor = group.color || '#6366f1'
+            const textColor = getReadableTextColor(groupColor)
+            return (
+              <div
+                key={label}
+                draggable
+                onDragStart={(e) => onDragStart(e, label)}
+                onDragEnd={onDragEnd}
+                className={`px-2 py-1 text-xs rounded flex items-center gap-2 cursor-move select-none transition-colors ${
+                  draggedLabel === label
+                    ? 'bg-blue-200 dark:bg-blue-700 text-blue-800 dark:text-blue-200'
+                    : `${textColor} hover:opacity-80`
+                }`}
+                style={{
+                  backgroundColor:
+                    draggedLabel === label ? undefined : groupColor,
+                }}
+              >
+                <span>{label}</span>
+                <button
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onRemoveLabelFromGroup(groupTitle, label)
+                  }}
+                  className={`font-bold hover:opacity-80 ${textColor}`}
+                >
+                  ×
+                </button>
+              </div>
+            )
+          })}
+          {group.labels.length === 0 && (
+            <p className="text-gray-500 dark:text-gray-400 text-sm">
+              Drag labels from above to add them to this group
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const LabelGroupsConfig = () => {
+  const { config } = useConfigurationContext()
+  const {
+    editorData,
+    handleAddGroup,
+    handleRemoveGroup,
+    handleAddLabelToGroup,
+    handleRemoveLabelFromGroup,
+    handleUpdateGroup,
+    handleSave,
+    validateGroupTitle,
+    mutation,
+    canManageGroups,
+  } = useLabelGroupsEditor()
+
+  const [newGroupTitle, setNewGroupTitle] = useState('')
+  const [newGroupNote, setNewGroupNote] = useState('')
+  const [newGroupColor, setNewGroupColor] = useState('#6366f1')
+  const [draggedLabel, setDraggedLabel] = useState<string | null>(null)
+
+  const allLabels = useMemo(
+    () =>
+      unique([
+        ...(config?.labeler?.policies.labelValues || []),
+        ...Object.values(ALL_LABELS).map(({ identifier }) => identifier),
+      ]).sort((a, b) => a.localeCompare(b)),
+    [config],
+  )
+
+  // gather ungrouped labels
+  const ungroupedLabels = useMemo(() => {
+    const groupedLabels = new Set<string>()
+    Object.values(editorData).forEach((group) => {
+      group.labels.forEach((label) => groupedLabels.add(label))
+    })
+    return allLabels.filter((label) => !groupedLabels.has(label))
+  }, [allLabels, editorData])
+
+  const handleCreateGroup = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmedTitle = newGroupTitle.trim()
+    const error = validateGroupTitle(trimmedTitle)
+    if (error) {
+      return
+    }
+
+    const success = handleAddGroup(trimmedTitle, newGroupNote, newGroupColor)
+    if (success) {
+      setNewGroupTitle('')
+      setNewGroupNote('')
+      setNewGroupColor('#6366f1')
+    }
+  }
+
+  const handleDragStart = (e: React.DragEvent, label: string) => {
+    setDraggedLabel(label)
+    e.dataTransfer.setData('text/plain', label)
+    e.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDragEnd = () => {
+    setDraggedLabel(null)
+  }
+
+  if (!canManageGroups) {
+    return (
+      <div className="p-4 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 rounded">
+        <p className="text-red-700 dark:text-red-300">
+          You {"don't"} have permission to manage label groups.
+        </p>
+      </div>
+    )
+  }
+
+  const trimmedGroupTitle = newGroupTitle.trim()
+  const validatedGroupTitle = validateGroupTitle(trimmedGroupTitle)
+
+  return (
+    <div>
+      <div className="flex flex-row justify-between my-4">
+        <h4 className="font-medium text-gray-700 dark:text-gray-100">
+          Label Groups
+        </h4>
+      </div>
+      <Card className="mb-4 pb-4">
+        <div className="p-2">
+          <p className="text-sm mb-2">
+            Grouped labels help your moderators easily visualize and find labels
+            when taking moderation actions.
+            <br />
+            Create new groups below and drag your labels into appropriate groups
+            to give moderators a more organized list of labels.
+          </p>
+          <form
+            onSubmit={handleCreateGroup}
+            className="mb-2 pb-2 border-b border-gray-200 dark:border-gray-700"
+          >
+            <div className="flex flex-row gap-4">
+              <FormLabel
+                htmlFor="title"
+                label="Group Title"
+                required
+                className="mb-2 w-2/3"
+              >
+                <Input
+                  required
+                  type="text"
+                  name="title"
+                  value={newGroupTitle}
+                  className="w-full"
+                  onChange={(e) => setNewGroupTitle(e.target.value)}
+                  placeholder="NSFW, Account Labels etc."
+                />
+                {trimmedGroupTitle && validatedGroupTitle && (
+                  <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                    {validatedGroupTitle}
+                  </p>
+                )}
+              </FormLabel>
+
+              <FormLabel htmlFor="color" label="Color">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="color"
+                    id="color"
+                    value={newGroupColor}
+                    onChange={(e) => setNewGroupColor(e.target.value)}
+                    className="w-10 h-8 rounded border border-gray-300 dark:border-gray-600 cursor-pointer"
+                  />
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {newGroupColor}
+                  </span>
+                </div>
+              </FormLabel>
+            </div>
+            <FormLabel htmlFor="note" label="Note">
+              <Input
+                type="text"
+                value={newGroupNote}
+                placeholder="Optional note describing the group"
+                onChange={(e) => setNewGroupNote(e.target.value)}
+                className="w-full"
+              />
+            </FormLabel>
+            <div className="flex flex-row justify-end mt-2">
+              <ActionButton size="sm" type="submit" appearance="outlined">
+                <span className="text-xs">Add Group</span>
+              </ActionButton>
+            </div>
+          </form>
+
+          {/* ungrouped Label list*/}
+          <div className="my-2">
+            <h5 className="text-sm text-gray-900 dark:text-gray-100">
+              Ungrouped Labels ({ungroupedLabels.length})
+            </h5>
+            <p className="text-xs text-gray-700 dark:text-gray-300">
+              Drag and drop labels from here into groups
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 border-t border-b border-gray-200 pb-2 dark:border-gray-700">
+            {ungroupedLabels.map((label) => (
+              <div
+                key={label}
+                draggable
+                onDragStart={(e) => handleDragStart(e, label)}
+                onDragEnd={handleDragEnd}
+                className={`text-xs px-2 py-1 rounded cursor-move select-none transition-colors ${
+                  draggedLabel === label
+                    ? 'bg-blue-200 dark:bg-blue-700 text-blue-800 dark:text-blue-200'
+                    : 'bg-gray-100 dark:bg-gray-600 text-gray-800 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-500'
+                }`}
+              >
+                {label}
+              </div>
+            ))}
+            {ungroupedLabels.length === 0 && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                All labels have been assigned to groups. You can also drag
+                labels from one group to another to re-assign.
+              </p>
+            )}
+          </div>
+
+          <div>
+            {Object.entries(editorData).map(([groupTitle, group]) => (
+              <GroupDropZone
+                key={groupTitle}
+                groupTitle={groupTitle}
+                group={group}
+                draggedLabel={draggedLabel}
+                onAddLabelToGroup={handleAddLabelToGroup}
+                onRemoveLabelFromGroup={handleRemoveLabelFromGroup}
+                onRemoveGroup={handleRemoveGroup}
+                onUpdateGroup={handleUpdateGroup}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              />
+            ))}
+          </div>
+
+          {Object.keys(editorData).length === 0 && (
+            <div className="text-center py-4 border-b border-gray-200 dark:border-gray-700">
+              <p className="text-gray-500 dark:text-gray-400">
+                No groups created yet. Create your first group above.
+              </p>
+            </div>
+          )}
+
+          <div className="mt-3 mb-2 flex flex-row justify-end">
+            <ActionButton
+              appearance={mutation.isLoading ? 'outlined' : 'primary'}
+              disabled={mutation.isLoading}
+              onClick={handleSave}
+              size="sm"
+            >
+              Save Groups
+            </ActionButton>
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/components/config/LabelGroups.tsx
+++ b/components/config/LabelGroups.tsx
@@ -8,7 +8,6 @@ import { ActionButton } from '@/common/buttons'
 import { TrashIcon } from '@heroicons/react/24/solid'
 import { FormLabel, Input } from '@/common/forms'
 
-
 interface GroupDropZoneProps {
   groupTitle: string
   group: LabelGroup
@@ -230,7 +229,7 @@ export const LabelGroupsConfig = () => {
   const validatedGroupTitle = validateGroupTitle(trimmedGroupTitle)
 
   return (
-    <div>
+    <div id="configure-label-groups">
       <div className="flex flex-row justify-between my-4">
         <h4 className="font-medium text-gray-700 dark:text-gray-100">
           Label Groups

--- a/components/config/Labeler.tsx
+++ b/components/config/Labeler.tsx
@@ -15,6 +15,7 @@ import { LocalPreferences } from './LocalPreferences'
 import { QueueSetting } from 'components/setting/Queue'
 import { toast } from 'react-toastify'
 import { LabelerRecordView } from 'components/labeler/RecordView'
+import { LabelGroupsConfig } from './LabelGroups'
 
 export function LabelerConfig() {
   const { config, isServiceAccount } = useConfigurationContext()
@@ -38,6 +39,7 @@ export function LabelerConfig() {
 
       <ServerConfig />
       <QueueSetting />
+      <LabelGroupsConfig />
       <LocalPreferences />
       <ExternalLabelerConfig />
     </div>

--- a/components/config/useLabelGroups.tsx
+++ b/components/config/useLabelGroups.tsx
@@ -38,18 +38,12 @@ export const useLabelGroupsList = () => {
   })
 }
 
-export const useLabelGroupsEditor = () => {
+// wrangles external data from context/react-query etc. helps keep tests and components cleaner
+export const useLabelGroupsData = () => {
   const queryClient = useQueryClient()
   const labelerAgent = useLabelerAgent()
   const { data: initialSetting } = useLabelGroupsList()
-  const [editorData, setEditorData] = useState<LabelGroupsSetting>({})
   const { role } = useServerConfig()
-
-  useEffect(() => {
-    if (initialSetting) {
-      setEditorData(initialSetting.value)
-    }
-  }, [initialSetting])
 
   const mutation = useMutation({
     mutationKey: ['label-groups-setting', 'upsert'],
@@ -71,6 +65,21 @@ export const useLabelGroupsEditor = () => {
       toast.error(`Failed to save label groups: ${error?.['message']}`)
     },
   })
+
+  return {
+    initialSetting,
+    mutation,
+    canManageGroups: role === ToolsOzoneTeamDefs.ROLEADMIN,
+  }
+}
+
+// local state management hook for group editor
+export const useLabelGroupsEditor = (initialData: LabelGroupsSetting = {}) => {
+  const [editorData, setEditorData] = useState<LabelGroupsSetting>(initialData)
+
+  useEffect(() => {
+    setEditorData(initialData)
+  }, [initialData])
 
   const handleAddGroup = (title: string, note?: string, color?: string) => {
     const trimmedTitle = title.trim()
@@ -142,12 +151,6 @@ export const useLabelGroupsEditor = () => {
     }))
   }
 
-  const handleSave = () => {
-    if (editorData) {
-      mutation.mutate(editorData)
-    }
-  }
-
   const getGroupTitles = () => Object.keys(editorData)
 
   const validateGroupTitle = (title: string) => {
@@ -164,10 +167,8 @@ export const useLabelGroupsEditor = () => {
   }
 
   return {
-    mutation,
     editorData,
     setEditorData,
-    handleSave,
     handleAddGroup,
     handleUpdateGroup,
     handleRemoveGroup,
@@ -176,7 +177,6 @@ export const useLabelGroupsEditor = () => {
     getGroupTitles,
     validateGroupTitle,
     getLabelGroup,
-    canManageGroups: role === ToolsOzoneTeamDefs.ROLEADMIN,
   }
 }
 

--- a/components/config/useLabelGroups.tsx
+++ b/components/config/useLabelGroups.tsx
@@ -1,0 +1,186 @@
+import { useLabelerAgent, useServerConfig } from '@/shell/ConfigurationContext'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ToolsOzoneTeamDefs } from '@atproto/api'
+import { toast } from 'react-toastify'
+import { useState, useEffect } from 'react'
+
+const LabelGroupsSettingKey = 'tools.ozone.setting.labelGroups'
+
+export type LabelGroup = {
+  labels: string[]
+  note?: string
+  color?: string
+}
+
+export type LabelGroupsSetting = Record<string, LabelGroup>
+
+export const useLabelGroupsList = () => {
+  const labelerAgent = useLabelerAgent()
+  return useQuery({
+    queryKey: ['label-groups-setting'],
+    queryFn: async () => {
+      const { data } = await labelerAgent.tools.ozone.setting.listOptions({
+        scope: 'instance',
+        keys: [LabelGroupsSettingKey],
+      })
+
+      const labelGroupsSetting = data.options.find(
+        (option) => option.key === LabelGroupsSettingKey,
+      )
+
+      return labelGroupsSetting
+        ? {
+            ...labelGroupsSetting,
+            value: labelGroupsSetting.value as LabelGroupsSetting,
+          }
+        : null
+    },
+  })
+}
+
+export const useLabelGroupsEditor = () => {
+  const queryClient = useQueryClient()
+  const labelerAgent = useLabelerAgent()
+  const { data: initialSetting } = useLabelGroupsList()
+  const [editorData, setEditorData] = useState<LabelGroupsSetting>({})
+  const { role } = useServerConfig()
+
+  useEffect(() => {
+    if (initialSetting) {
+      setEditorData(initialSetting.value)
+    }
+  }, [initialSetting])
+
+  const mutation = useMutation({
+    mutationKey: ['label-groups-setting', 'upsert'],
+    mutationFn: async (value: LabelGroupsSetting) => {
+      await labelerAgent.tools.ozone.setting.upsertOption({
+        value,
+        scope: 'instance',
+        key: LabelGroupsSettingKey,
+        managerRole: ToolsOzoneTeamDefs.ROLEADMIN,
+      })
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries(['label-groups-setting'])
+      toast.success('Label groups saved')
+    },
+
+    onError: (error) => {
+      toast.error(`Failed to save label groups: ${error?.['message']}`)
+    },
+  })
+
+  const handleAddGroup = (title: string, note?: string, color?: string) => {
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle || editorData[trimmedTitle]) return false
+
+    setEditorData((prev) => ({
+      ...prev,
+      [trimmedTitle]: {
+        labels: [],
+        note: note?.trim() || undefined,
+        color: color || undefined,
+      },
+    }))
+    return true
+  }
+
+  const handleUpdateGroup = (
+    title: string,
+    updates: { labels?: string[]; note?: string; color?: string },
+  ) => {
+    setEditorData((prev) => ({
+      ...prev,
+      [title]: {
+        ...prev[title],
+        ...updates,
+      },
+    }))
+  }
+
+  const handleRemoveGroup = (title: string) => {
+    setEditorData((prev) => {
+      const { [title]: _, ...rest } = prev
+      return rest
+    })
+  }
+
+  const handleAddLabelToGroup = (groupTitle: string, label: string) => {
+    setEditorData((prev) => {
+      // Remove label from any other group first
+      const updatedData = { ...prev }
+      Object.keys(updatedData).forEach((key) => {
+        if (key !== groupTitle) {
+          updatedData[key] = {
+            ...updatedData[key],
+            labels: updatedData[key].labels.filter((l) => l !== label),
+          }
+        }
+      })
+
+      // Add to target group if not already there
+      if (!updatedData[groupTitle]?.labels.includes(label)) {
+        updatedData[groupTitle] = {
+          ...updatedData[groupTitle],
+          labels: [...(updatedData[groupTitle]?.labels || []), label],
+        }
+      }
+
+      return updatedData
+    })
+  }
+
+  const handleRemoveLabelFromGroup = (groupTitle: string, label: string) => {
+    setEditorData((prev) => ({
+      ...prev,
+      [groupTitle]: {
+        ...prev[groupTitle],
+        labels: prev[groupTitle].labels.filter((l) => l !== label),
+      },
+    }))
+  }
+
+  const handleSave = () => {
+    if (editorData) {
+      mutation.mutate(editorData)
+    }
+  }
+
+  const getGroupTitles = () => Object.keys(editorData)
+
+  const validateGroupTitle = (title: string) => {
+    const trimmedTitle = title.trim()
+    if (!trimmedTitle) return 'Group title is required'
+    if (editorData[trimmedTitle]) return 'Group title already exists'
+    return null
+  }
+
+  const getLabelGroup = (label: string) => {
+    return Object.entries(editorData).find(([_, group]) =>
+      group.labels.includes(label),
+    )?.[0]
+  }
+
+  return {
+    mutation,
+    editorData,
+    setEditorData,
+    handleSave,
+    handleAddGroup,
+    handleUpdateGroup,
+    handleRemoveGroup,
+    handleAddLabelToGroup,
+    handleRemoveLabelFromGroup,
+    getGroupTitles,
+    validateGroupTitle,
+    getLabelGroup,
+    canManageGroups: role === ToolsOzoneTeamDefs.ROLEADMIN,
+  }
+}
+
+export const useLabelGroups = () => {
+  const { data } = useLabelGroupsList()
+  return data?.value || null
+}

--- a/cypress/components/configure/LabelGroups.cy.tsx
+++ b/cypress/components/configure/LabelGroups.cy.tsx
@@ -239,18 +239,7 @@ describe('<LabelGroups />', () => {
     cy.get('input[name="title"]').should('not.exist')
   })
 
-  it('calls save handler when save button is clicked', () => {
-    cy.mount(<LabelGroups {...mockProps} />)
-
-    cy.contains('Save Groups').click()
-
-    cy.wrap(mockProps.handleSave).should(
-      'have.been.calledWith',
-      Cypress.sinon.match.object,
-    )
-  })
-
-  it('supports drag and drop between ungrouped labels and groups', () => {
+  it('supports drag and drop between ungrouped labels and groups and saves updated data', () => {
     const propsWithGroups = {
       ...mockProps,
       initialData: {
@@ -288,6 +277,16 @@ describe('<LabelGroups />', () => {
       .parent()
       .contains('span', 'nsfw')
       .should('be.visible')
+
+    cy.contains('Save Groups').click()
+
+    cy.wrap(mockProps.handleSave).should('have.been.calledWith', {
+      'Target Group': {
+        labels: ['spam', 'nsfw'],
+        color: '#6366f1',
+        note: undefined,
+      },
+    })
   })
 
   it('shows drag feedback when dragging labels', () => {

--- a/cypress/components/configure/LabelGroups.cy.tsx
+++ b/cypress/components/configure/LabelGroups.cy.tsx
@@ -1,0 +1,326 @@
+/// <reference types="cypress" />
+import React from 'react'
+import '../../../styles/globals.css'
+import { LabelGroups } from '../../../components/config/LabelGroups'
+
+describe('<LabelGroups />', () => {
+  let mockProps: React.ComponentProps<typeof LabelGroups>
+
+  beforeEach(() => {
+    mockProps = {
+      initialData: {},
+      allLabels: ['spam', 'nsfw', 'adult', 'violence', 'harassment'],
+      canManageGroups: true,
+      mutation: { isLoading: false },
+      handleSave: cy.stub(),
+    }
+  })
+
+  it('renders all ungrouped labels when no groups exist', () => {
+    cy.mount(<LabelGroups {...mockProps} />)
+
+    cy.get('h5').contains('Ungrouped Labels (5)')
+    cy.get('[data-cy="ungrouped-label"]').should('have.length', 5)
+
+    mockProps.allLabels.forEach((label) => {
+      cy.contains(label).should('be.visible')
+    })
+
+    cy.contains('No groups created yet. Create your first group above.')
+  })
+
+  it('allows creating a new group with valid input', () => {
+    cy.mount(<LabelGroups {...mockProps} />)
+
+    cy.get('input[name="title"]').type('Test Group')
+    cy.get('input[type="color"]').should('have.value', '#6366f1') // Default color
+    cy.get('input[placeholder*="Optional note"]').type('Test note')
+
+    // Submit the form
+    cy.get('button[type="submit"]').click()
+
+    // Verify the group was added to the UI (form should be reset)
+    cy.get('input[name="title"]').should('have.value', '')
+    cy.get('input[placeholder*="Optional note"]').should('have.value', '')
+    cy.get('input[type="color"]').should('have.value', '#6366f1') // Back to default
+  })
+
+  it('shows validation error for duplicate group title', () => {
+    const propsWithExistingGroup = {
+      ...mockProps,
+      initialData: {
+        'Existing Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithExistingGroup} />)
+
+    cy.get('input[name="title"]').type('Existing Group')
+    cy.get('button[type="submit"]').click()
+
+    cy.contains('Group title already exists').should('be.visible')
+  })
+
+  it('displays existing groups with labels', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        NSFW: {
+          labels: ['nsfw', 'adult'],
+          color: '#ef4444',
+          note: 'Adult content',
+        },
+        Spam: {
+          labels: ['spam'],
+          color: '#f59e0b',
+          note: undefined,
+        },
+      },
+      allLabels: ['spam', 'nsfw', 'adult', 'violence', 'harassment'],
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    // Check group headers
+    cy.contains('h3', 'NSFW').should('be.visible')
+    cy.contains('h3', 'Spam').should('be.visible')
+
+    // Check group notes
+    cy.contains('Adult content').should('be.visible')
+
+    // Check labels in groups
+
+    // Check ungrouped labels (should be 2: violence, harassment)
+    cy.contains('Ungrouped Labels (2)')
+  })
+
+  it('allows removing labels from groups', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: ['spam', 'nsfw'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+    cy.contains('span', 'spam').siblings('button').click()
+    cy.contains('span', 'spam').should('not.exist')
+  })
+
+  it('allows removing entire groups', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    cy.contains('h3', 'Test Group').should('be.visible')
+
+    cy.get('[data-cy="remove-group-button"]').click()
+
+    cy.contains('h3', 'Test Group').should('not.exist')
+    cy.contains('No groups created yet. Create your first group above.')
+  })
+
+  it('allows changing group colors', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    cy.get('input[type="color"]').eq(1).should('have.value', '#6366f1')
+    cy.get('input[type="color"]')
+      .eq(1)
+      .invoke('val', '#ff0000')
+      .trigger('change')
+
+    cy.get('input[type="color"]').eq(1).should('have.value', '#ff0000')
+  })
+
+  it('shows manual label addition interface', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    cy.get('[data-cy="add-group-button"]').click()
+
+    cy.get('input[placeholder*="Enter label name"]').should('be.visible')
+    cy.get('[data-cy="add-custom-label-button"]').should('be.visible')
+
+    cy.get('input[placeholder*="Enter label name"]').type('my new label')
+    cy.get('input[placeholder*="Enter label name"]').should(
+      'have.value',
+      'mynewlabel',
+    )
+
+    cy.get('[data-cy="add-custom-label-button"]').click()
+
+    cy.contains('span', 'mynewlabel').should('be.visible')
+  })
+
+  it('handles keyboard shortcuts in manual label input', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: [],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    cy.get('[data-cy="add-group-button"]').click()
+
+    cy.get('input[placeholder*="Enter label name"]').type('testlabel{enter}')
+    cy.contains('span', 'testlabel').should('be.visible')
+
+    cy.get('[data-cy="add-group-button"]').click()
+    cy.get('input[placeholder*="Enter label name"]').type('anotherlabel{esc}')
+    cy.get('input[placeholder*="Enter label name"]').should('not.exist')
+  })
+
+  it('disables save button when loading', () => {
+    const loadingProps = {
+      ...mockProps,
+      mutation: { isLoading: true },
+    }
+
+    cy.mount(<LabelGroups {...loadingProps} />)
+
+    cy.contains('Save Groups').should('be.disabled')
+  })
+
+  it('shows permission denied message when user cannot manage groups', () => {
+    const noPermissionProps = {
+      ...mockProps,
+      canManageGroups: false,
+    }
+
+    cy.mount(<LabelGroups {...noPermissionProps} />)
+
+    cy.contains("You don't have permission to manage label groups.").should(
+      'be.visible',
+    )
+    cy.get('input[name="title"]').should('not.exist')
+  })
+
+  it('calls save handler when save button is clicked', () => {
+    cy.mount(<LabelGroups {...mockProps} />)
+
+    cy.contains('Save Groups').click()
+
+    cy.wrap(mockProps.handleSave).should(
+      'have.been.calledWith',
+      Cypress.sinon.match.object,
+    )
+  })
+
+  it('supports drag and drop between ungrouped labels and groups', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Target Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    cy.contains('Ungrouped Labels (4)')
+
+    const dataTransfer = new DataTransfer()
+    cy.get('[data-cy="ungrouped-label"]')
+      .contains('nsfw')
+      .trigger('dragstart', { dataTransfer })
+
+    cy.contains('h3', 'Target Group')
+      .parent()
+      .parent()
+      .trigger('dragover', { dataTransfer })
+
+    cy.contains('h3', 'Target Group')
+      .parent()
+      .parent()
+      .trigger('drop', { dataTransfer })
+
+    cy.contains('Ungrouped Labels (3)')
+    cy.contains('h3', 'Target Group')
+      .parent()
+      .parent()
+      .parent()
+      .contains('span', 'nsfw')
+      .should('be.visible')
+  })
+
+  it('shows drag feedback when dragging labels', () => {
+    const propsWithGroups = {
+      ...mockProps,
+      initialData: {
+        'Test Group': {
+          labels: ['spam'],
+          color: '#6366f1',
+          note: undefined,
+        },
+      },
+    }
+
+    cy.mount(<LabelGroups {...propsWithGroups} />)
+
+    const dataTransfer = new DataTransfer()
+    cy.get('[data-cy="ungrouped-label"]')
+      .contains('nsfw')
+      .trigger('dragstart', { dataTransfer })
+
+    cy.get('[data-cy="ungrouped-label"]')
+      .contains('nsfw')
+      .should('have.class', 'bg-blue-200')
+
+    cy.contains('h3', 'Test Group')
+      .parent()
+      .parent()
+      .trigger('dragover', { dataTransfer })
+
+    cy.contains('Drop here to add label').should('be.visible')
+  })
+})
+
+// Prevent TypeScript from reading file as legacy script
+export {}

--- a/cypress/components/labeler/RecordView.cy.tsx
+++ b/cypress/components/labeler/RecordView.cy.tsx
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 import React from 'react'
+import '../../../styles/globals.css'
 import { AppBskyLabelerService, ComAtprotoModerationDefs } from '@atproto/api'
 import { deepCopy } from '../../support/utils'
 import { LabelerRecordView } from '../../../components/labeler/RecordView'
@@ -93,7 +94,7 @@ describe('<LabelerRecordView />', () => {
     // Assert that subject collections field is not shown when subject types does not contain record
     cy.get('h3').contains('Subject Collections').should('not.exist')
   })
-  it.only('Shows label only editor view when a detailed definition doesnt exist', () => {
+  it('Shows label only editor view when a detailed definition doesnt exist', () => {
     const labelOnly: AppBskyLabelerService.Record = deepCopy(basicLabelerRecord)
 
     const onUpdateSpy = cy.spy().as('onUpdateSpy')

--- a/cypress/e2e/mod-action/label.cy.ts
+++ b/cypress/e2e/mod-action/label.cy.ts
@@ -37,11 +37,11 @@ describe('Mod Action -> Label', () => {
     )
     cy.get('[data-cy="mod-event-selector"] button').click()
     cy.get('[data-headlessui-state="open"] > a:contains("Label")').click()
-    cy.get('[data-cy="label-selector-buttons"] button')
+    cy.get('[data-cy="label-selector-buttons"] span')
       .contains(seedFixture.carla.repo.labels[0].val)
       .click()
     cy.get(
-      `[data-cy="label-selector-buttons"] button:contains("${NUDITY_LABEL}")`,
+      `[data-cy="label-selector-buttons"] span:contains("${NUDITY_LABEL}")`,
     ).click()
     cy.get('#mod-action-panel button[type="submit"]').click()
 
@@ -87,7 +87,7 @@ describe('Mod Action -> Label', () => {
     cy.get('button')
       .contains(`Click here to add ${TEST_LABEL} as a label.`)
       .click()
-    cy.get('[data-cy="label-selector-buttons"] button').contains(TEST_LABEL)
+    cy.get('[data-cy="label-selector-buttons"] span').contains(TEST_LABEL)
     cy.get('#mod-action-panel button[type="submit"]').click()
 
     cy.intercept(

--- a/cypress/e2e/mod-action/multi-cid-label.cy.ts
+++ b/cypress/e2e/mod-action/multi-cid-label.cy.ts
@@ -48,7 +48,7 @@ describe('Mod Action -> Label', () => {
     cy.get('[data-cy="label-list"]').contains(PORN_LABEL)
     cy.get('[data-cy="mod-event-selector"] button').click()
     cy.get('[data-headlessui-state="open"] > a:contains("Label")').click()
-    cy.get('[data-cy="label-selector-buttons"] button')
+    cy.get('[data-cy="label-selector-buttons"] span')
       .contains(PORN_LABEL)
       .click()
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -188,3 +188,13 @@ export function isNonNullable<V>(v: V): v is NonNullable<V> {
 export function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
+
+// Utility function to determine if we should use light or dark text based on background color
+export function getReadableTextColor(backgroundColor: string) {
+  const hex = backgroundColor.replace('#', '')
+  const r = parseInt(hex.substring(0, 2), 16)
+  const g = parseInt(hex.substring(2, 4), 16)
+  const b = parseInt(hex.substring(4, 6), 16)
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  return brightness > 128 ? 'text-gray-900' : 'text-white'
+}


### PR DESCRIPTION
This PR uses the options api in ozone to allow creating instance-wide custom groups of labels with color coding and descriptive note to aid moderators visually identify labels quickly in the UI.


https://github.com/user-attachments/assets/3445133f-9f8f-45d3-82f6-81d712045a21

