### PR TITLE
Allow setting the default login service URL through env vars

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ env:
   NEXT_PUBLIC_OZONE_SERVICE_DID: did:plc:ar7c4by46qjdydhdevvrndac
   NEXT_PUBLIC_PLC_DIRECTORY_URL: https://plc.directory
   NEXT_PUBLIC_HANDLE_RESOLVER_URL: https://api.bsky.app
+  NEXT_PUBLIC_DEFAULT_LOGIN_SERVICE_URL: https://bsky.social
 
 jobs:
   cypress-tests:

--- a/components/shell/auth/credential/CredentialSignInForm.tsx
+++ b/components/shell/auth/credential/CredentialSignInForm.tsx
@@ -4,6 +4,7 @@ import { createRef, FormEvent, useCallback, useState } from 'react'
 
 import { Alert } from '@/common/Alert'
 import { ErrorInfo } from '@/common/ErrorInfo'
+import { DEFAULT_LOGIN_SERVICE_URL } from '@/lib/constants'
 
 export type CredentialSignIn = (input: {
   identifier: string
@@ -11,6 +12,12 @@ export type CredentialSignIn = (input: {
   authFactorToken?: string
   service: string
 }) => unknown
+
+const BSKY_SOCIAL_URL = 'https://bsky.social'
+const STAGING_BSKY_URL = 'https://staging.bsky.dev'
+
+export const getSuggestedServiceUrls = (defaultPdsUrl: string) =>
+  Array.from(new Set([defaultPdsUrl, BSKY_SOCIAL_URL, STAGING_BSKY_URL]))
 
 /**
  * @returns Nice tailwind css form asking to enter either a handle or the host
@@ -22,12 +29,13 @@ export function CredentialSignInForm({
 }: {
   signIn: CredentialSignIn
 } & Omit<React.HTMLAttributes<HTMLFormElement>, 'onSubmit'>) {
+  const suggestedServiceUrls = getSuggestedServiceUrls(DEFAULT_LOGIN_SERVICE_URL)
   const [error, setError] = useState<string | null>(null)
   const [isValidatingAuth, setIsValidatingAuth] = useState(false)
 
   const [handle, setHandle] = useState('')
   const [password, setPassword] = useState('')
-  const [service, setService] = useState('https://bsky.social')
+  const [service, setService] = useState(DEFAULT_LOGIN_SERVICE_URL)
   const [authFactor, setAuthFactor] = useState<{
     token: string
     isInvalid: boolean
@@ -107,8 +115,9 @@ export function CredentialSignInForm({
             onChange={(e) => setService(e.target.value)}
           />
           <datalist id="service-url-suggestions">
-            <option value="https://bsky.social" />
-            <option value="https://staging.bsky.dev" />
+            {suggestedServiceUrls.map((url) => (
+              <option key={url} value={url} />
+            ))}
           </datalist>
         </div>
         <div>

--- a/cypress/components/shell/auth/CredentialSignInForm.cy.tsx
+++ b/cypress/components/shell/auth/CredentialSignInForm.cy.tsx
@@ -1,0 +1,60 @@
+/// <reference types="cypress" />
+
+import { mount } from 'cypress/react'
+import { DEFAULT_LOGIN_SERVICE_URL } from '../../../../lib/constants'
+import {
+  CredentialSignInForm,
+  getSuggestedServiceUrls,
+} from '../../../../components/shell/auth/credential/CredentialSignInForm'
+
+describe('getSuggestedServiceUrls', () => {
+  it('keeps bsky.social when default is different', () => {
+    expect(getSuggestedServiceUrls('https://example-pds.test')).to.deep.equal([
+      'https://example-pds.test',
+      'https://bsky.social',
+      'https://staging.bsky.dev',
+    ])
+  })
+
+  it('does not duplicate bsky.social when it is the default', () => {
+    expect(getSuggestedServiceUrls('https://bsky.social')).to.deep.equal([
+      'https://bsky.social',
+      'https://staging.bsky.dev',
+    ])
+  })
+})
+
+describe('<CredentialSignInForm />', () => {
+  it('initializes service input from configured default and allows edits', () => {
+    mount(
+      <CredentialSignInForm className="mt-8 space-y-6" signIn={() => null} />,
+    )
+
+    cy.get('#service-url').should('have.value', DEFAULT_LOGIN_SERVICE_URL)
+    cy.get('#service-url').clear()
+    cy.get('#service-url').type('https://example-pds.test')
+    cy.get('#service-url').should('have.value', 'https://example-pds.test')
+  })
+
+  it('renders deduplicated suggestions derived from the default PDS URL', () => {
+    mount(
+      <CredentialSignInForm className="mt-8 space-y-6" signIn={() => null} />,
+    )
+
+    const expectedSuggestions = getSuggestedServiceUrls(DEFAULT_LOGIN_SERVICE_URL)
+
+    cy.get('#service-url-suggestions option')
+      .then(($options) =>
+        Array.from($options).map((option) => option.getAttribute('value')),
+      )
+      .then((values) => {
+        const suggestionValues = values.filter(
+          (value): value is string => Boolean(value),
+        )
+        expect(suggestionValues).to.deep.equal(expectedSuggestions)
+        expect(new Set(suggestionValues).size).to.equal(suggestionValues.length)
+      })
+  })
+})
+
+export {}

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -5,6 +5,7 @@ declare global {
     interface ProcessEnv {
       NEXT_PUBLIC_HANDLE_RESOLVER_URL?: string // e.g. https://resolver.example.com
       NEXT_PUBLIC_PLC_DIRECTORY_URL?: string // e.g. https://plc.directory
+      NEXT_PUBLIC_DEFAULT_LOGIN_SERVICE_URL?: string // e.g. https://bsky.social
       NEXT_PUBLIC_QUEUE_CONFIG?: string
       NEXT_PUBLIC_OZONE_SERVICE_DID?: string // e.g. did:plc:xxx#atproto_labeler
       NEXT_PUBLIC_OZONE_PUBLIC_URL?: string // e.g. https://ozone.example.com (falls back to window.location.origin)

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,6 +28,9 @@ export const HANDLE_RESOLVER_URL =
     ? 'http://localhost:2584'
     : 'https://api.bsky.app')
 
+export const DEFAULT_LOGIN_SERVICE_URL =
+  process.env.NEXT_PUBLIC_DEFAULT_LOGIN_SERVICE_URL || 'https://bsky.social'
+
 export const DM_DISABLE_TAG = 'chat-disabled'
 export const VIDEO_UPLOAD_DISABLE_TAG = 'video-upload-disabled'
 export const TRUSTED_VERIFIER_TAG = 'trusted-verifier'


### PR DESCRIPTION
## Summary

The Ozone login screen currently defaults to `https://bsky.social` when signing in with account credentials.

<img width="529" height="568" alt="Screenshot 2026-05-22 at 8 22 27 PM" src="https://github.com/user-attachments/assets/5bf683dd-7e37-4a4a-abeb-1aec1d109c83" />

This PR allows self-hosters to set a different default URL for the log-in screen, as a nice-to-have improvement. Useful for Ozone instances set as moderation services for self-hosted PDSes.

The new default value is taken from `NEXT_PUBLIC_DEFAULT_LOGIN_SERVICE_URL` if present; if not, it defaults to `https://bsky.social` to preserve current behaviour as the default.

If set, the service will also be added to the `datalist` of suggested services for that field, preserving existing values.

## Validation

Added one `cypress` test to validate changes, test is passing:

```bash
yarn exec cypress run --component --browser electron --spec cypress/components/shell/auth/CredentialSignInForm.cy.tsx
```

## Screenshots

Login screen with a default set (`NEXT_PUBLIC_DEFAULT_LOGIN_SERVICE_URL=https://my.default.pds`):

<img width="498" height="537" alt="Screenshot 2026-05-22 at 8 30 49 PM" src="https://github.com/user-attachments/assets/9c3779f3-d732-4163-82e0-7ad3f6ed0032" />

Datalist suggestions:

<img width="437" height="469" alt="Screenshot 2026-05-22 at 8 31 29 PM" src="https://github.com/user-attachments/assets/93319e0a-4d8c-4135-8e06-eea395892a9b" />
