### PR TITLE
Add conversation support to report level features

### DIFF
--- a/app/reports/beta/Filters.tsx
+++ b/app/reports/beta/Filters.tsx
@@ -34,6 +34,8 @@ const SUBJECT_TYPE_OPTIONS = [
   { id: 'all', text: 'All Subject Types', value: '' },
   { id: 'account', text: 'Account', value: 'account' },
   { id: 'record', text: 'Record', value: 'record' },
+  { id: 'message', text: 'Message', value: 'message' },
+  { id: 'conversation', text: 'Conversation', value: 'conversation' },
 ]
 
 function useFiltersUpdater() {
@@ -91,10 +93,11 @@ export function BetaReportsFilters() {
   const setSubjectType = (value: string) => {
     if (value === subjectType) {
       updateParam({ subjectType: undefined, collections: undefined })
-    } else if (value === 'account') {
-      updateParam({ subjectType: 'account', collections: undefined })
+    } else if (value === 'record') {
+      updateParam({ subjectType: value })
     } else {
-      updateParam({ subjectType: value || undefined })
+      // Collections only apply to record subjects
+      updateParam({ subjectType: value || undefined, collections: undefined })
     }
   }
 

--- a/components/queues/QueueFilters.tsx
+++ b/components/queues/QueueFilters.tsx
@@ -77,6 +77,7 @@ export function QueueFilters({
           <option value="account">account</option>
           <option value="record">record</option>
           <option value="message">message</option>
+          <option value="conversation">conversation</option>
         </Select>
         <div hidden={hiddenFilters?.includes('collection')} className="flex-1">
           <CollectionAutocomplete

--- a/components/queues/configure/QueueForm.tsx
+++ b/components/queues/configure/QueueForm.tsx
@@ -266,7 +266,7 @@ export function QueueForm({
                   />
                 )}
               </div>
-              <div className="h-6 flex items-center gap-1">
+              <div className="h-8 flex items-center gap-1">
                 <Checkbox
                   id="subjectTypes-message"
                   name="subjectTypes"
@@ -276,6 +276,19 @@ export function QueueForm({
                 />
                 <Tooltip anchor="right start">
                   Reports against direct messages.
+                </Tooltip>
+              </div>
+              <div className="h-6 flex items-center gap-1">
+                <Checkbox
+                  id="subjectTypes-conversation"
+                  name="subjectTypes"
+                  checked={subjectTypes.has('conversation')}
+                  onChange={() => toggleSubjectType('conversation')}
+                  label="conversation"
+                />
+                <Tooltip anchor="right start">
+                  Reports against an entire DM conversation, such as a group
+                  chat.
                 </Tooltip>
               </div>
             </div>

--- a/cypress/e2e/queues/configure/main.cy.ts
+++ b/cypress/e2e/queues/configure/main.cy.ts
@@ -13,6 +13,7 @@ describe('Queue Management', () => {
   let authFixture: Record<string, any>
   let spamQueue: Record<string, any>
   let hateSpeechQueue: Record<string, any>
+  let convoQueue: Record<string, any>
 
   beforeEach(() => {
     cy.visit(`${BASE_URL}/configure?tab=queues`)
@@ -21,6 +22,7 @@ describe('Queue Management', () => {
       cy.fixture('queues.json').then((queues) => {
         spamQueue = queues.spamQueue
         hateSpeechQueue = queues.hateSpeechQueue
+        convoQueue = queues.convoQueue
         mockQueueGetAssignmentsResponse({
           statusCode: 200,
           body: { assignments: [] },
@@ -146,6 +148,42 @@ describe('Queue Management', () => {
       cy.wait(2000)
 
       cy.contains('Queue created successfully').should('be.visible')
+    })
+
+    it('creates a queue with the conversation subject type', () => {
+      const createdQueue = {
+        ...convoQueue,
+        id: 100,
+        name: 'My Convo Queue',
+      }
+
+      mockCreateQueueResponse({
+        statusCode: 200,
+        body: { queue: createdQueue },
+      })
+      mockListQueuesResponse({
+        statusCode: 200,
+        body: { queues: [createdQueue] },
+      })
+
+      cy.get('[data-cy="add-queue-button"]').click()
+      cy.get('#name').should('be.visible')
+
+      cy.get('#name').type('My Convo Queue')
+      cy.get('#subjectTypes-conversation').check()
+
+      cy.get('[data-cy="report-types-input"]').scrollIntoView().type('spam')
+      cy.contains('Spam').click()
+      cy.get('[data-cy="report-types-input"]').type('{esc}')
+
+      cy.get('[data-cy="submit-queue-button"]').click()
+      cy.wait(2000)
+
+      cy.contains('Queue created successfully').should('be.visible')
+      cy.get('[data-cy="queue-card"]').within(() => {
+        cy.contains('My Convo Queue')
+        cy.contains('conversation')
+      })
     })
 
     it('shows collection field only when record subject type is checked', () => {

--- a/cypress/fixtures/queues.json
+++ b/cypress/fixtures/queues.json
@@ -16,6 +16,23 @@
       "lastUpdated": "2026-03-02T15:49:30.681Z"
     }
   },
+  "convoQueue": {
+    "id": 3,
+    "name": "Convo Queue",
+    "description": "Handles reports against DM conversations",
+    "subjectTypes": ["conversation"],
+    "reportTypes": ["tools.ozone.report.defs#reasonMisleadingSpam"],
+    "createdBy": "did:plc:tfeay256xpz3vf5v5d3cxykt",
+    "createdAt": "2026-03-02T15:49:30.681Z",
+    "updatedAt": "2026-03-02T15:49:30.681Z",
+    "enabled": true,
+    "stats": {
+      "pendingCount": 2,
+      "actionedCount": 4,
+      "escalatedCount": 0,
+      "lastUpdated": "2026-03-02T15:49:30.681Z"
+    }
+  },
   "hateSpeechQueue": {
     "id": 2,
     "name": "Hate Speech Queue",


### PR DESCRIPTION
- Conversation checkbox in the queue create form
- Conversation option in the queue list subject filter
- Message and Conversation options in the beta report list filter; clear collections for all non-record subject types
- Cypress coverage for creating a conversation queue

Dependent on https://github.com/bluesky-social/atproto/pull/5076