### PR TITLE
Update HOSTING.md with security note for PostgreSQL

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -92,6 +92,9 @@ $ sudo ufw allow 80/tcp
 $ sudo ufw allow 443/tcp
 ```
 
+> [!WARNING]
+> The PostgreSQL Database in the docker compose configuration should not be exposed directly to the internet, make sure you have a firewall in place to prevent this. If you need to access the database from a different machine, use a vlan or similar private networking (e.g., tailscale or ssh port forwarding), exposing the database directly to the public internet is a security risk.
+
 #### Install Docker
 
 On your server, install Docker CE (Community Edition), using the the following instructions. For other operating systems you may reference the [official Docker install guides](https://docs.docker.com/engine/install/).


### PR DESCRIPTION
There's been some research showing that ozone installs have been exposing the PostgreSQL database to the public internet, so adding in a more stern warning here to discourage that practice: https://bsky.app/profile/valkyrie.hacker.gf/post/3m2dpzreuuc2t