### PR TITLE
Add support for new gallery embed on posts

### DIFF
--- a/components/common/posts/GalleryEmbed.tsx
+++ b/components/common/posts/GalleryEmbed.tsx
@@ -1,0 +1,149 @@
+import { AppBskyEmbedGallery } from '@atproto/api'
+import { useState } from 'react'
+import {
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline'
+import Lightbox from 'yet-another-react-lightbox'
+import Captions from 'yet-another-react-lightbox/plugins/captions'
+import Thumbnails from 'yet-another-react-lightbox/plugins/thumbnails'
+import { classNames } from '@/lib/util'
+
+// Mirrors `getImageSizeClass` in PostsFeed.tsx so gallery thumbnails align
+// visually with `app.bsky.embed.images` thumbnails. Width is applied to the
+// surrounding <figure> as well as the <img> so the figcaption (alt text)
+// wraps within the thumbnail's footprint and doesn't stretch the flex item.
+const getThumbWidthClass = (imageCount: number) =>
+  imageCount < 3 ? 'w-32' : 'w-20'
+const getThumbHeightClass = (imageCount: number) =>
+  imageCount < 3 ? 'h-32' : 'h-20'
+
+// Cap rows at 5 thumbnails: 5 * w-20 (5rem) + 4 * gap-2 (0.5rem) = 27rem.
+// Smaller item counts (and the w-32 size) naturally use less than this.
+const MAX_ROW_WIDTH = 'max-w-[27rem]'
+
+type GalleryEntry =
+  | { kind: 'image'; item: AppBskyEmbedGallery.ViewImage; imageIndex: number }
+  | { kind: 'unsupported'; $type: string }
+
+function ImageAltText({ alt }: { alt: string }) {
+  if (!alt) return null
+  return (
+    <p className="leading-2 text-gray-400 text-xs leading-3 mt-1">
+      <InformationCircleIcon className="w-4 h-4 inline mr-1" />
+      {alt}
+    </p>
+  )
+}
+
+function UnsupportedGalleryItem({
+  $type,
+  widthClass,
+  heightClass,
+}: {
+  $type: string
+  widthClass: string
+  heightClass: string
+}) {
+  return (
+    <div
+      className={classNames(
+        widthClass,
+        heightClass,
+        'flex items-center justify-center border-2 border-dashed border-gray-400 text-gray-500 dark:text-gray-300',
+      )}
+      title={`Unsupported gallery item: ${$type}`}
+    >
+      <ExclamationCircleIcon className="w-6 h-6" />
+    </div>
+  )
+}
+
+export const GalleryEmbed = ({
+  embed,
+  imageClassName,
+}: {
+  embed: AppBskyEmbedGallery.View
+  imageClassName?: string
+}) => {
+  const [lightboxImageIndex, setLightboxImageIndex] = useState(-1)
+
+  // Tag each item as image|unsupported preserving display order; track the
+  // image-only index used by the lightbox slide list so clicks line up.
+  const entries: GalleryEntry[] = []
+  const images: AppBskyEmbedGallery.ViewImage[] = []
+  for (const it of embed.items) {
+    if (AppBskyEmbedGallery.isViewImage(it)) {
+      entries.push({ kind: 'image', item: it, imageIndex: images.length })
+      images.push(it)
+    } else {
+      entries.push({ kind: 'unsupported', $type: it.$type })
+    }
+  }
+
+  const widthClass = getThumbWidthClass(entries.length)
+  const heightClass = getThumbHeightClass(entries.length)
+  const imgClassName = classNames(imageClassName, widthClass, heightClass)
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+    }
+  }
+
+  return (
+    <div className="pb-2 pl-14">
+      <Lightbox
+        open={lightboxImageIndex >= 0}
+        plugins={[Thumbnails, Captions]}
+        carousel={{ finite: true }}
+        controller={{ closeOnBackdropClick: true }}
+        close={() => setLightboxImageIndex(-1)}
+        slides={images.map((img) => ({
+          src: img.fullsize,
+          description: img.alt,
+        }))}
+        index={lightboxImageIndex}
+        on={{
+          // The lightbox may open from other Dialog/modal components
+          // in that case, we want to make sure that esc button presses
+          // only close the lightbox and not the parent Dialog/modal underneath
+          entered: () => {
+            document.addEventListener('keydown', handleKeyDown)
+          },
+          exited: () => {
+            document.removeEventListener('keydown', handleKeyDown)
+          },
+        }}
+      />
+      <div className={classNames('flex flex-wrap gap-2', MAX_ROW_WIDTH)}>
+        {entries.map((entry, i) =>
+          entry.kind === 'image' ? (
+            <figure key={i} className={widthClass}>
+              <button
+                type="button"
+                onClick={() => setLightboxImageIndex(entry.imageIndex)}
+              >
+                <img
+                  className={imgClassName}
+                  src={entry.item.thumbnail}
+                  alt={entry.item.alt}
+                />
+              </button>
+              <figcaption>
+                <ImageAltText alt={entry.item.alt} />
+              </figcaption>
+            </figure>
+          ) : (
+            <UnsupportedGalleryItem
+              key={i}
+              $type={entry.$type}
+              widthClass={widthClass}
+              heightClass={heightClass}
+            />
+          ),
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/common/posts/PostsFeed.tsx
+++ b/components/common/posts/PostsFeed.tsx
@@ -7,6 +7,7 @@ import {
   AppBskyFeedPost,
   AppBskyEmbedRecord,
   AppBskyEmbedImages,
+  AppBskyEmbedGallery,
   AppBskyEmbedExternal,
   AppBskyGraphDefs,
   $Typed,
@@ -39,6 +40,7 @@ import {
   useWorkspaceRemoveItemsMutation,
 } from '@/workspace/hooks'
 import { ImageList } from './ImageList'
+import { GalleryEmbed } from './GalleryEmbed'
 import {
   GraphicMediaFilterPreference,
   useGraphicMediaPreferences,
@@ -351,6 +353,11 @@ export function EmbedRenderer({
         />
       </div>
     )
+  }
+  // render gallery embeds (open-union; up to 20 items, may include
+  // future non-image variants which render as an unsupported placeholder)
+  if (AppBskyEmbedGallery.isView(embed)) {
+    return <GalleryEmbed embed={embed} imageClassName={imageClassName} />
   }
   // render external link embeds
   if (AppBskyEmbedExternal.isView(embed)) {

--- a/components/common/posts/helpers.ts
+++ b/components/common/posts/helpers.ts
@@ -1,6 +1,7 @@
 import {
   $Typed,
   AppBskyEmbedExternal,
+  AppBskyEmbedGallery,
   AppBskyEmbedImages,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
@@ -14,6 +15,7 @@ export const isValidPostRecord = asPredicate(AppBskyFeedPost.validateRecord)
 
 export type KnownEmbedView =
   | $Typed<AppBskyEmbedExternal.View>
+  | $Typed<AppBskyEmbedGallery.View>
   | $Typed<AppBskyEmbedImages.View>
   | $Typed<AppBskyEmbedRecord.View>
   | $Typed<AppBskyEmbedVideo.View>

--- a/components/repositories/useCopyRecordDetails.tsx
+++ b/components/repositories/useCopyRecordDetails.tsx
@@ -7,19 +7,16 @@ import {
   ToolsOzoneModerationDefs,
 } from '@atproto/api'
 
-const appendGalleryAlts = (
-  gallery: AppBskyEmbedGallery.Main,
-  startIndex: number,
-): { text: string; nextIndex: number } => {
+const galleryAltsText = (gallery: AppBskyEmbedGallery.Main): string => {
   let text = ''
-  let i = startIndex
+  let i = 1
   for (const item of gallery.items) {
     if (AppBskyEmbedGallery.isImage(item)) {
       text += `Image ${i} ALT: ${item.alt}\n`
       i += 1
     }
   }
-  return { text, nextIndex: i }
+  return text
 }
 
 export const useCopyRecordDetails = ({
@@ -38,7 +35,7 @@ export const useCopyRecordDetails = ({
           data += `Image ${i + 1} ALT: ${img.alt}\n`
         })
       } else if (asPredicate(AppBskyEmbedGallery.validateMain)(embed)) {
-        data += appendGalleryAlts(embed, 1).text
+        data += galleryAltsText(embed)
       } else if (
         asPredicate(AppBskyEmbedRecordWithMedia.validateMain)(embed)
       ) {
@@ -49,7 +46,7 @@ export const useCopyRecordDetails = ({
         } else if (
           asPredicate(AppBskyEmbedGallery.validateMain)(embed.media)
         ) {
-          data += appendGalleryAlts(embed.media, 1).text
+          data += galleryAltsText(embed.media)
         }
       }
     }

--- a/components/repositories/useCopyRecordDetails.tsx
+++ b/components/repositories/useCopyRecordDetails.tsx
@@ -1,10 +1,26 @@
 import { copyToClipboard } from '@/common/CopyButton'
 import {
+  AppBskyEmbedGallery,
   AppBskyEmbedImages,
   AppBskyEmbedRecordWithMedia,
   asPredicate,
   ToolsOzoneModerationDefs,
 } from '@atproto/api'
+
+const appendGalleryAlts = (
+  gallery: AppBskyEmbedGallery.Main,
+  startIndex: number,
+): { text: string; nextIndex: number } => {
+  let text = ''
+  let i = startIndex
+  for (const item of gallery.items) {
+    if (AppBskyEmbedGallery.isImage(item)) {
+      text += `Image ${i} ALT: ${item.alt}\n`
+      i += 1
+    }
+  }
+  return { text, nextIndex: i }
+}
 
 export const useCopyRecordDetails = ({
   record,
@@ -16,19 +32,25 @@ export const useCopyRecordDetails = ({
     if (record?.value) {
       data += `Created At: ${record.value.createdAt}\n`
       data += `Content: ${record.value.text}\n`
-      if (asPredicate(AppBskyEmbedImages.validateMain)(record.value.embed)) {
-        record.value.embed.images.forEach((img, i) => {
+      const embed = record.value.embed
+      if (asPredicate(AppBskyEmbedImages.validateMain)(embed)) {
+        embed.images.forEach((img, i) => {
           data += `Image ${i + 1} ALT: ${img.alt}\n`
         })
+      } else if (asPredicate(AppBskyEmbedGallery.validateMain)(embed)) {
+        data += appendGalleryAlts(embed, 1).text
       } else if (
-        asPredicate(AppBskyEmbedRecordWithMedia.validateMain)(
-          record.value.embed,
-        ) &&
-        asPredicate(AppBskyEmbedImages.validateMain)(record.value.embed.media)
+        asPredicate(AppBskyEmbedRecordWithMedia.validateMain)(embed)
       ) {
-        record.value.embed.media.images.forEach((img, i) => {
-          data += `Image ${i + 1} ALT: ${img.alt}\n`
-        })
+        if (asPredicate(AppBskyEmbedImages.validateMain)(embed.media)) {
+          embed.media.images.forEach((img, i) => {
+            data += `Image ${i + 1} ALT: ${img.alt}\n`
+          })
+        } else if (
+          asPredicate(AppBskyEmbedGallery.validateMain)(embed.media)
+        ) {
+          data += appendGalleryAlts(embed.media, 1).text
+        }
       }
     }
     copyToClipboard(data, 'record details')

--- a/components/workspace/hooks.tsx
+++ b/components/workspace/hooks.tsx
@@ -14,6 +14,7 @@ import {
 import { regenerateBatchId } from '@/lib/batchId'
 import { useServerConfig } from '@/shell/ConfigurationContext'
 import {
+  AppBskyEmbedGallery,
   AppBskyEmbedImages,
   AppBskyEmbedRecord,
   asPredicate,
@@ -267,6 +268,12 @@ const getEmbedValues = (embed: unknown): string => {
       .map(({ image }) => {
         return image.ref.toString()
       })
+      .join('|')
+  }
+  if (asPredicate(AppBskyEmbedGallery.validateMain)(embed)) {
+    return embed.items
+      .filter(AppBskyEmbedGallery.isImage)
+      .map(({ image }) => image.ref.toString())
       .join('|')
   }
   if (asPredicate(AppBskyEmbedRecord.validateMain)(embed)) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unlink-atproto": "node scripts/toggle-atproto.js --unlink"
   },
   "dependencies": {
-    "@atproto/api": "0.20.7",
+    "@atproto/api": "0.20.9",
     "@atproto/oauth-client-browser": "^0.3.42",
     "@atproto/oauth-types": "^0.6.3",
     "@atproto/xrpc": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,9 +81,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/api@npm:0.20.7":
-  version: 0.20.7
-  resolution: "@atproto/api@npm:0.20.7"
+"@atproto/api@npm:0.20.9":
+  version: 0.20.9
+  resolution: "@atproto/api@npm:0.20.9"
   dependencies:
     "@atproto/common-web": "npm:^0.5.0"
     "@atproto/lexicon": "npm:^0.7.1"
@@ -93,7 +93,7 @@ __metadata:
     multiformats: "npm:^13.0.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/cc36fb9cb5a9741967e4b037b2e39d979a0d6f3e8953a0b7153cbb9970bf8ca1f623e886c91943f1f37e2dc223690b9cb2252275622e8d44aca9966a28658e2c
+  checksum: 10c0/e07daa012f9a48ad8977a4e84fadfa8490ea316f3afedf97be81f0d39a9f930a26c10bee704204015bc933f9e969a1cdc102b7c0bd2e0bd44a1ae046b6e93ed5
   languageName: node
   linkType: hard
 
@@ -7006,7 +7006,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone@workspace:."
   dependencies:
-    "@atproto/api": "npm:0.20.7"
+    "@atproto/api": "npm:0.20.9"
     "@atproto/oauth-client-browser": "npm:^0.3.42"
     "@atproto/oauth-types": "npm:^0.6.3"
     "@atproto/xrpc": "npm:^0.8.0"


### PR DESCRIPTION
Made some changes in the atproto dev-env mock data code to create a new post by `bob.test` with the new gallery embed with 10 images.

Here's a few screenshots comparing the images embed (1 image) with the new gallery embed (10 images):

profile posts
<img width="742" height="826" alt="Screenshot 2026-06-05 at 12 33 24 PM" src="https://github.com/user-attachments/assets/1abc9293-9d6f-4310-bb95-b1d22d538f69" />

post review modal
<img width="1321" height="888" alt="Screenshot 2026-06-05 at 12 41 19 PM" src="https://github.com/user-attachments/assets/5ce81142-e3dc-4c6f-baf8-bfb20c3faf21" />

post images fullscreen carousel
<img width="2553" height="1316" alt="Screenshot 2026-06-05 at 12 36 52 PM" src="https://github.com/user-attachments/assets/1e470236-d12d-41b2-bc0e-8e2e9686bc9e" />
