### PR TITLE
Bind postgres to localhost

### DIFF
--- a/service/compose.yaml
+++ b/service/compose.yaml
@@ -32,6 +32,7 @@ services:
   postgres:
     container_name: postgres
     image: postgres:14.11-bookworm
+    command: postgres -c listen_addresses=localhost
     network_mode: host
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
This ensures that postgres binds to localhost rather than to all addresses in the ozone distribution.  It is a secondary measure to help protect against installations that are running without a firewall—it is always recommended to run a firewall and deny traffic on ports not in use by the ozone web server (i.e. 80 and 443).