### PR TITLE
workspace: check for did or uri in all csv cols if no header found

### DIFF
--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -1,3 +1,4 @@
+import { isDid } from '@atproto/api'
 import { parseAtUri } from './util'
 
 export type CsvContent = {
@@ -105,10 +106,10 @@ export const extractFromCSV = (data: string): string[] => {
   // before returning an empty array due to no headers, lets first try and parse out a did or an aturi from the data
   if (didIndex === -1 && uriIndex === -1 && content.length >= 1) {
     for (const [idx, value] of content.entries()) {
-      if (value.startsWith('did:')) {
+      if (isDid(value)) {
         didIndex = idx
         break
-      } else if (value.startsWith('at://')) {
+      } else if (parseAtUri(value)) {
         uriIndex = idx
         break
       }


### PR DESCRIPTION
Lots of places that we export data from (i.e. Osprey) don't have column headers that exactly match `did` or `uri`. For example, we might export something that has the header `SubjectDid` instead.

This PR would continue to support the `did` or `uri` header value as the "default", but then fallback to trying to find any column with values matching either a did or an at uri, then use that column for the workspace import instead.