### PR TITLE
Various Report-level Fixes

### DIFF
--- a/app/analytics/detail/page-content.tsx
+++ b/app/analytics/detail/page-content.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { groupedReasonTypes } from '@/reports/helpers/getType'
+import { statReasonTypes } from '@/reports/helpers/getType'
 import { HistoricalGraph } from '@/reports/stats/HistoricalGraph'
 import { LiveStatsPanel } from '@/reports/stats/LiveStats'
 import {
@@ -19,9 +19,7 @@ export function StatsDetailPageContent() {
   const { filters, handleFilterChange } = useParamStatsFilters()
 
   const isAggregate = filters.grouping === 'aggregate'
-  const reportTypes = filters.category
-    ? groupedReasonTypes[filters.category]
-    : []
+  const reportTypes = filters.category ? statReasonTypes[filters.category] : []
   const live: LiveStatsParams = isAggregate
     ? {}
     : {

--- a/app/analytics/detail/page-content.tsx
+++ b/app/analytics/detail/page-content.tsx
@@ -12,13 +12,19 @@ import {
   LiveStatsParams,
   useHistoricalStats,
 } from '@/reports/stats/useReportStats'
+import { usePermission } from '@/shell/ConfigurationContext'
 import { ArrowLeftIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 
 export function StatsDetailPageContent() {
+  const canViewModeratorStats = usePermission('canViewModeratorStats')
   const { filters, handleFilterChange } = useParamStatsFilters()
 
-  const isAggregate = filters.grouping === 'aggregate'
+  // consider aggregate if selected or if not permitted
+  const isAggregate =
+    filters.grouping === 'aggregate' ||
+    (filters.grouping === 'moderator' && !canViewModeratorStats)
+
   const reportTypes = filters.category ? statReasonTypes[filters.category] : []
   const live: LiveStatsParams = isAggregate
     ? {}

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -113,7 +113,7 @@ function getReportsFromCache(
   queryClient: ReturnType<typeof useQueryClient>,
 ): ToolsOzoneReportDefs.ReportView[] {
   const allReports: ToolsOzoneReportDefs.ReportView[] = []
-  for (const key of ['events', 'betaReports']) {
+  for (const key of ['betaReports']) {
     const allQueriesData = queryClient.getQueriesData<
       InfiniteData<{ reports: ToolsOzoneReportDefs.ReportView[] }>
     >({ queryKey: [key] })

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -532,6 +532,8 @@ function ReportDetailLayout(props: {
   } = props
   const subjectOptions = [subject]
 
+  const router = useRouter()
+
   const createActivity = useCreateActivity()
 
   const [reportActionScope, setReportActionScope] = useState<
@@ -713,6 +715,9 @@ function ReportDetailLayout(props: {
     modEventType,
   )
 
+  const subjectDid =
+    report.subject.repo?.did || profile?.did || repo?.did || record?.repo.did
+
   return (
     <div className="dark:text-gray-50">
       <div className="flex flex-col lg:flex-row gap-6">
@@ -851,6 +856,23 @@ function ReportDetailLayout(props: {
                   <SubjectTag key={tag} tag={tag} />
                 ))}
               </LabelList>
+            </div>
+          )}
+
+          {/* Open account in action panel */}
+          {!isSubjectDid && subjectDid && (
+            <div className="">
+              <button
+                type="button"
+                onClick={() =>
+                  router.replace(
+                    `${window.location.origin}/reports/${report.id}?quickOpen=${subjectDid}`,
+                  )
+                }
+                className="text-xs text-gray-500 underline"
+              >
+                Open account in action panel
+              </button>
             </div>
           )}
 

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -31,7 +31,7 @@ import {
 import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
 import { ActionError } from '@/reports/ModerationForm/ActionError'
 import { ReportTypeMultiselect } from '@/reports/ReportTypeMultiselect'
-import { useReports } from '@/reports/useReports'
+import { useReportAutoAdvance, useReports } from '@/reports/useReports'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
@@ -489,7 +489,7 @@ function ReportDetailLayout(props: {
 
   const router = useRouter()
   const createActivity = useCreateActivity()
-  const { advanceToNext } = useReports(report.id)
+  useReportAutoAdvance(report.id, report.status)
 
   const [reportActionScope, setReportActionScope] = useState<
     'current' | 'all' | 'types'
@@ -596,7 +596,6 @@ function ReportDetailLayout(props: {
       }
 
       setSelectedAction(null) // Reset after successful submission
-      advanceToNext()
     } else {
       await onSubmit(finalVals)
     }

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -484,7 +484,7 @@ export function ReportDetailPageContent() {
           viewers={viewers}
           onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
             await emitEvent(
-              hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
+              hydrateModToolInfo(vals, ActionPanelNames.ReportPage),
             )
             queryClient.invalidateQueries({ queryKey: ['report', reportId] })
             queryClient.invalidateQueries({

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -31,7 +31,11 @@ import {
 import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
 import { ActionError } from '@/reports/ModerationForm/ActionError'
 import { ReportTypeMultiselect } from '@/reports/ReportTypeMultiselect'
-import { useReportAutoAdvance, useReports } from '@/reports/useReports'
+import {
+  useReportArrowKeyNavigation,
+  useReportAutoAdvance,
+  useReports,
+} from '@/reports/useReports'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
@@ -489,6 +493,7 @@ function ReportDetailLayout(props: {
 
   const router = useRouter()
   const createActivity = useCreateActivity()
+  useReportArrowKeyNavigation(report.id)
   useReportAutoAdvance(report.id, report.status)
 
   const [reportActionScope, setReportActionScope] = useState<

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -14,16 +14,9 @@ import { LabelSelector } from '@/common/labels/Selector'
 import { isSelfLabel } from '@/common/labels/util'
 import { ConfirmationModal } from '@/common/modals/confirmation'
 import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
-import { MessageActorMeta } from '@/dms/MessageActorMeta'
-import { ModEventDetailsPopover } from '@/mod-event/DetailsPopover'
-import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
-import { RecordAuthorStatus } from '@/subject/RecordAuthorStatus'
-import { SubjectTag } from 'components/tags/SubjectTag'
-import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { ConversationSubjectWarning } from '@/dms/ConversationSubjectWarning'
-import { PriorityScore } from '@/subject/PriorityScore'
-import { Alert } from '@/common/Alert'
-import { TextWithLinks } from '@/common/TextWithLinks'
+import { MessageActorMeta } from '@/dms/MessageActorMeta'
+import { getDidFromUri } from '@/lib/util'
 import { AgeAssuranceBadge } from '@/mod-event/AgeAssuranceStateBadge'
 import { ModEventDetailsPopover } from '@/mod-event/DetailsPopover'
 import { ModEventItem } from '@/mod-event/EventItem'
@@ -77,22 +70,13 @@ import {
   AssignmentViewWithModerator,
   ViewersIndicator,
 } from 'components/reports/ViewersIndicator'
-import {
-  useAssignModerator,
-  useCreateActivity,
-  useUnassignModerator,
-} from 'components/reports/hooks'
+import { useAssignModerator, useCreateActivity, useUnassignModerator } from 'components/reports/hooks'
 import { useAssignmentPolling } from 'components/reports/useAssignmentPolling'
 import { getHandleFromSubjectView } from 'components/reports/utils'
 import { SubjectTag } from 'components/tags/SubjectTag'
 import { WorkspacePanel } from 'components/workspace/Panel'
 import { formatDistanceToNow } from 'date-fns'
-import {
-  useParams,
-  usePathname,
-  useRouter,
-  useSearchParams,
-} from 'next/navigation'
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'react-toastify'
 

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -564,22 +564,22 @@ function ReportDetailLayout(props: {
     const subj = (finalVals as any).subject
     const event = finalVals.event
     const eventType = event?.$type as string | undefined
-    // check if event was elevated to the owning account
-    const isElevated =
+    // check if event was cascaded to the owning account
+    const isCascaded =
       report.subject.type !== 'account' &&
       subj.$type === 'com.atproto.admin.defs#repoRef'
 
     if (eventType && REPORT_STATUS_EVENT_TYPES.has(eventType as any)) {
-      if (isElevated) {
+      if (isCascaded) {
         const reportUrl = `${window.location.origin}/reports/${report.id}`
-        // 1. Send event plus elevation comment
+        // 1. Send event plus cascaded comment
         if ('comment' in event) {
           await onSubmit({
             ...finalVals,
             event: {
               ...event,
               comment:
-                `[ELEVATED_ACTION]: This action was taken after actioning a report on a subject that the account owns. (${reportUrl})\n\n${event.comment || ''}`.trim(),
+                `[CASCADED_ACTION]: This action was taken after actioning a report on a subject that the account owns. (${reportUrl})\n\n${event.comment || ''}`.trim(),
             },
           })
         } else {
@@ -590,7 +590,7 @@ function ReportDetailLayout(props: {
             event: {
               ...event,
               $type: MOD_EVENTS.COMMENT,
-              comment: `[ELEVATED_ACTION]: An action  before this event occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
+              comment: `[CASCADED_ACTION]: An action before this event occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
             },
           })
         }

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -555,22 +555,22 @@ function ReportDetailLayout(props: {
     const subj = (finalVals as any).subject
     const event = finalVals.event
     const eventType = event?.$type as string | undefined
-    // check if event was escalated to the owning account
-    const isEscalated =
+    // check if event was elevated to the owning account
+    const isElevated =
       report.subject.type !== 'account' &&
       subj.$type === 'com.atproto.admin.defs#repoRef'
 
     if (eventType && REPORT_STATUS_EVENT_TYPES.has(eventType as any)) {
-      if (isEscalated) {
+      if (isElevated) {
         const reportUrl = `${window.location.origin}/reports/${report.id}`
-        // 1. Send event plus escalation comment
+        // 1. Send event plus elevation comment
         if ('comment' in event) {
           await onSubmit({
             ...finalVals,
             event: {
               ...event,
               comment:
-                `[ESCALATION_ACTION]: This action was taken after actioning this report: \n${reportUrl}\n\n${event.comment || ''}`.trim(),
+                `[ELEVATED_ACTION]: This action was taken after actioning a report on a subject that the account owns. (${reportUrl})\n\n${event.comment || ''}`.trim(),
             },
           })
         } else {
@@ -581,7 +581,7 @@ function ReportDetailLayout(props: {
             event: {
               ...event,
               $type: MOD_EVENTS.COMMENT,
-              comment: `[ESCALATION_ACTION]: The action immediately before this occurred after actioning this report: \n${reportUrl}`,
+              comment: `[ELEVATED_ACTION]: The action immediately before this occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
             },
           })
         }

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -70,13 +70,22 @@ import {
   AssignmentViewWithModerator,
   ViewersIndicator,
 } from 'components/reports/ViewersIndicator'
-import { useAssignModerator, useCreateActivity, useUnassignModerator } from 'components/reports/hooks'
+import {
+  useAssignModerator,
+  useCreateActivity,
+  useUnassignModerator,
+} from 'components/reports/hooks'
 import { useAssignmentPolling } from 'components/reports/useAssignmentPolling'
 import { getHandleFromSubjectView } from 'components/reports/utils'
 import { SubjectTag } from 'components/tags/SubjectTag'
 import { WorkspacePanel } from 'components/workspace/Panel'
 import { formatDistanceToNow } from 'date-fns'
-import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'react-toastify'
 
@@ -581,7 +590,7 @@ function ReportDetailLayout(props: {
             event: {
               ...event,
               $type: MOD_EVENTS.COMMENT,
-              comment: `[ELEVATED_ACTION]: The action immediately before this occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
+              comment: `[ELEVATED_ACTION]: An action  before this event occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
             },
           })
         }

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -40,6 +40,7 @@ import {
   ReviewStateIcon,
   SubjectReviewStateBadge,
 } from '@/subject/ReviewStateMarker'
+import { useRefetchOnlineModerators } from '@/team/useOnlineModerators'
 import {
   ComAtprotoModerationDefs,
   ToolsOzoneModerationEmitEvent,
@@ -162,6 +163,7 @@ function ReportInfoPanel({
   onClickDid?: (did: string) => void
 }) {
   const labelerAgent = useLabelerAgent()
+  const refetchOnlineModerators = useRefetchOnlineModerators()
   const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false)
 
   const {
@@ -169,7 +171,10 @@ function ReportInfoPanel({
     isPending,
     error,
   } = useAssignModerator({
-    onSuccess: () => toast.success('Report assigned to you'),
+    onSuccess: () => {
+      toast.success('Report assigned to you')
+      refetchOnlineModerators()
+    },
   })
 
   const {
@@ -334,6 +339,7 @@ export function ReportDetailPageContent() {
   const queryClient = useQueryClient()
   const emitEvent = useEmitEvent()
   const { toggleWorkspacePanel, isWorkspaceOpen } = useWorkspaceOpener()
+  const refetchOnlineModerators = useRefetchOnlineModerators()
 
   const quickOpenParam = searchParams.get('quickOpen') ?? ''
   const setQuickActionPanelSubject = (subject: string) => {
@@ -360,6 +366,7 @@ export function ReportDetailPageContent() {
   useEffect(() => {
     labelerAgent.tools.ozone.report
       .assignModerator({ reportId })
+      .then(() => refetchOnlineModerators())
       .catch(() => {})
   }, [reportId])
 

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -1,83 +1,92 @@
 'use client'
-import { useState, useEffect, useMemo } from 'react'
-import { useParams, useRouter, useSearchParams, usePathname } from 'next/navigation'
-import { useQuery, useQueryClient, InfiniteData } from '@tanstack/react-query'
-import {
-  ToolsOzoneReportDefs,
-  ToolsOzoneModerationEmitEvent,
-  ComAtprotoModerationDefs,
-} from '@atproto/api'
-import { formatDistanceToNow } from 'date-fns'
-import { toast } from 'react-toastify'
-import {
-  ArrowLeftIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from '@heroicons/react/24/outline'
+import { Alert } from '@/common/Alert'
+import { Loading } from '@/common/Loader'
+import { PreviewCard } from '@/common/PreviewCard'
+import { TextWithLinks } from '@/common/TextWithLinks'
 import { ActionButton, ButtonPrimary, ButtonSecondary } from '@/common/buttons'
 import { Checkbox, FormLabel, Select, Textarea } from '@/common/forms'
-import { PreviewCard } from '@/common/PreviewCard'
-import { ModEventList } from '@/mod-event/EventList'
-import { ModEventItem } from '@/mod-event/EventItem'
-import { ModToolProvider } from '@/mod-event/ModToolContext'
 import {
   LabelList,
   LabelListEmpty,
   ModerationLabel,
 } from '@/common/labels/List'
-import { isSelfLabel } from '@/common/labels/util'
 import { LabelSelector } from '@/common/labels/Selector'
-import { getDidFromUri } from '@/lib/util'
-import { Loading } from '@/common/Loader'
-import { BlobListFormField } from 'app/actions/ModActionPanel/BlobList'
-import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
-import {
-  ReviewStateIcon,
-  SubjectReviewStateBadge,
-} from '@/subject/ReviewStateMarker'
-import { ActionError } from '@/reports/ModerationForm/ActionError'
+import { isSelfLabel } from '@/common/labels/util'
+import { ConfirmationModal } from '@/common/modals/confirmation'
+import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
 import { MessageActorMeta } from '@/dms/MessageActorMeta'
-import { ModEventDetailsPopover } from '@/mod-event/DetailsPopover'
-import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
-import { RecordAuthorStatus } from '@/subject/RecordAuthorStatus'
-import { SubjectTag } from 'components/tags/SubjectTag'
-import { HighProfileWarning } from '@/repositories/HighProfileWarning'
-import { PriorityScore } from '@/subject/PriorityScore'
-import { Alert } from '@/common/Alert'
-import { TextWithLinks } from '@/common/TextWithLinks'
+import { getDidFromUri } from '@/lib/util'
 import { AgeAssuranceBadge } from '@/mod-event/AgeAssuranceStateBadge'
-import { useQuickAction } from 'app/actions/ModActionPanel/useQuickAction'
-import { PolicySeveritySelector } from 'app/actions/ModActionPanel/PolicySeveritySelector'
-import { EmailComposerFields } from 'components/email/Composer'
+import { ModEventDetailsPopover } from '@/mod-event/DetailsPopover'
+import { ModEventItem } from '@/mod-event/EventItem'
+import { ModEventList } from '@/mod-event/EventList'
+import { ModToolProvider } from '@/mod-event/ModToolContext'
+import { MOD_EVENTS } from '@/mod-event/constants'
 import {
   ActionPanelNames,
   hydrateModToolInfo,
   useEmitEvent,
 } from '@/mod-event/helpers/emitEvent'
-import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { ReasonBadge } from 'components/reports/ReasonBadge'
-import { useAssignModerator, useUnassignModerator } from 'components/reports/hooks'
-import { ConfirmationModal } from '@/common/modals/confirmation'
-import {
-  ReportActionsBar,
-  ActivityTimeline,
-  ReportActionType,
-} from 'components/reports/ReportActions'
-import { MemberView } from 'components/reports/MemberView'
+import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
+import { ActionError } from '@/reports/ModerationForm/ActionError'
 import { ReportTypeMultiselect } from '@/reports/ReportTypeMultiselect'
-import { MOD_EVENTS } from '@/mod-event/constants'
-import { ReportStatusBadge } from 'components/reports/ReportStatusBadge'
+import { HighProfileWarning } from '@/repositories/HighProfileWarning'
+import { useLabelerAgent } from '@/shell/ConfigurationContext'
+import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
+import { PriorityScore } from '@/subject/PriorityScore'
+import { RecordAuthorStatus } from '@/subject/RecordAuthorStatus'
+import {
+  ReviewStateIcon,
+  SubjectReviewStateBadge,
+} from '@/subject/ReviewStateMarker'
+import {
+  ComAtprotoModerationDefs,
+  ToolsOzoneModerationEmitEvent,
+  ToolsOzoneReportDefs,
+} from '@atproto/api'
+import {
+  ArrowLeftIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline'
+import { InfiniteData, useQuery, useQueryClient } from '@tanstack/react-query'
+import { BlobListFormField } from 'app/actions/ModActionPanel/BlobList'
+import { PolicySeveritySelector } from 'app/actions/ModActionPanel/PolicySeveritySelector'
+import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
+import { useQuickAction } from 'app/actions/ModActionPanel/useQuickAction'
+import { EmailComposerFields } from 'components/email/Composer'
+import { MemberView } from 'components/reports/MemberView'
 import { MutedBadge } from 'components/reports/MutedBadge'
 import { QueueBadge } from 'components/reports/QueueBadge'
+import { ReasonBadge } from 'components/reports/ReasonBadge'
 import {
-  ViewersIndicator,
+  ActivityTimeline,
+  ReportActionsBar,
+  ReportActionType,
+} from 'components/reports/ReportActions'
+import { ReportStatusBadge } from 'components/reports/ReportStatusBadge'
+import {
   AssignmentViewWithModerator,
+  ViewersIndicator,
 } from 'components/reports/ViewersIndicator'
-import { getHandleFromSubjectView } from 'components/reports/utils'
+import {
+  useAssignModerator,
+  useCreateActivity,
+  useUnassignModerator,
+} from 'components/reports/hooks'
 import { useAssignmentPolling } from 'components/reports/useAssignmentPolling'
-import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
+import { getHandleFromSubjectView } from 'components/reports/utils'
+import { SubjectTag } from 'components/tags/SubjectTag'
 import { WorkspacePanel } from 'components/workspace/Panel'
-import { useWorkspaceOpener } from '@/common/useWorkspaceOpener'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'react-toastify'
 
 const FORM_ID = 'report-detail-action-panel'
 
@@ -305,7 +314,7 @@ function ReportInfoPanel({
         confirmButtonDisabled={isUnassigning}
         error={
           unassignError
-            ? (unassignError as any)?.message ?? 'Failed to unassign'
+            ? ((unassignError as any)?.message ?? 'Failed to unassign')
             : undefined
         }
         onConfirm={() => unassignFromMe(report.id)}
@@ -460,7 +469,9 @@ export function ReportDetailPageContent() {
               hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
             )
             queryClient.invalidateQueries({ queryKey: ['report', reportId] })
-            queryClient.invalidateQueries({ queryKey: ['reportActivities', reportId] })
+            queryClient.invalidateQueries({
+              queryKey: ['reportActivities', reportId],
+            })
           }}
           onCancel={() => router.push('/reports')}
           onClickDid={setQuickActionPanelSubject}
@@ -478,7 +489,9 @@ export function ReportDetailPageContent() {
             hydrateModToolInfo(vals, ActionPanelNames.QuickAction),
           )
           queryClient.invalidateQueries({ queryKey: ['report', reportId] })
-          queryClient.invalidateQueries({ queryKey: ['reportActivities', reportId] })
+          queryClient.invalidateQueries({
+            queryKey: ['reportActivities', reportId],
+          })
         }}
       />
       <WorkspacePanel
@@ -510,6 +523,8 @@ function ReportDetailLayout(props: {
     onClickDid,
   } = props
   const subjectOptions = [subject]
+
+  const createActivity = useCreateActivity()
 
   const [reportActionScope, setReportActionScope] = useState<
     'current' | 'all' | 'types'
@@ -545,31 +560,74 @@ function ReportDetailLayout(props: {
       }
     }
 
-    const eventType = (finalVals.event as any)?.$type as string | undefined
-    if (eventType && REPORT_STATUS_EVENT_TYPES.has(eventType as any)) {
-      const reportAction: ToolsOzoneModerationEmitEvent.ReportAction = {}
-      if (reportActionScope === 'current') {
-        reportAction.ids = [report.id]
-      } else if (reportActionScope === 'all') {
-        reportAction.all = true
-      } else if (reportActionTypes.length > 0) {
-        reportAction.types = reportActionTypes
-      }
-      await onSubmit({ ...finalVals, reportAction })
+    const subj = (finalVals as any).subject
+    const event = finalVals.event
+    const eventType = event?.$type as string | undefined
+    // check if event was escalated to the owning account
+    const isEscalated =
+      report.subject.type !== 'account' &&
+      subj.$type === 'com.atproto.admin.defs#repoRef'
 
-      // For appeal reports: emit resolveAppeal after the primary action (revert takedown or label)
-      if (
-        isAppealReport(report.reportType) &&
-        eventType !== MOD_EVENTS.RESOLVE_APPEAL
-      ) {
-        await onSubmit({
-          ...finalVals,
-          event: {
-            $type: MOD_EVENTS.RESOLVE_APPEAL,
-            comment: '[RESOLVING_APPEAL]',
+    if (eventType && REPORT_STATUS_EVENT_TYPES.has(eventType as any)) {
+      if (isEscalated) {
+        const reportUrl = `${window.location.origin}/reports/${report.id}`
+        // 1. Send event plus escalation comment
+        if ('comment' in event) {
+          await onSubmit({
+            ...finalVals,
+            event: {
+              ...event,
+              comment:
+                `[ESCALATION_ACTION]: This action was taken after actioning this report: \n${reportUrl}\n\n${event.comment || ''}`.trim(),
+            },
+          })
+        } else {
+          await onSubmit(finalVals)
+          await onSubmit({
+            subject: subj,
+            createdBy: finalVals.createdBy,
+            event: {
+              ...event,
+              $type: MOD_EVENTS.COMMENT,
+              comment: `[ESCALATION_ACTION]: The action immediately before this occurred after actioning this report: \n${reportUrl}`,
+            },
+          })
+        }
+        // 2. Add note to report log
+        await createActivity.mutateAsync({
+          reportId: report.id,
+          activity: {
+            $type: 'tools.ozone.report.defs#noteActivity',
           },
-          reportAction: { ids: [report.id] },
+          internalNote:
+            'Account-level actions were taken as a result of actioning this report.',
+          isAutomated: true,
         })
+      } else {
+        const reportAction: ToolsOzoneModerationEmitEvent.ReportAction = {}
+        if (reportActionScope === 'current') {
+          reportAction.ids = [report.id]
+        } else if (reportActionScope === 'all') {
+          reportAction.all = true
+        } else if (reportActionTypes.length > 0) {
+          reportAction.types = reportActionTypes
+        }
+        await onSubmit({ ...finalVals, reportAction })
+
+        // For appeal reports: emit resolveAppeal after the primary action (revert takedown or label)
+        if (
+          isAppealReport(report.reportType) &&
+          eventType !== MOD_EVENTS.RESOLVE_APPEAL
+        ) {
+          await onSubmit({
+            ...finalVals,
+            event: {
+              $type: MOD_EVENTS.RESOLVE_APPEAL,
+              comment: '[RESOLVING_APPEAL]',
+            },
+            reportAction: { ids: [report.id] },
+          })
+        }
       }
 
       setSelectedAction(null) // Reset after successful submission
@@ -803,7 +861,11 @@ function ReportDetailLayout(props: {
 
         {/* Right col */}
         <div className="w-full lg:w-1/2 shrink-0">
-          <ReportInfoPanel report={report} assignment={assignment} onClickDid={onClickDid} />
+          <ReportInfoPanel
+            report={report}
+            assignment={assignment}
+            onClickDid={onClickDid}
+          />
 
           <ViewersIndicator viewers={viewers} onClickDid={onClickDid} />
 
@@ -844,9 +906,15 @@ function ReportDetailLayout(props: {
             onResolveAppeal={
               isAppealReport(report.reportType)
                 ? async () => {
-                    const reportAction: ToolsOzoneModerationEmitEvent.ReportAction = { ids: [report.id] }
+                    const reportAction: ToolsOzoneModerationEmitEvent.ReportAction =
+                      { ids: [report.id] }
                     await onSubmit({
-                      subject: { $type: 'com.atproto.admin.defs#repoRef', did: subject.startsWith('at://') ? getDidFromUri(subject)! : subject },
+                      subject: {
+                        $type: 'com.atproto.admin.defs#repoRef',
+                        did: subject.startsWith('at://')
+                          ? getDidFromUri(subject)!
+                          : subject,
+                      },
                       createdBy: config.did,
                       event: {
                         $type: MOD_EVENTS.RESOLVE_APPEAL,
@@ -896,7 +964,9 @@ function ReportDetailLayout(props: {
                   defaultSeverityLevel={selectedSeverityLevelName}
                   currentStrikes={currentStrikes}
                   actionRecommendation={actionRecommendation}
-                  variant={isReverseTakedownEvent ? 'reverse-takedown' : 'takedown'}
+                  variant={
+                    isReverseTakedownEvent ? 'reverse-takedown' : 'takedown'
+                  }
                   targetServices={targetServices}
                   setTargetServices={setTargetServices}
                   isSubjectDid={isSubjectDid}

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -443,6 +443,7 @@ export function ReportDetailPageContent() {
               size="xs"
               appearance="primary"
               disabled={prevId === null}
+              className="disabled:opacity-50"
               onClick={() =>
                 prevId !== null && router.push(`/reports/${prevId}`)
               }
@@ -454,6 +455,7 @@ export function ReportDetailPageContent() {
               size="xs"
               appearance="primary"
               disabled={nextId === null}
+              className="disabled:opacity-50"
               onClick={() =>
                 nextId !== null && router.push(`/reports/${nextId}`)
               }

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -358,6 +358,8 @@ export function ReportDetailPageContent() {
     skipInitialPoll: calledGetReport,
   })
 
+  const createActivity = useCreateActivity()
+
   if (!report && isLoading) {
     return (
       <div className="flex flex-col items-center justify-center h-64">
@@ -432,9 +434,23 @@ export function ReportDetailPageContent() {
           assignment={report.assignment}
           viewers={viewers}
           onSubmit={async (vals: ToolsOzoneModerationEmitEvent.InputSchema) => {
-            await emitEvent(
+            const result = await emitEvent(
               hydrateModToolInfo(vals, ActionPanelNames.ReportPage),
             )
+            const eventId = (result as any)?.id
+            const isCascaded =
+              report.subject.type !== 'account' &&
+              vals.subject.$type === 'com.atproto.admin.defs#repoRef'
+            if (isCascaded && eventId) {
+              await createActivity.mutateAsync({
+                reportId: report.id,
+                activity: {
+                  $type: 'tools.ozone.report.defs#noteActivity',
+                },
+                internalNote: `Account-level actions were taken as a result of actioning this report. (${window.location.origin}/events/${eventId})`,
+                isAutomated: true,
+              })
+            }
             queryClient.invalidateQueries({ queryKey: ['report', reportId] })
             queryClient.invalidateQueries({
               queryKey: ['reportActivities', reportId],
@@ -492,7 +508,6 @@ function ReportDetailLayout(props: {
   const subjectOptions = [subject]
 
   const router = useRouter()
-  const createActivity = useCreateActivity()
   useReportArrowKeyNavigation(report.id)
   useReportAutoAdvance(report.id, report.status)
 
@@ -540,39 +555,8 @@ function ReportDetailLayout(props: {
 
     if (eventType && REPORT_STATUS_EVENT_TYPES.has(eventType as any)) {
       if (isCascaded) {
-        const reportUrl = `${window.location.origin}/reports/${report.id}`
-        // 1. Send event plus cascaded comment
-        if ('comment' in event) {
-          await onSubmit({
-            ...finalVals,
-            event: {
-              ...event,
-              comment:
-                `[CASCADED_ACTION]: This action was taken after actioning a report on a subject that the account owns. (${reportUrl})\n\n${event.comment || ''}`.trim(),
-            },
-          })
-        } else {
-          await onSubmit(finalVals)
-          await onSubmit({
-            subject: subj,
-            createdBy: finalVals.createdBy,
-            event: {
-              ...event,
-              $type: MOD_EVENTS.COMMENT,
-              comment: `[CASCADED_ACTION]: An action before this event occurred after actioning a report on a subject that the account owns. (${reportUrl})`,
-            },
-          })
-        }
-        // 2. Add note to report log
-        await createActivity.mutateAsync({
-          reportId: report.id,
-          activity: {
-            $type: 'tools.ozone.report.defs#noteActivity',
-          },
-          internalNote:
-            'Account-level actions were taken as a result of actioning this report.',
-          isAutomated: true,
-        })
+        // Send original event without a report action
+        await onSubmit(finalVals)
       } else {
         const reportAction: ToolsOzoneModerationEmitEvent.ReportAction = {}
         if (reportActionScope === 'current') {

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -660,14 +660,17 @@ function ReportDetailLayout(props: {
     setSelectedAction(null)
   }
 
-  // Sync selectedAction with modEventType
+  // Sync selectedAction and reportActionScope with modEventType
   useEffect(() => {
     if (selectedAction === 'label') {
       setModEventType(MOD_EVENTS.LABEL)
+      setReportActionScope('types')
     } else if (selectedAction === 'takedown') {
       setModEventType(MOD_EVENTS.TAKEDOWN)
+      setReportActionScope('types')
     } else if (selectedAction === 'revert-takedown') {
       setModEventType(MOD_EVENTS.REVERSE_TAKEDOWN)
+      setReportActionScope('current')
     }
   }, [selectedAction])
 

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -948,6 +948,7 @@ function ReportDetailLayout(props: {
 
           <ReportActionsBar
             report={report}
+            assignment={assignment}
             selectedAction={selectedAction}
             onActionSelect={setSelectedAction}
             subjectStatus={subjectStatus}

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -31,6 +31,7 @@ import {
 import { ActionDurationSelector } from '@/reports/ModerationForm/ActionDurationSelector'
 import { ActionError } from '@/reports/ModerationForm/ActionError'
 import { ReportTypeMultiselect } from '@/reports/ReportTypeMultiselect'
+import { useReports } from '@/reports/useReports'
 import { HighProfileWarning } from '@/repositories/HighProfileWarning'
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
 import { LastReviewedTimestamp } from '@/subject/LastReviewedTimestamp'
@@ -51,7 +52,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
 } from '@heroicons/react/24/outline'
-import { InfiniteData, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { BlobListFormField } from 'app/actions/ModActionPanel/BlobList'
 import { PolicySeveritySelector } from 'app/actions/ModActionPanel/PolicySeveritySelector'
 import { ModActionPanelQuick } from 'app/actions/ModActionPanel/QuickAction'
@@ -87,7 +88,7 @@ import {
   useRouter,
   useSearchParams,
 } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 
 const FORM_ID = 'report-detail-action-panel'
@@ -107,58 +108,6 @@ function isAppealReport(reportType?: string): boolean {
     reportType === ComAtprotoModerationDefs.REASONAPPEAL ||
     reportType === 'tools.ozone.report.defs#reasonAppeal'
   )
-}
-
-function getReportsFromCache(
-  queryClient: ReturnType<typeof useQueryClient>,
-): ToolsOzoneReportDefs.ReportView[] {
-  // Each filter combination produces its own 'betaReports' cache entry.
-  // Pick the most recently updated one for navigation in this cache.
-  const queries = queryClient
-    .getQueryCache()
-    .findAll({ queryKey: ['betaReports'] })
-
-  const latest = queries.reduce<(typeof queries)[number] | null>(
-    (best, q) =>
-      !best || q.state.dataUpdatedAt > best.state.dataUpdatedAt ? q : best,
-    null,
-  )
-  const data = latest?.state.data as
-    | InfiniteData<{ reports: ToolsOzoneReportDefs.ReportView[] }>
-    | undefined
-
-  if (!data?.pages) return []
-
-  const reports: ToolsOzoneReportDefs.ReportView[] = []
-  for (const page of data.pages) {
-    if (page.reports) reports.push(...page.reports)
-  }
-  return reports
-}
-
-function findAdjacentReportsInCache(
-  queryClient: ReturnType<typeof useQueryClient>,
-  reportId: number,
-): { prevId: number | null; nextId: number | null } {
-  const allReports = getReportsFromCache(queryClient)
-
-  if (allReports.length === 0) return { prevId: null, nextId: null }
-
-  const index = allReports.findIndex((r) => r.id === reportId)
-  if (index === -1) return { prevId: null, nextId: null }
-
-  return {
-    prevId: index > 0 ? allReports[index - 1].id : null,
-    nextId: index < allReports.length - 1 ? allReports[index + 1].id : null,
-  }
-}
-
-function findReportInCache(
-  queryClient: ReturnType<typeof useQueryClient>,
-  reportId: number,
-): ToolsOzoneReportDefs.ReportView | null {
-  const allReports = getReportsFromCache(queryClient)
-  return allReports.find((r) => r.id === reportId) ?? null
 }
 
 function ReportInfoPanel({
@@ -360,15 +309,11 @@ export function ReportDetailPageContent() {
     router.push((pathname ?? '') + '?' + nextParams.toString())
   }
 
-  const cachedReport = useMemo(
-    () => findReportInCache(queryClient, reportId),
-    [reportId],
-  )
-
-  const { prevId, nextId } = useMemo(
-    () => findAdjacentReportsInCache(queryClient, reportId),
-    [reportId],
-  )
+  const {
+    report: cachedReport,
+    prevReportId,
+    nextReportId,
+  } = useReports(reportId)
 
   // Register this session as a viewer (temporary, non-permanent assignment).
   useEffect(() => {
@@ -445,15 +390,15 @@ export function ReportDetailPageContent() {
         <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Report #{reportId}
         </h1>
-        {(prevId !== null || nextId !== null) && (
+        {(prevReportId !== null || nextReportId !== null) && (
           <div className="ml-auto flex items-center gap-1">
             <ActionButton
               size="xs"
               appearance="primary"
-              disabled={prevId === null}
+              disabled={prevReportId === null}
               className="disabled:opacity-50"
               onClick={() =>
-                prevId !== null && router.push(`/reports/${prevId}`)
+                prevReportId !== null && router.push(`/reports/${prevReportId}`)
               }
             >
               <ChevronLeftIcon className="h-4 w-4" />
@@ -462,10 +407,10 @@ export function ReportDetailPageContent() {
             <ActionButton
               size="xs"
               appearance="primary"
-              disabled={nextId === null}
+              disabled={nextReportId === null}
               className="disabled:opacity-50"
               onClick={() =>
-                nextId !== null && router.push(`/reports/${nextId}`)
+                nextReportId !== null && router.push(`/reports/${nextReportId}`)
               }
             >
               Next
@@ -543,8 +488,8 @@ function ReportDetailLayout(props: {
   const subjectOptions = [subject]
 
   const router = useRouter()
-
   const createActivity = useCreateActivity()
+  const { advanceToNext } = useReports(report.id)
 
   const [reportActionScope, setReportActionScope] = useState<
     'current' | 'all' | 'types'
@@ -651,6 +596,7 @@ function ReportDetailLayout(props: {
       }
 
       setSelectedAction(null) // Reset after successful submission
+      advanceToNext()
     } else {
       await onSubmit(finalVals)
     }
@@ -948,7 +894,6 @@ function ReportDetailLayout(props: {
 
           <ReportActionsBar
             report={report}
-            assignment={assignment}
             selectedAction={selectedAction}
             onActionSelect={setSelectedAction}
             subjectStatus={subjectStatus}

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -112,20 +112,28 @@ function isAppealReport(reportType?: string): boolean {
 function getReportsFromCache(
   queryClient: ReturnType<typeof useQueryClient>,
 ): ToolsOzoneReportDefs.ReportView[] {
-  const allReports: ToolsOzoneReportDefs.ReportView[] = []
-  for (const key of ['betaReports']) {
-    const allQueriesData = queryClient.getQueriesData<
-      InfiniteData<{ reports: ToolsOzoneReportDefs.ReportView[] }>
-    >({ queryKey: [key] })
+  // Each filter combination produces its own 'betaReports' cache entry.
+  // Pick the most recently updated one for navigation in this cache.
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: ['betaReports'] })
 
-    for (const [, data] of allQueriesData) {
-      if (!data?.pages) continue
-      for (const page of data.pages) {
-        if (page.reports) allReports.push(...page.reports)
-      }
-    }
+  const latest = queries.reduce<(typeof queries)[number] | null>(
+    (best, q) =>
+      !best || q.state.dataUpdatedAt > best.state.dataUpdatedAt ? q : best,
+    null,
+  )
+  const data = latest?.state.data as
+    | InfiniteData<{ reports: ToolsOzoneReportDefs.ReportView[] }>
+    | undefined
+
+  if (!data?.pages) return []
+
+  const reports: ToolsOzoneReportDefs.ReportView[] = []
+  for (const page of data.pages) {
+    if (page.reports) reports.push(...page.reports)
   }
-  return allReports
+  return reports
 }
 
 function findAdjacentReportsInCache(

--- a/app/reports/beta/Filters.tsx
+++ b/app/reports/beta/Filters.tsx
@@ -8,7 +8,6 @@ import { ReportStatuses } from '@/reports/constants'
 import { useAuthDid } from '@/shell/AuthContext'
 
 const STATUS_OPTIONS = [
-  { id: 'all', text: 'All Statuses', value: '' },
   { id: ReportStatuses.OPEN, text: 'Open', value: ReportStatuses.OPEN },
   { id: ReportStatuses.CLOSED, text: 'Closed', value: ReportStatuses.CLOSED },
   {

--- a/components/assignments/useAssignments.ts
+++ b/components/assignments/useAssignments.ts
@@ -94,37 +94,3 @@ export const useReportAssignments = (
     },
   })
 }
-
-const AUTO_ASSIGN_INTERVAL_MS = 3 * MINUTE
-export const useAutoAssignReport = ({
-  reportId,
-  queueId,
-}: {
-  reportId: number
-  queueId?: number
-}) => {
-  const labelerAgent = useLabelerAgent()
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
-
-  const assign = useCallback(async () => {
-    try {
-      await labelerAgent.tools.ozone.report.assignModerator({
-        reportId,
-        queueId,
-      })
-    } catch (err) {
-      console.warn(`Auto-assign failed. `, err)
-    }
-  }, [reportId, queueId, labelerAgent])
-
-  useEffect(() => {
-    assign()
-    intervalRef.current = setInterval(assign, AUTO_ASSIGN_INTERVAL_MS)
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-      }
-    }
-  }, [reportId, queueId])
-}

--- a/components/common/Loader.tsx
+++ b/components/common/Loader.tsx
@@ -78,6 +78,8 @@ export function displayError(err: unknown) {
     originalMessage = err
   } else if (typeof err?.['message'] === 'string') {
     originalMessage = err['message']
+  } else if (typeof err?.['error'] === 'string') {
+    originalMessage = err['error']
   }
   if (!originalMessage) {
     return displayErrorMapping.$default

--- a/components/mod-event/EventItem.tsx
+++ b/components/mod-event/EventItem.tsx
@@ -506,7 +506,7 @@ const TakedownOrMute = ({
         </p>
       )}
       {modEvent.event.comment ? (
-        <p className="pb-1">{`${modEvent.event.comment}`}</p>
+        <p className="pb-1 whitespace-pre-wrap">{`${modEvent.event.comment}`}</p>
       ) : null}
 
       {ToolsOzoneModerationDefs.isModEventTakedown(modEvent.event) && (

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -36,6 +36,7 @@ export enum ActionPanelNames {
   QuickAction = 'quick-action',
   EmailComposer = 'email-composer',
   AccountManager = 'account-manager',
+  ReportPage = 'report-page',
 }
 
 export const buildModToolInfo = (

--- a/components/mod-event/helpers/emitEvent.tsx
+++ b/components/mod-event/helpers/emitEvent.tsx
@@ -27,6 +27,7 @@ import {
   VIDEO_UPLOAD_DISABLE_TAG,
 } from '@/lib/constants'
 import { getBatchId } from '@/lib/batchId'
+import { useRefetchOnlineModerators } from '@/team/useOnlineModerators'
 
 const DELAY_DURATION_MS = 10000 // 10 seconds
 
@@ -65,6 +66,8 @@ export const hydrateModToolInfo = (
 export function useEmitEvent() {
   const labelerAgent = useLabelerAgent()
   const queryClient = useQueryClient()
+  const refetchOnlineModerators = useRefetchOnlineModerators()
+
   const pendingTimeoutRef = useRef<number | null>(null)
 
   return useCallback(
@@ -122,6 +125,7 @@ export function useEmitEvent() {
             queryKey: ['accountView', { id: vals?.subject.did }],
           })
         }
+        refetchOnlineModerators()
       }
 
       // If this is not a delayed action, proceed immediately

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -98,7 +98,6 @@ function TransitionConfirmPanel({
 }) {
   const [note, setNote] = useState('')
   const createActivity = useCreateActivity()
-  const { advanceToNext } = useReports(reportId)
   const { activityType, confirmLabel } = ACTION_CONFIG[action]
 
   const handleConfirm = () => {
@@ -117,9 +116,8 @@ function TransitionConfirmPanel({
           if (action === 'no-action' && onResolveAppeal) {
             await onResolveAppeal()
           }
-          if (action === 'no-action') {
-            advanceToNext()
-          }
+          // Auto-advance is handled centrally by useAdvanceOnReportClose,
+          // which fires when the report's status transitions to 'closed'.
           onDone()
         },
         onError: (e) => {
@@ -232,7 +230,7 @@ export function ReportActionsBar({
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
   onResolveAppeal?: () => Promise<void>
 }) {
-  const { advanceAfterAction, setAdvanceAfterAction } = useReports(report.id)
+  const { autoAdvance, setAutoAdvance } = useReports(report.id)
 
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null)
   const [showNote, setShowNote] = useState(false)
@@ -376,8 +374,8 @@ export function ReportActionsBar({
       <Checkbox
         className="mt-2 flex items-center text-xs"
         label="Advance to next after closing"
-        checked={!!advanceAfterAction}
-        onChange={(e) => setAdvanceAfterAction(e.target.checked)}
+        checked={!!autoAdvance}
+        onChange={(e) => setAutoAdvance(e.target.checked)}
       />
 
       {pendingAction && (

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -116,8 +116,6 @@ function TransitionConfirmPanel({
           if (action === 'no-action' && onResolveAppeal) {
             await onResolveAppeal()
           }
-          // Auto-advance is handled centrally by useAdvanceOnReportClose,
-          // which fires when the report's status transitions to 'closed'.
           onDone()
         },
         onError: (e) => {

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -237,7 +237,7 @@ export function ReportActionsBar({
   const isSubjectTakendown = !!subjectStatus?.takendown
 
   const status = report.status
-  const canEscalate = canTransitionTo(status, 'escalated')
+  const canEscalate = status === 'assigned' && canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
   const canNoAction =
     (status === 'open' || status === 'assigned' || status === 'escalated') &&

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -242,11 +242,8 @@ export function ReportActionsBar({
   const status = report.status
   const canEscalate = canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
-  const canNoAction =
-    (status === 'open' || status === 'assigned' || status === 'escalated') &&
-    canTransitionTo(status, 'closed')
-  const canAction =
-    status === 'open' || status === 'assigned' || status === 'escalated'
+  const canNoAction = (status === 'open' || status === 'assigned' || status === 'escalated') && canTransitionTo(status, 'closed')
+  const canAction = status === 'open' || status === 'assigned' || status === 'escalated'
 
   const handleActionClick = (action: ActionType) => {
     setShowNote(false)

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -460,7 +460,7 @@ function ActivityItem({
         </div>
 
         {noteText && (
-          <p className="mt-0.5 text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
+          <p className="mt-0.5 text-base text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">
             {noteText}
           </p>
         )}

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -1,9 +1,8 @@
 'use client'
 import { ActionButton } from '@/common/buttons'
 import { Dropdown } from '@/common/Dropdown'
-import { Textarea } from '@/common/forms'
+import { Checkbox, Textarea } from '@/common/forms'
 import { displayError } from '@/common/Loader'
-import { useAuthDid } from '@/shell/AuthContext'
 import { usePermission } from '@/shell/ConfigurationContext'
 import {
   ComAtprotoModerationDefs,
@@ -24,6 +23,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { useCreateActivity, useListActivities } from './hooks'
+import { useReports } from './useReports'
 
 export type ReportActionType = 'label' | 'takedown' | 'revert-takedown' | null
 
@@ -98,6 +98,7 @@ function TransitionConfirmPanel({
 }) {
   const [note, setNote] = useState('')
   const createActivity = useCreateActivity()
+  const { advanceToNext } = useReports(reportId)
   const { activityType, confirmLabel } = ACTION_CONFIG[action]
 
   const handleConfirm = () => {
@@ -115,6 +116,9 @@ function TransitionConfirmPanel({
         onSuccess: async () => {
           if (action === 'no-action' && onResolveAppeal) {
             await onResolveAppeal()
+          }
+          if (action === 'no-action') {
+            advanceToNext()
           }
           onDone()
         },
@@ -217,20 +221,18 @@ function NoteComposer({
 
 export function ReportActionsBar({
   report,
-  assignment,
   selectedAction,
   onActionSelect,
   subjectStatus,
   onResolveAppeal,
 }: {
   report: ToolsOzoneReportDefs.ReportView
-  assignment?: ToolsOzoneReportDefs.ReportAssignment
   selectedAction: ReportActionType
   onActionSelect: (action: ReportActionType) => void
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
   onResolveAppeal?: () => Promise<void>
 }) {
-  const currentUserDid = useAuthDid()
+  const { advanceAfterAction, setAdvanceAfterAction } = useReports(report.id)
 
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null)
   const [showNote, setShowNote] = useState(false)
@@ -240,18 +242,15 @@ export function ReportActionsBar({
     report.reportType === ComAtprotoModerationDefs.REASONAPPEAL ||
     report.reportType === 'tools.ozone.report.defs#reasonAppeal'
   const isSubjectTakendown = !!subjectStatus?.takendown
-  const assignedToMe = assignment?.did === currentUserDid
 
   const status = report.status
   const canEscalate = canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
   const canNoAction =
-    assignedToMe &&
     (status === 'open' || status === 'assigned' || status === 'escalated') &&
     canTransitionTo(status, 'closed')
   const canAction =
-    assignedToMe &&
-    (status === 'open' || status === 'assigned' || status === 'escalated')
+    status === 'open' || status === 'assigned' || status === 'escalated'
 
   const handleActionClick = (action: ActionType) => {
     setShowNote(false)
@@ -373,6 +372,13 @@ export function ReportActionsBar({
           Note
         </button>
       </div>
+
+      <Checkbox
+        className="mt-2 flex items-center text-xs"
+        label="Advance to next after closing"
+        checked={!!advanceAfterAction}
+        onChange={(e) => setAdvanceAfterAction(e.target.checked)}
+      />
 
       {pendingAction && (
         <TransitionConfirmPanel

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -33,7 +33,7 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
   open: ['closed', 'escalated', 'queued', 'assigned'],
   closed: ['open'],
   escalated: ['open', 'closed'],
-  queued: ['assigned', 'open', 'escalated'],
+  queued: ['assigned', 'open'],
   assigned: ['open', 'closed', 'escalated', 'queued'],
 }
 

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -237,7 +237,7 @@ export function ReportActionsBar({
   const isSubjectTakendown = !!subjectStatus?.takendown
 
   const status = report.status
-  const canEscalate = status === 'assigned' && canTransitionTo(status, 'escalated')
+  const canEscalate = canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
   const canNoAction =
     (status === 'open' || status === 'assigned' || status === 'escalated') &&

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -21,6 +21,8 @@ import { ActionButton } from '@/common/buttons'
 import { Textarea } from '@/common/forms'
 import { Dropdown } from '@/common/Dropdown'
 import { useCreateActivity, useListActivities } from './hooks'
+import { toast } from 'react-toastify'
+import { displayError } from '@/common/Loader'
 
 export type ReportActionType = 'label' | 'takedown' | 'revert-takedown' | null
 
@@ -40,15 +42,19 @@ function canTransitionTo(fromState: string, toState: string): boolean {
 const statusColors: Record<string, string> = {
   open: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
   closed: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
-  escalated: 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
-  queued: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+  escalated:
+    'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+  queued:
+    'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
   assigned: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
 }
 
 function StatusChip({ status }: { status: string }) {
   const color = statusColors[status] ?? statusColors.open
   return (
-    <span className={`${color} inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium capitalize`}>
+    <span
+      className={`${color} inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium capitalize`}
+    >
       {status}
     </span>
   )
@@ -56,10 +62,25 @@ function StatusChip({ status }: { status: string }) {
 
 type ActionType = 'escalate' | 'reopen' | 'no-action'
 
-const ACTION_CONFIG: Record<ActionType, { activityType: string; label: string; confirmLabel: string }> = {
-  escalate: { activityType: 'tools.ozone.report.defs#escalationActivity', label: 'Escalate', confirmLabel: 'Escalate report' },
-  reopen: { activityType: 'tools.ozone.report.defs#reopenActivity', label: 'Re-open', confirmLabel: 'Re-open report' },
-  'no-action': { activityType: 'tools.ozone.report.defs#closeActivity', label: 'No-action', confirmLabel: 'Close as no-action' },
+const ACTION_CONFIG: Record<
+  ActionType,
+  { activityType: string; label: string; confirmLabel: string }
+> = {
+  escalate: {
+    activityType: 'tools.ozone.report.defs#escalationActivity',
+    label: 'Escalate',
+    confirmLabel: 'Escalate report',
+  },
+  reopen: {
+    activityType: 'tools.ozone.report.defs#reopenActivity',
+    label: 'Re-open',
+    confirmLabel: 'Re-open report',
+  },
+  'no-action': {
+    activityType: 'tools.ozone.report.defs#closeActivity',
+    label: 'No-action',
+    confirmLabel: 'Close as no-action',
+  },
 }
 
 function TransitionConfirmPanel({
@@ -81,7 +102,11 @@ function TransitionConfirmPanel({
     createActivity.mutate(
       {
         reportId,
-        activity: { $type: activityType as Parameters<typeof createActivity.mutate>[0]['activity']['$type'] },
+        activity: {
+          $type: activityType as Parameters<
+            typeof createActivity.mutate
+          >[0]['activity']['$type'],
+        },
         internalNote: note.trim() || undefined,
       },
       {
@@ -90,6 +115,9 @@ function TransitionConfirmPanel({
             await onResolveAppeal()
           }
           onDone()
+        },
+        onError: (e) => {
+          toast.error(`Error actioning: ${displayError(e)}`)
         },
       },
     )
@@ -145,7 +173,12 @@ function NoteComposer({
         activity: { $type: 'tools.ozone.report.defs#noteActivity' },
         internalNote: text.trim(),
       },
-      { onSuccess: () => { setText(''); onDone() } },
+      {
+        onSuccess: () => {
+          setText('')
+          onDone()
+        },
+      },
     )
   }
 
@@ -206,8 +239,11 @@ export function ReportActionsBar({
   const status = report.status
   const canEscalate = canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
-  const canNoAction = (status === 'open' || status === 'assigned' || status === 'escalated') && canTransitionTo(status, 'closed')
-  const canAction = status === 'open' || status === 'assigned' || status === 'escalated'
+  const canNoAction =
+    (status === 'open' || status === 'assigned' || status === 'escalated') &&
+    canTransitionTo(status, 'closed')
+  const canAction =
+    status === 'open' || status === 'assigned' || status === 'escalated'
 
   const handleActionClick = (action: ActionType) => {
     setShowNote(false)
@@ -256,7 +292,9 @@ export function ReportActionsBar({
           <>
             {isSubjectTakendown && canTakedown && (
               <ActionButton
-                appearance={selectedAction === 'revert-takedown' ? 'primary' : 'outlined'}
+                appearance={
+                  selectedAction === 'revert-takedown' ? 'primary' : 'outlined'
+                }
                 size="sm"
                 onClick={() => handleReportActionSelect('revert-takedown')}
               >
@@ -277,14 +315,22 @@ export function ReportActionsBar({
         {canAction && !isAppeal && (canLabel || canTakedown) && (
           <Dropdown
             items={[
-              ...(canLabel ? [{
-                text: 'Label',
-                onClick: () => handleReportActionSelect('label'),
-              }] : []),
-              ...(canTakedown ? [{
-                text: 'Takedown',
-                onClick: () => handleReportActionSelect('takedown'),
-              }] : []),
+              ...(canLabel
+                ? [
+                    {
+                      text: 'Label',
+                      onClick: () => handleReportActionSelect('label'),
+                    },
+                  ]
+                : []),
+              ...(canTakedown
+                ? [
+                    {
+                      text: 'Takedown',
+                      onClick: () => handleReportActionSelect('takedown'),
+                    },
+                  ]
+                : []),
             ]}
             className={`inline-flex justify-center items-center gap-1 rounded-md border px-3 py-1.5 text-sm font-medium shadow-sm ${
               selectedAction
@@ -347,28 +393,43 @@ const ACTIVITY_TO_STATUS: Record<string, string> = {
 
 type ActivityPayload = { $type: string; previousStatus?: string }
 
-function ActivityItem({ activity }: { activity: ToolsOzoneReportDefs.ReportActivityView }) {
-  const payload = (activity as unknown as { activity: ActivityPayload }).activity
+function ActivityItem({
+  activity,
+}: {
+  activity: ToolsOzoneReportDefs.ReportActivityView
+}) {
+  const payload = (activity as unknown as { activity: ActivityPayload })
+    .activity
   const activityType = payload?.$type ?? ''
   const toStatus = ACTIVITY_TO_STATUS[activityType]
   const isStateChange = !!toStatus
-  const noteText = (activity as unknown as { internalNote?: string }).internalNote
-  const timeAgo = formatDistanceToNow(new Date(activity.createdAt), { addSuffix: true })
-  const moderator = (activity as unknown as { moderator?: { profile?: { handle?: string; displayName?: string } } }).moderator
+  const noteText = (activity as unknown as { internalNote?: string })
+    .internalNote
+  const timeAgo = formatDistanceToNow(new Date(activity.createdAt), {
+    addSuffix: true,
+  })
+  const moderator = (
+    activity as unknown as {
+      moderator?: { profile?: { handle?: string; displayName?: string } }
+    }
+  ).moderator
   const displayName = moderator?.profile?.handle || activity.createdBy
 
   return (
     <div className="relative flex gap-3">
       <div className="flex flex-col items-center">
-        <div className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${
-          isStateChange
-            ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-300'
-            : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
-        }`}>
-          {isStateChange
-            ? <ArrowRightIcon className="h-3.5 w-3.5" />
-            : <ChatBubbleLeftIcon className="h-3.5 w-3.5" />
-          }
+        <div
+          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${
+            isStateChange
+              ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-300'
+              : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
+          }`}
+        >
+          {isStateChange ? (
+            <ArrowRightIcon className="h-3.5 w-3.5" />
+          ) : (
+            <ChatBubbleLeftIcon className="h-3.5 w-3.5" />
+          )}
         </div>
       </div>
 
@@ -431,8 +492,14 @@ export function ActivityTimeline({ reportId }: { reportId: number }) {
         className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-800 rounded-lg"
         onClick={() => setOpen((v) => !v)}
       >
-        <span>Activity{activities?.length ? ` (${activities.length})` : ''}</span>
-        {open ? <ChevronUpIcon className="h-4 w-4" /> : <ChevronDownIcon className="h-4 w-4" />}
+        <span>
+          Activity{activities?.length ? ` (${activities.length})` : ''}
+        </span>
+        {open ? (
+          <ChevronUpIcon className="h-4 w-4" />
+        ) : (
+          <ChevronDownIcon className="h-4 w-4" />
+        )}
       </button>
 
       {open && (
@@ -441,7 +508,9 @@ export function ActivityTimeline({ reportId }: { reportId: number }) {
             <p className="py-4 text-center text-xs text-gray-400">Loading…</p>
           )}
           {!isLoading && !activities?.length && (
-            <p className="py-4 text-center text-xs text-gray-400">No activity yet</p>
+            <p className="py-4 text-center text-xs text-gray-400">
+              No activity yet
+            </p>
           )}
           {!!activities?.length && (
             <div className="relative">

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -1,38 +1,40 @@
 'use client'
-import { useState } from 'react'
+import { ActionButton } from '@/common/buttons'
+import { Dropdown } from '@/common/Dropdown'
+import { Textarea } from '@/common/forms'
+import { displayError } from '@/common/Loader'
+import { useAuthDid } from '@/shell/AuthContext'
+import { usePermission } from '@/shell/ConfigurationContext'
 import {
-  ArrowUpCircleIcon,
+  ComAtprotoModerationDefs,
+  ToolsOzoneModerationDefs,
+  ToolsOzoneReportDefs,
+} from '@atproto/api'
+import {
   ArrowPathIcon,
+  ArrowRightIcon,
+  ArrowUpCircleIcon,
   ChatBubbleLeftIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  ArrowRightIcon,
   CpuChipIcon,
   NoSymbolIcon,
 } from '@heroicons/react/24/outline'
-import {
-  ToolsOzoneReportDefs,
-  ToolsOzoneModerationDefs,
-  ComAtprotoModerationDefs,
-} from '@atproto/api'
-import { usePermission } from '@/shell/ConfigurationContext'
 import { formatDistanceToNow } from 'date-fns'
-import { ActionButton } from '@/common/buttons'
-import { Textarea } from '@/common/forms'
-import { Dropdown } from '@/common/Dropdown'
-import { useCreateActivity, useListActivities } from './hooks'
+import { useState } from 'react'
 import { toast } from 'react-toastify'
-import { displayError } from '@/common/Loader'
+import { useCreateActivity, useListActivities } from './hooks'
 
 export type ReportActionType = 'label' | 'takedown' | 'revert-takedown' | null
 
-// Mirror of backend VALID_TRANSITIONS in packages/ozone/src/report/activity.ts
+// Mirror of backend VALID_TRANSITIONS
+// https://github.com/bluesky-social/atproto/blob/main/packages/ozone/src/report/handle-report-update.ts
 const VALID_TRANSITIONS: Record<string, string[]> = {
   open: ['closed', 'escalated', 'queued', 'assigned'],
   closed: ['open'],
   escalated: ['open', 'closed'],
   queued: ['assigned', 'open', 'escalated'],
-  assigned: ['open', 'closed', 'escalated'],
+  assigned: ['open', 'closed', 'escalated', 'queued'],
 }
 
 function canTransitionTo(fromState: string, toState: string): boolean {
@@ -215,35 +217,41 @@ function NoteComposer({
 
 export function ReportActionsBar({
   report,
+  assignment,
   selectedAction,
   onActionSelect,
   subjectStatus,
   onResolveAppeal,
 }: {
   report: ToolsOzoneReportDefs.ReportView
+  assignment?: ToolsOzoneReportDefs.ReportAssignment
   selectedAction: ReportActionType
   onActionSelect: (action: ReportActionType) => void
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
   onResolveAppeal?: () => Promise<void>
 }) {
+  const currentUserDid = useAuthDid()
+
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null)
   const [showNote, setShowNote] = useState(false)
-
   const canLabel = usePermission('canLabel')
   const canTakedown = usePermission('canTakedown')
   const isAppeal =
     report.reportType === ComAtprotoModerationDefs.REASONAPPEAL ||
     report.reportType === 'tools.ozone.report.defs#reasonAppeal'
   const isSubjectTakendown = !!subjectStatus?.takendown
+  const assignedToMe = assignment?.did === currentUserDid
 
   const status = report.status
   const canEscalate = canTransitionTo(status, 'escalated')
   const canReopen = status === 'closed' && canTransitionTo(status, 'open')
   const canNoAction =
+    assignedToMe &&
     (status === 'open' || status === 'assigned' || status === 'escalated') &&
     canTransitionTo(status, 'closed')
   const canAction =
-    status === 'open' || status === 'assigned' || status === 'escalated'
+    assignedToMe &&
+    (status === 'open' || status === 'assigned' || status === 'escalated')
 
   const handleActionClick = (action: ActionType) => {
     setShowNote(false)

--- a/components/reports/helpers/getType.ts
+++ b/components/reports/helpers/getType.ts
@@ -21,6 +21,7 @@ export const reasonTypeOptions = {
   'tools.ozone.report.defs#reasonAppeal': 'Appeal',
 
   // Violence and Welfare
+  'tools.ozone.report.defs#reasonViolenceAnimal': 'Animal Violence',
   'tools.ozone.report.defs#reasonViolenceAnimalWelfare':
     'Animal Welfare Violation',
   'tools.ozone.report.defs#reasonViolenceThreats': 'Violent Threats',
@@ -47,6 +48,7 @@ export const reasonTypeOptions = {
   'tools.ozone.report.defs#reasonChildSafetyCSAM':
     'Child Sexual Abuse Material',
   'tools.ozone.report.defs#reasonChildSafetyGroom': 'Child Grooming',
+  'tools.ozone.report.defs#reasonChildSafetyPrivacy': 'Child Privacy Violation',
   'tools.ozone.report.defs#reasonChildSafetyMinorPrivacy':
     'Minor Privacy Violation',
   'tools.ozone.report.defs#reasonChildSafetyEndangerment': 'Child Endangerment',
@@ -67,6 +69,7 @@ export const reasonTypeOptions = {
   'tools.ozone.report.defs#reasonMisleadingImpersonation': 'Impersonation',
   'tools.ozone.report.defs#reasonMisleadingSpam': 'Spam',
   'tools.ozone.report.defs#reasonMisleadingScam': 'Scam',
+  'tools.ozone.report.defs#reasonMisleadingElections': 'Election Interference',
   'tools.ozone.report.defs#reasonMisleadingSyntheticContent':
     'Synthetic Content',
   'tools.ozone.report.defs#reasonMisleadingMisinformation': 'Misinformation',
@@ -93,6 +96,9 @@ export const reasonTypeOptions = {
   'tools.ozone.report.defs#reasonSelfHarmStunts': 'Self Harm Stunts',
   'tools.ozone.report.defs#reasonSelfHarmSubstances': 'Self Harm Substances',
   'tools.ozone.report.defs#reasonSelfHarmOther': 'Other Self Harm Content',
+
+  // Other
+  'tools.ozone.report.defs#reasonOther': 'Other',
 }
 
 export const groupedReasonTypes = {
@@ -107,9 +113,11 @@ export const groupedReasonTypes = {
   ],
   Appeal: ['tools.ozone.report.defs#reasonAppeal'],
   Violence: [
+    'tools.ozone.report.defs#reasonViolenceAnimal',
     'tools.ozone.report.defs#reasonViolenceAnimalWelfare',
     'tools.ozone.report.defs#reasonViolenceThreats',
     'tools.ozone.report.defs#reasonViolenceGraphicContent',
+    'tools.ozone.report.defs#reasonViolenceSelfHarm',
     'tools.ozone.report.defs#reasonViolenceGlorification',
     'tools.ozone.report.defs#reasonViolenceExtremistContent',
     'tools.ozone.report.defs#reasonViolenceTrafficking',
@@ -127,6 +135,7 @@ export const groupedReasonTypes = {
   'Child Safety': [
     'tools.ozone.report.defs#reasonChildSafetyCSAM',
     'tools.ozone.report.defs#reasonChildSafetyGroom',
+    'tools.ozone.report.defs#reasonChildSafetyPrivacy',
     'tools.ozone.report.defs#reasonChildSafetyMinorPrivacy',
     'tools.ozone.report.defs#reasonChildSafetyEndangerment',
     'tools.ozone.report.defs#reasonChildSafetyHarassment',
@@ -145,6 +154,7 @@ export const groupedReasonTypes = {
     'tools.ozone.report.defs#reasonMisleadingImpersonation',
     'tools.ozone.report.defs#reasonMisleadingSpam',
     'tools.ozone.report.defs#reasonMisleadingScam',
+    'tools.ozone.report.defs#reasonMisleadingElections',
     'tools.ozone.report.defs#reasonMisleadingSyntheticContent',
     'tools.ozone.report.defs#reasonMisleadingMisinformation',
     'tools.ozone.report.defs#reasonMisleadingOther',
@@ -170,6 +180,7 @@ export const groupedReasonTypes = {
     'tools.ozone.report.defs#reasonSelfHarmSubstances',
     'tools.ozone.report.defs#reasonSelfHarmOther',
   ],
+  Other: ['tools.ozone.report.defs#reasonOther'],
 }
 
 export const getTagForReport = (reasonType: string) => {

--- a/components/reports/helpers/getType.ts
+++ b/components/reports/helpers/getType.ts
@@ -183,6 +183,80 @@ export const groupedReasonTypes = {
   Other: ['tools.ozone.report.defs#reasonOther'],
 }
 
+// Reason types for statististics.
+// Needs to match backend for proper stat lookup.
+// https://github.com/bluesky-social/atproto/blob/main/packages/ozone/src/report/stats.ts
+export const statReasonTypes = {
+  Legacy: [
+    'com.atproto.moderation.defs#reasonSpam',
+    'com.atproto.moderation.defs#reasonViolation',
+    'com.atproto.moderation.defs#reasonMisleading',
+    'com.atproto.moderation.defs#reasonSexual',
+    'com.atproto.moderation.defs#reasonRude',
+    'com.atproto.moderation.defs#reasonOther',
+    'com.atproto.moderation.defs#reasonAppeal',
+  ],
+  Appeal: ['tools.ozone.report.defs#reasonAppeal'],
+  Violence: [
+    'tools.ozone.report.defs#reasonViolenceAnimalWelfare',
+    'tools.ozone.report.defs#reasonViolenceThreats',
+    'tools.ozone.report.defs#reasonViolenceGraphicContent',
+    'tools.ozone.report.defs#reasonViolenceSelfHarm',
+    'tools.ozone.report.defs#reasonViolenceGlorification',
+    'tools.ozone.report.defs#reasonViolenceExtremistContent',
+    'tools.ozone.report.defs#reasonViolenceTrafficking',
+    'tools.ozone.report.defs#reasonViolenceOther',
+  ],
+  Sexual: [
+    'tools.ozone.report.defs#reasonSexualAbuseContent',
+    'tools.ozone.report.defs#reasonSexualNCII',
+    'tools.ozone.report.defs#reasonSexualSextortion',
+    'tools.ozone.report.defs#reasonSexualDeepfake',
+    'tools.ozone.report.defs#reasonSexualAnimal',
+    'tools.ozone.report.defs#reasonSexualUnlabeled',
+    'tools.ozone.report.defs#reasonSexualOther',
+  ],
+  'Child Safety': [
+    'tools.ozone.report.defs#reasonChildSafetyCSAM',
+    'tools.ozone.report.defs#reasonChildSafetyGroom',
+    'tools.ozone.report.defs#reasonChildSafetyMinorPrivacy',
+    'tools.ozone.report.defs#reasonChildSafetyEndangerment',
+    'tools.ozone.report.defs#reasonChildSafetyHarassment',
+    'tools.ozone.report.defs#reasonChildSafetyPromotion',
+    'tools.ozone.report.defs#reasonChildSafetyOther',
+  ],
+  Harassment: [
+    'tools.ozone.report.defs#reasonHarassmentTroll',
+    'tools.ozone.report.defs#reasonHarassmentTargeted',
+    'tools.ozone.report.defs#reasonHarassmentHateSpeech',
+    'tools.ozone.report.defs#reasonHarassmentDoxxing',
+    'tools.ozone.report.defs#reasonHarassmentOther',
+  ],
+  Misleading: [
+    'tools.ozone.report.defs#reasonMisleadingBot',
+    'tools.ozone.report.defs#reasonMisleadingImpersonation',
+    'tools.ozone.report.defs#reasonMisleadingSpam',
+    'tools.ozone.report.defs#reasonMisleadingScam',
+    'tools.ozone.report.defs#reasonMisleadingSyntheticContent',
+    'tools.ozone.report.defs#reasonMisleadingMisinformation',
+    'tools.ozone.report.defs#reasonMisleadingOther',
+  ],
+  'Rule Violations': [
+    'tools.ozone.report.defs#reasonRuleSiteSecurity',
+    'tools.ozone.report.defs#reasonRuleStolenContent',
+    'tools.ozone.report.defs#reasonRuleProhibitedSales',
+    'tools.ozone.report.defs#reasonRuleBanEvasion',
+    'tools.ozone.report.defs#reasonRuleOther',
+  ],
+  Civic: [
+    'tools.ozone.report.defs#reasonCivicElectoralProcess',
+    'tools.ozone.report.defs#reasonCivicDisclosure',
+    'tools.ozone.report.defs#reasonCivicInterference',
+    'tools.ozone.report.defs#reasonCivicMisinformation',
+    'tools.ozone.report.defs#reasonCivicImpersonation',
+  ],
+}
+
 export const getTagForReport = (reasonType: string) => {
   const reasonWithoutPrefix = reasonType
     .replace('com.atproto.moderation.defs#reason', '')

--- a/components/reports/stats/Stats.tsx
+++ b/components/reports/stats/Stats.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 import { Line, LineChart, ResponsiveContainer } from 'recharts'
 import { twMerge } from 'tailwind-merge'
 import { getHrefFromGroup, StatGroup } from '.'
-import { groupedReasonTypes } from '../helpers/getType'
+import { statReasonTypes } from '../helpers/getType'
 import {
   LiveStatsParams,
   useHistoricalStats,
@@ -164,9 +164,7 @@ export function StatCard({
 
 export function StatsCard({ group }: { group: StatGroup }) {
   const filterParams: LiveStatsParams = {
-    reportTypes: group.category
-      ? groupedReasonTypes[group.category]
-      : undefined,
+    reportTypes: group.category ? statReasonTypes[group.category] : undefined,
     queueId: group.queueId,
     moderatorDid: group.moderatorDid,
   }

--- a/components/reports/stats/StatsFilters.tsx
+++ b/components/reports/stats/StatsFilters.tsx
@@ -1,6 +1,7 @@
 import { PaginatedSelect } from '@/common/PaginatedSelect'
 import { useQueueList } from '@/queues/useQueues'
 import { ReportCategorySelect } from '@/reports/ReportCategorySelect'
+import { usePermission } from '@/shell/ConfigurationContext'
 import { MemberSingleSelect } from '@/team/MemberSingleSelect'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -45,7 +46,12 @@ function filtersFromParams(searchParams: URLSearchParams): StatsFilterState {
   if (startDateParam) dateRange.startDate = startDateParam
   if (endDateParam) dateRange.endDate = endDateParam
 
-  const validGroupings: Grouping[] = ['aggregate', 'queue', 'category', 'moderator']
+  const validGroupings: Grouping[] = [
+    'aggregate',
+    'queue',
+    'category',
+    'moderator',
+  ]
   const grouping: Grouping =
     groupingParam && validGroupings.includes(groupingParam as Grouping)
       ? (groupingParam as Grouping)
@@ -144,12 +150,13 @@ export function StatsFilters({
   value: StatsFilterState
   onChange: (value: StatsFilterState) => void
 }) {
-  const {
-    data: queuesData,
-    hasNextPage,
-    fetchNextPage,
-  } = useQueueList()
+  const canViewModeratorStats = usePermission('canViewModeratorStats')
+  const { data: queuesData, hasNextPage, fetchNextPage } = useQueueList()
   const queues = queuesData?.pages.flatMap((page) => page.queues ?? []) ?? []
+
+  const groupings = canViewModeratorStats
+    ? GROUPINGS
+    : GROUPINGS.filter((mode) => mode.key !== 'moderator')
 
   const handleGroupingChange = (grouping: Grouping) => {
     onChange({
@@ -172,7 +179,7 @@ export function StatsFilters({
           onChange={(e) => handleGroupingChange(e.target.value as Grouping)}
           className="block w-auto text-sm rounded border-gray-300 dark:border-slate-600 dark:bg-slate-700 dark:text-gray-200"
         >
-          {GROUPINGS.map((mode) => (
+          {groupings.map((mode) => (
             <option key={mode.key} value={mode.key}>
               {mode.label}
             </option>
@@ -228,7 +235,7 @@ export function StatsFilters({
         </div>
       )}
 
-      {value.grouping === 'moderator' && (
+      {canViewModeratorStats && value.grouping === 'moderator' && (
         <div>
           <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
             Moderator

--- a/components/reports/stats/index.ts
+++ b/components/reports/stats/index.ts
@@ -1,9 +1,9 @@
-import { groupedReasonTypes } from '../helpers/getType'
+import { statReasonTypes } from '../helpers/getType'
 
 export interface StatGroup {
   title: string
   description?: string
-  category?: keyof typeof groupedReasonTypes
+  category?: keyof typeof statReasonTypes
   queueId?: number
   moderatorDid?: string
 }

--- a/components/reports/table.tsx
+++ b/components/reports/table.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircleIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  ChevronRightIcon,
   Bars3BottomLeftIcon,
 } from '@heroicons/react/20/solid'
 import { LoadMoreButton } from '../common/LoadMoreButton'
@@ -266,7 +267,18 @@ function ReportRow({
     : report.subject.record?.repo?.did
 
   return (
-    <tr {...others}>
+    <tr
+      {...others}
+      onClick={(e) => {
+        // Let nested links/buttons (subject, reporter, etc.) handle their own clicks
+        if ((e.target as HTMLElement).closest('button, a')) return
+        router.push(reportUrl)
+      }}
+      className={classNames(
+        'group cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700/50',
+        others.className,
+      )}
+    >
       {/* Mobile-only collapsed row */}
       <td className="w-full max-w-0 py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-gray-200 sm:w-auto sm:max-w-none sm:pl-6 sm:hidden">
         <div className="flex flex-row items-center pb-1 gap-1">
@@ -373,13 +385,7 @@ function ReportRow({
           <MutedBadge isMuted={report.isMuted} />
         </div>
         {!!report.comment && (
-          <div
-            className="mb-1 cursor-pointer"
-            onClick={(e) => {
-              if ((e.target as HTMLElement).closest('button, a')) return
-              router.push(reportUrl)
-            }}
-          >
+          <div className="mb-1">
             <ReporterComment comment={report.comment} />
           </div>
         )}
@@ -492,6 +498,12 @@ function ReportRow({
             </span>
           </div>
         )}
+      </td>
+      <td className="hidden w-8 pr-3 py-4 text-right align-middle sm:table-cell">
+        <ChevronRightIcon
+          className="h-5 w-5 inline-block text-gray-300 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-300"
+          aria-hidden="true"
+        />
       </td>
     </tr>
   )
@@ -662,6 +674,9 @@ function ReportRowHead() {
             ))}
         </Link>
       </th>
+      <th scope="col" className="hidden w-8 py-3.5 sm:table-cell">
+        <span className="sr-only">Open report</span>
+      </th>
     </tr>
   )
 }
@@ -675,7 +690,7 @@ function EmptyRows({
 }) {
   return (
     <tr>
-      <td colSpan={5} className="text-center">
+      <td colSpan={6} className="text-center">
         {isInitialLoading ? (
           <>
             <Loading />

--- a/components/reports/useReports.ts
+++ b/components/reports/useReports.ts
@@ -5,7 +5,7 @@ import { InfiniteData, useQueryClient } from '@tanstack/react-query'
 import {
   useRouter
 } from 'next/navigation'
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocalStorage } from 'react-use'
 
 function getReportsFromCache(
@@ -127,4 +127,41 @@ export function useReportAutoAdvance(reportId: number, status?: string) {
     // reportId/status change, capturing the latest closure at that point.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reportId, status])
+}
+
+/**
+ * Navigates between adjacent reports using arrow keys.
+ */
+export function useReportArrowKeyNavigation(reportId: number) {
+  const router = useRouter()
+  const { prevReportId, nextReportId } = useReports(reportId)
+
+  const isEditableTarget = useCallback((target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) return false
+    const tag = target.tagName
+    return (
+      tag === 'INPUT' ||
+      tag === 'TEXTAREA' ||
+      tag === 'SELECT' ||
+      target.isContentEditable
+    )
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return
+      if (isEditableTarget(e.target)) return
+
+      if (e.key === 'ArrowLeft' && prevReportId !== null) {
+        e.preventDefault()
+        router.push(`/reports/${prevReportId}`)
+      } else if (e.key === 'ArrowRight' && nextReportId !== null) {
+        e.preventDefault()
+        router.push(`/reports/${nextReportId}`)
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [reportId, prevReportId, nextReportId, router])
 }

--- a/components/reports/useReports.ts
+++ b/components/reports/useReports.ts
@@ -5,7 +5,7 @@ import { InfiniteData, useQueryClient } from '@tanstack/react-query'
 import {
   useRouter
 } from 'next/navigation'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useLocalStorage } from 'react-use'
 
 function getReportsFromCache(
@@ -82,33 +82,49 @@ export function useReports(reportId: number) {
     [reportId],
   )
 
-  // auto advance
-  const [advanceAfterAction, setAdvanceAfterAction] = useLocalStorage(
+  // auto advance setting
+  const [autoAdvance, setAutoAdvance] = useLocalStorage(
     'reports.advanceAfterAction',
     false,
   )
-  const advanceToNext = () => {
-    if (advanceAfterAction) {
-      if (nextId) {
-        router.push(`/reports/${nextId}`)
-      }
-    }
-  }
-
-  console.log('useReports', {
-    reportId,
-    report,
-    prevId,
-    nextId,
-    advanceAfterAction,
-  })
 
   return {
     report,
     prevReportId: prevId,
     nextReportId: nextId,
-    advanceAfterAction,
-    setAdvanceAfterAction,
-    advanceToNext,
+    autoAdvance,
+    setAutoAdvance,
   }
+}
+
+/**
+ * Advances to the next report after closing.
+ * Respects autoAdvance setting.
+ */
+export function useReportAutoAdvance(reportId: number, status?: string) {
+  const router = useRouter()
+  const { nextReportId, autoAdvance } = useReports(reportId)
+
+  // Track the report a status belongs to, so navigating between reports (which
+  // keeps this hook mounted on the /reports/[id] route) re-baselines instead of
+  // comparing the new report's status against the previous report's.
+  const prevRef = useRef<{ reportId: number; status?: string }>({
+    reportId,
+    status,
+  })
+
+  useEffect(() => {
+    const prev = prevRef.current
+    prevRef.current = { reportId, status }
+    // Only react to status changes within the same report.
+    if (prev.reportId !== reportId) return
+    if (prev.status && prev.status !== 'closed' && status === 'closed') {
+      if (autoAdvance && nextReportId) {
+        router.push(`/reports/${nextReportId}`)
+      }
+    }
+    // advanceToNext is recreated each render; the effect re-runs only on
+    // reportId/status change, capturing the latest closure at that point.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reportId, status])
 }

--- a/components/reports/useReports.ts
+++ b/components/reports/useReports.ts
@@ -1,0 +1,114 @@
+import {
+  ToolsOzoneReportDefs
+} from '@atproto/api'
+import { InfiniteData, useQueryClient } from '@tanstack/react-query'
+import {
+  useRouter
+} from 'next/navigation'
+import { useMemo } from 'react'
+import { useLocalStorage } from 'react-use'
+
+function getReportsFromCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+): ToolsOzoneReportDefs.ReportView[] {
+  // Each filter combination produces its own 'betaReports' cache entry.
+  // Pick the most recently updated one for navigation in this cache.
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: ['betaReports'] })
+
+  const latest = queries.reduce<(typeof queries)[number] | null>(
+    (best, q) =>
+      !best || q.state.dataUpdatedAt > best.state.dataUpdatedAt ? q : best,
+    null,
+  )
+  const data = latest?.state.data as
+    | InfiniteData<{ reports: ToolsOzoneReportDefs.ReportView[] }>
+    | undefined
+
+  if (!data?.pages) return []
+
+  const reports: ToolsOzoneReportDefs.ReportView[] = []
+  for (const page of data.pages) {
+    if (page.reports) reports.push(...page.reports)
+  }
+  return reports
+}
+
+function findAdjacentReportsInCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  reportId: number,
+): { prevId: number | null; nextId: number | null } {
+  const allReports = getReportsFromCache(queryClient)
+
+  if (allReports.length === 0) return { prevId: null, nextId: null }
+
+  const index = allReports.findIndex((r) => r.id === reportId)
+  if (index === -1) return { prevId: null, nextId: null }
+
+  return {
+    prevId: index > 0 ? allReports[index - 1].id : null,
+    nextId: index < allReports.length - 1 ? allReports[index + 1].id : null,
+  }
+}
+
+function findReportInCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  reportId: number,
+): ToolsOzoneReportDefs.ReportView | null {
+  const allReports = getReportsFromCache(queryClient)
+  return allReports.find((r) => r.id === reportId) ?? null
+}
+
+/**
+ * Hook to manage current report
+ */
+export function useReports(reportId: number) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  // current report
+  const report = useMemo(() => {
+    if (reportId === null) return null
+    return findReportInCache(queryClient, reportId)
+  }, [reportId])
+
+  // adjacent
+  const { prevId, nextId } = useMemo(
+    function () {
+      if (reportId === null) return { prevId: null, nextId: null }
+      return findAdjacentReportsInCache(queryClient, reportId)
+    },
+    [reportId],
+  )
+
+  // auto advance
+  const [advanceAfterAction, setAdvanceAfterAction] = useLocalStorage(
+    'reports.advanceAfterAction',
+    false,
+  )
+  const advanceToNext = () => {
+    if (advanceAfterAction) {
+      if (nextId) {
+        router.push(`/reports/${nextId}`)
+      }
+    }
+  }
+
+  console.log('useReports', {
+    reportId,
+    report,
+    prevId,
+    nextId,
+    advanceAfterAction,
+  })
+
+  return {
+    report,
+    prevReportId: prevId,
+    nextReportId: nextId,
+    advanceAfterAction,
+    setAdvanceAfterAction,
+    advanceToNext,
+  }
+}

--- a/components/shell/Shell.tsx
+++ b/components/shell/Shell.tsx
@@ -4,6 +4,7 @@ import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
 import { SidebarNav } from './SidebarNav'
 import { MobileMenuProvider, MobileMenu, MobileMenuBtn } from './MobileMenu'
 import { ProfileMenu } from './ProfileMenu'
+import { OnlineModeratorsIndicator } from '../team/OnlineModeratorsIndicator'
 
 import { useCommandPaletteAsyncSearch } from './CommandPalette/useAsyncSearch'
 import { useFluentReportSearchUpdate } from '@/reports/useFluentReportSearch'
@@ -62,7 +63,9 @@ export function Shell({ children }: React.PropsWithChildren) {
                     </div>
                   </form>
                 </div>
-                <div className="ml-2 flex items-center space-x-4 sm:ml-6 sm:space-x-6">
+                <div className="ml-2 flex items-center gap-6 sm:ml-6 sm:gap-6">
+                  {/* Online moderators indicator */}
+                  <OnlineModeratorsIndicator />
                   {/* Profile dropdown */}
                   <ProfileMenu />
                 </div>

--- a/components/team/OnlineModeratorsIndicator.tsx
+++ b/components/team/OnlineModeratorsIndicator.tsx
@@ -65,7 +65,7 @@ function ModeratorListItem({
   const handle = profile?.handle
   const avatar = profile?.avatar
 
-  const timeAgo = getTimeAgo(lastActive)
+  const activeFor = getActiveFor(lastActive)
 
   return (
     <Link
@@ -87,18 +87,18 @@ function ModeratorListItem({
           </div>
         )}
         <div className="text-xs text-gray-500 dark:text-gray-400">
-          Active {timeAgo}
+          {activeFor}
         </div>
       </div>
     </Link>
   )
 }
 
-function getTimeAgo(date: Date): string {
+function getActiveFor(date: Date): string {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
-
-  if (seconds < 60) return 'just now'
   const minutes = Math.floor(seconds / 60)
-  if (minutes === 1) return '1 minute ago'
-  return `${minutes} minutes ago`
+
+  if (minutes < 1) return 'Active for less than a minute'
+  if (minutes === 1) return 'Active for 1 minute'
+  return `Active for ${minutes} minutes`
 }

--- a/components/team/OnlineModeratorsIndicator.tsx
+++ b/components/team/OnlineModeratorsIndicator.tsx
@@ -13,7 +13,7 @@ export function OnlineModeratorsIndicator() {
   return (
     <Popover className="relative">
       <PopoverButton className="flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500">
-        <span className="sr-only">View online moderators</span>
+        <span className="sr-only">{onlineModerators.length} online</span>
         <div className="relative">
           <UserGroupIcon className="h-5 w-5 text-gray-600 dark:text-gray-300" />
           <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-green-500 ring-1 ring-white dark:ring-slate-900" />
@@ -25,7 +25,7 @@ export function OnlineModeratorsIndicator() {
 
       <PopoverPanel className="absolute right-0 z-10 mt-2 w-64 origin-top-right rounded-md bg-white dark:bg-slate-900 py-2 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
         <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-slate-700">
-          Online Moderators ({onlineModerators.length})
+          {onlineModerators.length} online
         </div>
         <div className="max-h-96 overflow-y-auto">
           {onlineModerators.map((mod) => (

--- a/components/team/OnlineModeratorsIndicator.tsx
+++ b/components/team/OnlineModeratorsIndicator.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+import { UserGroupIcon } from '@heroicons/react/24/outline'
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { useLabelerAgent } from '../shell/ConfigurationContext'
+import { useOnlineModerators } from './useOnlineModerators'
+
+export function OnlineModeratorsIndicator() {
+  const { data: onlineModerators = [] } = useOnlineModerators()
+
+  return (
+    <Popover className="relative">
+      <PopoverButton className="flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500">
+        <span className="sr-only">View online moderators</span>
+        <div className="relative">
+          <UserGroupIcon className="h-5 w-5 text-gray-600 dark:text-gray-300" />
+          <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-green-500 ring-1 ring-white dark:ring-slate-900" />
+        </div>
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+          {onlineModerators.length}
+        </span>
+      </PopoverButton>
+
+      <PopoverPanel className="absolute right-0 z-10 mt-2 w-64 origin-top-right rounded-md bg-white dark:bg-slate-900 py-2 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-slate-700">
+          Online Moderators ({onlineModerators.length})
+        </div>
+        <div className="max-h-96 overflow-y-auto">
+          {onlineModerators.map((mod) => (
+            <ModeratorListItem
+              key={mod.did}
+              did={mod.did}
+              lastActive={mod.lastActive}
+            />
+          ))}
+        </div>
+      </PopoverPanel>
+    </Popover>
+  )
+}
+
+function ModeratorListItem({
+  did,
+  lastActive,
+}: {
+  did: string
+  lastActive: Date
+}) {
+  const labelerAgent = useLabelerAgent()
+  const { data: profile } = useQuery({
+    queryKey: ['moderator-profile', did],
+    queryFn: async () => {
+      const { data } = await labelerAgent.app.bsky.actor.getProfile({
+        actor: did,
+      })
+      return data
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+
+  const displayName = profile?.displayName || profile?.handle || did
+  const handle = profile?.handle
+  const avatar = profile?.avatar
+
+  const timeAgo = getTimeAgo(lastActive)
+
+  return (
+    <Link
+      href={`/repositories/${did}`}
+      className="flex items-center gap-2 px-3 py-2 hover:bg-gray-50 dark:hover:bg-slate-800"
+    >
+      <img
+        className="h-6 w-6 rounded-full"
+        src={avatar || '/img/default-avatar.jpg'}
+        alt=""
+      />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+          {displayName}
+        </div>
+        {handle && displayName !== handle && (
+          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+            @{handle}
+          </div>
+        )}
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          Active {timeAgo}
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+function getTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
+
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes === 1) return '1 minute ago'
+  return `${minutes} minutes ago`
+}

--- a/components/team/useMemberList.tsx
+++ b/components/team/useMemberList.tsx
@@ -45,13 +45,13 @@ export const useMemberList = (q?: string) => {
 }
 
 /**
- * Fetches all active members.
+ * Fetches full list of active members.
  */
-export const useActiveMemberList = () => {
+export const useFullMemberList = () => {
   const labelerAgent = useLabelerAgent()
 
   return useQuery({
-    queryKey: ['activeMemberList'],
+    queryKey: ['fullMemberList'],
     // expensive so use longer stale time
     staleTime: 5 * 60 * 1000,
     queryFn: async () => {

--- a/components/team/useMemberList.tsx
+++ b/components/team/useMemberList.tsx
@@ -1,6 +1,10 @@
 import { useLabelerAgent } from '@/shell/ConfigurationContext'
-import { Agent, ToolsOzoneTeamListMembers } from '@atproto/api'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import {
+  Agent,
+  ToolsOzoneTeamDefs,
+  ToolsOzoneTeamListMembers,
+} from '@atproto/api'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { MemberRoleNames } from './helpers'
 
@@ -38,4 +42,31 @@ export const useMemberList = (q?: string) => {
     roles,
     setRoles,
   }
+}
+
+/**
+ * Fetches all active members.
+ */
+export const useActiveMemberList = () => {
+  const labelerAgent = useLabelerAgent()
+
+  return useQuery({
+    queryKey: ['activeMemberList'],
+    // expensive so use longer stale time
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const data = new Map<string, ToolsOzoneTeamDefs.Member>()
+      let cursor: string | undefined
+      do {
+        const page = await getMembersList(labelerAgent, {
+          disabled: false,
+          limit: 100,
+          cursor,
+        })
+        page.members.forEach((member) => data.set(member.did, member))
+        cursor = page.cursor
+      } while (cursor)
+      return data
+    },
+  })
 }

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLabelerAgent } from '../shell/ConfigurationContext'
+import { useConfigContext } from '../shell/ConfigContext'
 
 export const ONLINE_MODERATORS_QUERY_KEY = ['onlineModerators']
 
@@ -14,6 +15,7 @@ const STALE_TIME = 2 * 1000 // debounce protection when used with refetch below
 
 export function useOnlineModerators() {
   const labelerAgent = useLabelerAgent()
+  const { config } = useConfigContext()
 
   return useQuery<OnlineModerator[]>({
     queryKey: ONLINE_MODERATORS_QUERY_KEY,
@@ -22,7 +24,7 @@ export function useOnlineModerators() {
       const activeThreshold = new Date(Date.now() - ACTIVE_THRESHOLD)
 
       const updateMod = (did: string, activityTime: Date) => {
-        if (did === labelerAgent?.did) return
+        if (did === config.did) return
         const existing = moderatorActivity.get(did)
         if (!existing || activityTime.getTime() > existing.getTime()) {
           moderatorActivity.set(did, activityTime)

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -23,6 +23,7 @@ export function useOnlineModerators() {
 
       const updateMod = (did: string, activityTime: Date) => {
         if (activityTime < activeThreshold) return
+        if (did === labelerAgent?.did) return
         const existing = moderatorActivity.get(did)
         if (!existing || activityTime.getTime() > existing.getTime()) {
           moderatorActivity.set(did, activityTime)

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -25,6 +25,7 @@ export function useOnlineModerators() {
 
       const updateMod = (did: string, activityTime: Date) => {
         if (did === config.did) return
+        if (activityTime < activeThreshold) return
         const existing = moderatorActivity.get(did)
         if (!existing || activityTime.getTime() > existing.getTime()) {
           moderatorActivity.set(did, activityTime)

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -1,7 +1,8 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useLabelerAgent } from '../shell/ConfigurationContext'
-import { useConfigContext } from '../shell/ConfigContext'
 import { MOD_EVENTS } from '@/mod-event/constants'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useConfigContext } from '../shell/ConfigContext'
+import { useLabelerAgent } from '../shell/ConfigurationContext'
+import { useFullMemberList } from './useMemberList'
 
 export const ONLINE_MODERATORS_QUERY_KEY = ['onlineModerators']
 
@@ -33,9 +34,12 @@ const MOD_ACTION_EVENT_TYPES = [
 export function useOnlineModerators() {
   const labelerAgent = useLabelerAgent()
   const { config } = useConfigContext()
+  const { data: members } = useFullMemberList()
 
   return useQuery<OnlineModerator[]>({
     queryKey: ONLINE_MODERATORS_QUERY_KEY,
+    select: (moderators) =>
+      members ? moderators.filter((mod) => members.has(mod.did)) : moderators,
     queryFn: async () => {
       const activeThreshold = new Date(Date.now() - ACTIVE_THRESHOLD)
 

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -1,0 +1,84 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLabelerAgent } from '../shell/ConfigurationContext'
+
+export const ONLINE_MODERATORS_QUERY_KEY = ['onlineModerators']
+
+export type OnlineModerator = {
+  did: string
+  lastActive: Date
+}
+
+const ACTIVE_THRESHOLD = 5 * 60 * 1000
+const REFETCH_INTERVAL = 5 * 1000
+const STALE_TIME = 2 * 1000 // prevent spamming requests
+
+export function useOnlineModerators() {
+  const labelerAgent = useLabelerAgent()
+
+  return useQuery<OnlineModerator[]>({
+    queryKey: ONLINE_MODERATORS_QUERY_KEY,
+    queryFn: async () => {
+      const moderatorActivity = new Map<string, Date>()
+      const activeThreshold = new Date(Date.now() - ACTIVE_THRESHOLD)
+
+      const updateMod = (did: string, activityTime: Date) => {
+        if (activityTime < activeThreshold) return
+        const existing = moderatorActivity.get(did)
+        if (!existing || activityTime.getTime() > existing.getTime()) {
+          moderatorActivity.set(did, activityTime)
+        }
+      }
+
+      // mod events
+      try {
+        const { data } = await labelerAgent.tools.ozone.moderation.queryEvents({
+          createdAfter: activeThreshold.toISOString(),
+          limit: 10,
+        })
+        data.events.forEach((event) => {
+          updateMod(event.createdBy, new Date(event.createdAt))
+        })
+      } catch (err) {
+        console.warn('Failed to fetch recent moderation events:', err)
+      }
+
+      // report assignments
+      try {
+        // In practice, reports are self-assigned
+        // Can assume they reasonably indicate online status for now
+        // TODO: use tools.ozone.report.queryActivities once available
+        const { data: reportData } =
+          await labelerAgent.tools.ozone.report.getAssignments({
+            onlyActive: true,
+            limit: 10,
+          })
+        reportData.assignments.forEach((assignment) => {
+          updateMod(assignment.did, new Date(assignment.startAt))
+        })
+      } catch (err) {
+        console.warn('Failed to fetch active report assignments:', err)
+      }
+
+      // Sort by most recent
+      const onlineModerators = Array.from(moderatorActivity.entries())
+        .map(([did, lastActive]) => ({ did, lastActive: new Date(lastActive) }))
+        .sort((a, b) => b.lastActive.getTime() - a.lastActive.getTime())
+
+      return onlineModerators
+    },
+    refetchInterval: REFETCH_INTERVAL,
+    staleTime: STALE_TIME,
+    retry: false,
+  })
+}
+
+export function useRefetchOnlineModerators() {
+  const queryClient = useQueryClient()
+
+  return () => {
+    queryClient.refetchQueries({
+      queryKey: ONLINE_MODERATORS_QUERY_KEY,
+      stale: true,
+    })
+  }
+}

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -10,7 +10,7 @@ export type OnlineModerator = {
 
 const ACTIVE_THRESHOLD = 5 * 60 * 1000
 const REFETCH_INTERVAL = 5 * 1000
-const STALE_TIME = 2 * 1000 // prevent spamming requests
+const STALE_TIME = 2 * 1000 // debounce protection when used with refetch below
 
 export function useOnlineModerators() {
   const labelerAgent = useLabelerAgent()

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -22,7 +22,6 @@ export function useOnlineModerators() {
       const activeThreshold = new Date(Date.now() - ACTIVE_THRESHOLD)
 
       const updateMod = (did: string, activityTime: Date) => {
-        if (activityTime < activeThreshold) return
         if (did === labelerAgent?.did) return
         const existing = moderatorActivity.get(did)
         if (!existing || activityTime.getTime() > existing.getTime()) {

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -20,15 +20,13 @@ export function useOnlineModerators() {
   return useQuery<OnlineModerator[]>({
     queryKey: ONLINE_MODERATORS_QUERY_KEY,
     queryFn: async () => {
-      const moderatorActivity = new Map<string, Date>()
       const activeThreshold = new Date(Date.now() - ACTIVE_THRESHOLD)
 
-      const updateMod = (did: string, activityTime: Date) => {
-        if (did === config.did) return
-        if (activityTime < activeThreshold) return
+      const moderatorActivity = new Map<string, Date>()
+      const update = (did: string, activityDate: Date) => {
         const existing = moderatorActivity.get(did)
-        if (!existing || activityTime.getTime() > existing.getTime()) {
-          moderatorActivity.set(did, activityTime)
+        if (!existing || activityDate > existing) {
+          moderatorActivity.set(did, activityDate)
         }
       }
 
@@ -39,7 +37,8 @@ export function useOnlineModerators() {
           limit: 30,
         })
         data.events.forEach((event) => {
-          updateMod(event.createdBy, new Date(event.createdAt))
+          if (event.createdBy === config.did) return // block labeler events
+          update(event.createdBy, new Date(event.createdAt))
         })
       } catch (err) {
         console.warn('Failed to fetch recent moderation events:', err)
@@ -56,7 +55,13 @@ export function useOnlineModerators() {
             limit: 30,
           })
         reportData.assignments.forEach((assignment) => {
-          updateMod(assignment.did, new Date(assignment.startAt))
+          // if recent or a temp assignment
+          if (
+            new Date(assignment.startAt) > activeThreshold ||
+            assignment.endAt
+          ) {
+            update(assignment.did, new Date(assignment.startAt))
+          }
         })
       } catch (err) {
         console.warn('Failed to fetch active report assignments:', err)

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -34,7 +34,7 @@ export function useOnlineModerators() {
       try {
         const { data } = await labelerAgent.tools.ozone.moderation.queryEvents({
           createdAfter: activeThreshold.toISOString(),
-          limit: 10,
+          limit: 30,
         })
         data.events.forEach((event) => {
           updateMod(event.createdBy, new Date(event.createdAt))

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -52,7 +52,7 @@ export function useOnlineModerators() {
         const { data: reportData } =
           await labelerAgent.tools.ozone.report.getAssignments({
             onlyActive: true,
-            limit: 10,
+            limit: 30,
           })
         reportData.assignments.forEach((assignment) => {
           updateMod(assignment.did, new Date(assignment.startAt))

--- a/components/team/useOnlineModerators.ts
+++ b/components/team/useOnlineModerators.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLabelerAgent } from '../shell/ConfigurationContext'
 import { useConfigContext } from '../shell/ConfigContext'
+import { MOD_EVENTS } from '@/mod-event/constants'
 
 export const ONLINE_MODERATORS_QUERY_KEY = ['onlineModerators']
 
@@ -12,6 +13,22 @@ export type OnlineModerator = {
 const ACTIVE_THRESHOLD = 5 * 60 * 1000
 const REFETCH_INTERVAL = 5 * 1000
 const STALE_TIME = 2 * 1000 // debounce protection when used with refetch below
+
+// Event types that indicate a moderator is actively working.
+const MOD_ACTION_EVENT_TYPES = [
+  MOD_EVENTS.TAKEDOWN,
+  MOD_EVENTS.REVERSE_TAKEDOWN,
+  MOD_EVENTS.LABEL,
+  MOD_EVENTS.EMAIL,
+  MOD_EVENTS.COMMENT,
+  MOD_EVENTS.ESCALATE,
+  MOD_EVENTS.ACKNOWLEDGE,
+  MOD_EVENTS.TAG,
+  MOD_EVENTS.MUTE,
+  MOD_EVENTS.UNMUTE,
+  MOD_EVENTS.RESOLVE_APPEAL,
+  MOD_EVENTS.SET_PRIORITY,
+]
 
 export function useOnlineModerators() {
   const labelerAgent = useLabelerAgent()
@@ -34,6 +51,7 @@ export function useOnlineModerators() {
       try {
         const { data } = await labelerAgent.tools.ozone.moderation.queryEvents({
           createdAfter: activeThreshold.toISOString(),
+          types: MOD_ACTION_EVENT_TYPES,
           limit: 30,
         })
         data.events.forEach((event) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -51,7 +51,7 @@ Cypress.Commands.add(
     })
 
     // The login form mounts after @atproto/oauth-client-browser import
-    // Wait it out so we don't time out form is in the DOM
+    // Allow a timeout for the import to complete
     cy.get('#service-url', { timeout: 10000 }).clear().type(API_URL)
     cy.get('#account-handle').type('alice.test')
     cy.get('#password').type('hunter2')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -50,7 +50,9 @@ Cypress.Commands.add(
       body: authFixture.getLabelerRecordResponse,
     })
 
-    cy.get('#service-url').clear().type(API_URL)
+    // The login form mounts after @atproto/oauth-client-browser import
+    // Wait it out so we don't time out form is in the DOM
+    cy.get('#service-url', { timeout: 10000 }).clear().type(API_URL)
     cy.get('#account-handle').type('alice.test')
     cy.get('#password').type('hunter2')
     cy.get("button[type='submit']").click()

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -21,6 +21,7 @@ export type ServerConfig = {
     canManageQueues: boolean
     canAssignOthers: boolean
     canPurgeAgeAssurance: boolean
+    canViewModeratorStats: boolean
   }
 }
 
@@ -56,6 +57,7 @@ export const parseServerConfig = (
       canManageQueues: isModerator,
       canAssignOthers: isAdmin,
       canPurgeAgeAssurance: isModerator,
+      canViewModeratorStats: isAdmin,
     },
   }
 }


### PR DESCRIPTION
* Handle actions that cascade onto the account by creating a report note
* Add online moderators indicator
* Add link to open accounts in action panel from report page
* Create `useReports` hook to manage report viewing and navigation
* Add 'advance after close' to report page
* Update report reason types
* Fix flaky tests