### PR TITLE
Enable daemon in service runner

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -223,6 +223,7 @@ OZONE_DID_PLC_URL=https://plc.directory
 OZONE_APPVIEW_URL=https://api.bsky.app
 OZONE_APPVIEW_DID=did:web:api.bsky.app
 LOG_ENABLED=1
+DAEMON_ENABLED=1
 OZONE_CONFIG
 ```
 
@@ -355,6 +356,7 @@ You will need to customize various settings configured through the Ozone environ
 | `OZONE_APPVIEW_URL`     | `https://api.bsky.app`        | ❌             | Used to communicate with the appview and receive content from Bluesky      |
 | `OZONE_APPVIEW_DID`     | `did:web:api.bsky.app`        | ❌             | Used to communicate with the appview and receive content from Bluesky      |
 | `LOG_ENABLED`           | `1`                           | ❌             | Set to 0 if you would not like JSON log output from the Ozone              |
+| `DAEMON_ENABLED`        | `1`                           | ❌             | Set to 0 if you would not like scheduled actions to be run.              |
 
 There are additional environment variables that can be tweaked depending on how you're running your service, particularly if another service on the network allows delegates some control to your Ozone instance, e.g. to prompt them to purge certain content.
 

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -245,7 +245,7 @@ curl https://raw.githubusercontent.com/bluesky-social/ozone/main/service/compose
 ##### Create the systemd service
 
 > [!TIP]
-> The `--profile daemon` flag in the systemd service below enables the [ozone's background daemon](https://github.com/bluesky-social/atproto/tree/main/packages/ozone/src/daemon) to run. This is not to be confused with the systemd daemon that manages the ozone application. This enables certain features such as temporary takedowns. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
+> The `--profile daemon` flag in the systemd service below enables the [ozone's background daemon](https://github.com/bluesky-social/atproto/tree/main/packages/ozone/src/daemon) to run. This enables certain features such as temporary takedowns. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
 
 ```bash
 cat <<SYSTEMD_UNIT_FILE | sudo tee /etc/systemd/system/ozone.service

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -242,10 +242,10 @@ Download the `compose.yaml` to run your Ozone instance, which includes the follo
 curl https://raw.githubusercontent.com/bluesky-social/ozone/main/service/compose.yaml | sudo tee /ozone/compose.yaml
 ```
 
-> [!TIP]
-> The `--profile daemon` flag in the systemd service below enables the background daemon container for scheduled actions. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
-
 ##### Create the systemd service
+
+> [!TIP]
+> The `--profile daemon` flag in the systemd service below enables the [ozone's background daemon](https://github.com/bluesky-social/atproto/tree/main/packages/ozone/src/daemon) to run. This is not to be confused with the systemd daemon that manages the ozone application. This enables certain features such as temporary takedowns. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
 
 ```bash
 cat <<SYSTEMD_UNIT_FILE | sudo tee /etc/systemd/system/ozone.service

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -245,7 +245,7 @@ curl https://raw.githubusercontent.com/bluesky-social/ozone/main/service/compose
 ##### Create the systemd service
 
 > [!TIP]
-> The `--profile daemon` flag in the systemd service below enables the [ozone's background daemon](https://github.com/bluesky-social/atproto/tree/main/packages/ozone/src/daemon) to run. This enables certain features such as temporary takedowns. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
+> The `--profile daemon` flag below will start [ozone's daemon](https://github.com/bluesky-social/atproto/tree/main/packages/ozone/src/daemon). This enables certain features such as temporary takedowns. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
 
 ```bash
 cat <<SYSTEMD_UNIT_FILE | sudo tee /etc/systemd/system/ozone.service

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -223,7 +223,6 @@ OZONE_DID_PLC_URL=https://plc.directory
 OZONE_APPVIEW_URL=https://api.bsky.app
 OZONE_APPVIEW_DID=did:web:api.bsky.app
 LOG_ENABLED=1
-DAEMON_ENABLED=1
 OZONE_CONFIG
 ```
 
@@ -234,6 +233,7 @@ OZONE_CONFIG
 Download the `compose.yaml` to run your Ozone instance, which includes the following containers:
 
 - `ozone` Node Ozone server—both UI and backend—running on http://localhost:3000
+- `ozone-daemon` Background daemon for scheduled actions (event pushing, blob diverting, etc.)
 - `postgres` Postgres database used by the Ozone backend
 - `caddy` HTTP reverse proxy handling TLS and proxying requests to Ozone
 - `watchtower` Daemon responsible for auto-updating containers to keep the server secure and current
@@ -241,6 +241,9 @@ Download the `compose.yaml` to run your Ozone instance, which includes the follo
 ```bash
 curl https://raw.githubusercontent.com/bluesky-social/ozone/main/service/compose.yaml | sudo tee /ozone/compose.yaml
 ```
+
+> [!TIP]
+> The `--profile daemon` flag in the systemd service below enables the background daemon container for scheduled actions. If you do not want the daemon, remove `--profile daemon` from both the `ExecStart` and `ExecStop` commands.
 
 ##### Create the systemd service
 
@@ -256,8 +259,8 @@ After=docker.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/ozone
-ExecStart=/usr/bin/docker compose --file /ozone/compose.yaml up --detach
-ExecStop=/usr/bin/docker compose --file /ozone/compose.yaml down
+ExecStart=/usr/bin/docker compose --file /ozone/compose.yaml --profile daemon up --detach
+ExecStop=/usr/bin/docker compose --file /ozone/compose.yaml --profile daemon down
 
 [Install]
 WantedBy=default.target
@@ -356,7 +359,6 @@ You will need to customize various settings configured through the Ozone environ
 | `OZONE_APPVIEW_URL`     | `https://api.bsky.app`        | ❌             | Used to communicate with the appview and receive content from Bluesky      |
 | `OZONE_APPVIEW_DID`     | `did:web:api.bsky.app`        | ❌             | Used to communicate with the appview and receive content from Bluesky      |
 | `LOG_ENABLED`           | `1`                           | ❌             | Set to 0 if you would not like JSON log output from the Ozone              |
-| `DAEMON_ENABLED`        | `1`                           | ❌             | Set to 0 if you would not like scheduled actions to be run.              |
 
 There are additional environment variables that can be tweaked depending on how you're running your service, particularly if another service on the network allows delegates some control to your Ozone instance, e.g. to prompt them to purge certain content.
 

--- a/service/compose.yaml
+++ b/service/compose.yaml
@@ -1,5 +1,4 @@
 # @NOTE: this compose file is intended to accompany the guide found in HOSTING.md
-version: '3.9'
 services:
   caddy:
     container_name: caddy
@@ -27,6 +26,21 @@ services:
         condition: service_healthy
     env_file:
       - /ozone/ozone.env
+    labels:
+      - 'com.centurylinklabs.watchtower.enable=true'
+  ozone-daemon:
+    container_name: ozone-daemon
+    image: ghcr.io/bluesky-social/ozone:0.1
+    network_mode: host
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - /ozone/ozone.env
+    command: ["node", "./service/daemon.js"]
+    profiles:
+      - daemon
     labels:
       - 'com.centurylinklabs.watchtower.enable=true'
   postgres:

--- a/service/compose.yaml
+++ b/service/compose.yaml
@@ -1,4 +1,5 @@
 # @NOTE: this compose file is intended to accompany the guide found in HOSTING.md
+version: '3.9'
 services:
   caddy:
     container_name: caddy
@@ -34,7 +35,7 @@ services:
     network_mode: host
     restart: unless-stopped
     depends_on:
-      postgres:
+      ozone:
         condition: service_healthy
     env_file:
       - /ozone/ozone.env

--- a/service/daemon.js
+++ b/service/daemon.js
@@ -4,28 +4,24 @@ const {
   envToCfg,
   envToSecrets,
   OzoneDaemon,
-  Database,
 } = require('@atproto/ozone')
 
 async function main() {
   const env = readEnv()
   const config = envToCfg(env)
   const secrets = envToSecrets(env)
-  const migrate = process.env.OZONE_DB_MIGRATE === '1'
-  if (migrate) {
-    const db = new Database({
-      url: config.db.postgresUrl,
-      schema: config.db.postgresSchema,
-    })
-    await db.migrateToLatestOrThrow()
-    await db.close()
-  }
   const daemon = await OzoneDaemon.create(config, secrets)
   await daemon.start()
   httpLogger.info('Ozone daemon is running')
-  process.on('SIGTERM', async () => {
-    await daemon.destroy()
-  })
+  const shutdown = async () => {
+    try {
+      await daemon.destroy()
+    } finally {
+      process.exit(0)
+    }
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
 }
 
 main().catch(console.error)

--- a/service/daemon.js
+++ b/service/daemon.js
@@ -1,0 +1,31 @@
+const {
+  readEnv,
+  httpLogger,
+  envToCfg,
+  envToSecrets,
+  OzoneDaemon,
+  Database,
+} = require('@atproto/ozone')
+
+async function main() {
+  const env = readEnv()
+  const config = envToCfg(env)
+  const secrets = envToSecrets(env)
+  const migrate = process.env.OZONE_DB_MIGRATE === '1'
+  if (migrate) {
+    const db = new Database({
+      url: config.db.postgresUrl,
+      schema: config.db.postgresSchema,
+    })
+    await db.migrateToLatestOrThrow()
+    await db.close()
+  }
+  const daemon = await OzoneDaemon.create(config, secrets)
+  await daemon.start()
+  httpLogger.info('Ozone daemon is running')
+  process.on('SIGTERM', async () => {
+    await daemon.destroy()
+  })
+}
+
+main().catch(console.error)

--- a/service/index.js
+++ b/service/index.js
@@ -5,6 +5,7 @@ const {
   envToCfg,
   envToSecrets,
   OzoneService,
+  OzoneDaemon,
   Database,
 } = require('@atproto/ozone')
 const pkg = require('@atproto/ozone/package.json')
@@ -40,6 +41,14 @@ async function main() {
   /** @type {import('net').AddressInfo} */
   const addr = httpServer.address()
   httpLogger.info(`Ozone is running at http://localhost:${addr.port}`)
+
+  if (process.env.DAEMON_ENABLED) {
+    const daemon = await OzoneDaemon.create(config, secrets)
+    await daemon.start()
+    process.on('SIGTERM', async () => {
+      await daemon.destroy()
+    })
+  }
 }
 
 main().catch(console.error)

--- a/service/index.js
+++ b/service/index.js
@@ -5,7 +5,6 @@ const {
   envToCfg,
   envToSecrets,
   OzoneService,
-  OzoneDaemon,
   Database,
 } = require('@atproto/ozone')
 const pkg = require('@atproto/ozone/package.json')
@@ -41,14 +40,6 @@ async function main() {
   /** @type {import('net').AddressInfo} */
   const addr = httpServer.address()
   httpLogger.info(`Ozone is running at http://localhost:${addr.port}`)
-
-  if (process.env.DAEMON_ENABLED) {
-    const daemon = await OzoneDaemon.create(config, secrets)
-    await daemon.start()
-    process.on('SIGTERM', async () => {
-      await daemon.destroy()
-    })
-  }
 }
 
 main().catch(console.error)


### PR DESCRIPTION
This PR adds code to run the ozone daemon from the service runner. This allows Ozone instances to use features that depend on the daemon (e.g. scheduled actions).

## Steps to Test

Set up a local postgres db. Create an `ozone` database using `pgsql` or equivalent. Update the default database URL below if needed.

Create `service/.env`:
```
OZONE_SERVER_DID=...
OZONE_PUBLIC_URL=http://localhost:3000
OZONE_ADMIN_DIDS=...
OZONE_ADMIN_PASSWORD=password
OZONE_SIGNING_KEY_HEX=... # see HOSTING.md to generate
OZONE_DB_POSTGRES_URL=postgresql://pg:password@127.0.0.1:5432/ozone
OZONE_DB_MIGRATE=1
OZONE_DID_PLC_URL=https://plc.directory
OZONE_APPVIEW_URL=https://api.bsky.app
OZONE_APPVIEW_DID=...
LOG_ENABLED=1
DAEMON_ENABLED=1
```

`cd service/ && yarn install`

`set -a && source .env && set +a && node index.js && node daemon.js`