### PR TITLE
Deduplicate labels on negation to prevent internal server error

### DIFF
--- a/app/actions/ModActionPanel/useQuickAction.tsx
+++ b/app/actions/ModActionPanel/useQuickAction.tsx
@@ -18,6 +18,7 @@ import {
   HOUR,
   pluralize,
   takesKeyboardEvt,
+  unique,
 } from '@/lib/util'
 import { MOD_EVENTS } from '@/mod-event/constants'
 import {
@@ -374,8 +375,10 @@ export const useQuickAction = (
       // left to be created/negated for the current CID, it emits the original event separate event for that.
       if (ToolsOzoneModerationDefs.isModEventLabel(coreEvent)) {
         const labels = diffLabels(
-          // Make sure we don't try to negate self labels
-          currentLabels.filter((label) => !isSelfLabel(label)),
+          // Make sure we don't try to negate self labels, and deduplicate
+          // by value to avoid sending duplicate negations for a given label when
+          // two labelers (e.g. own + external) have applied the same label value
+          unique(currentLabels.filter((label) => !isSelfLabel(label))),
           nextLabels,
         )
         coreEvent.createLabelVals = labels.createLabelVals


### PR DESCRIPTION
## Related issues

Addresses #280

## Bug

If an account has been applied two labels with the same value `foo` by two different labelers (e.g. our own labeler vs. an external labeler `bar`), trying to remove our own `foo` results in an Internal Server Error since the front-end tries to emit a record negating the same label value twice (`['foo', 'foo']`

## Fix

Deduplicate current values to handle this case. If the account has the same label value applied multiple times, we'll only count it once when figuring out which ones to negate.

## Validation

Tested on an Ozone self-hosted instance, this gets rid of the issue and allows the label to be removed.