### PR TITLE
:bug: Fix workspace items not scrollable when account has many tags

### DIFF
--- a/components/workspace/List.tsx
+++ b/components/workspace/List.tsx
@@ -215,7 +215,7 @@ const ListItem = <ItemType extends string>({
   return (
     <Card key={item}>
       <div className="flex items-center justify-between space-x-4">
-        <div className="flex items-center">
+        <div className="flex items-center min-w-0 flex-wrap gap-y-1">
           <Checkbox
             id={item}
             name="workspaceItem"
@@ -283,7 +283,7 @@ const ListItem = <ItemType extends string>({
                 />
               )}
               {!!displayLabels?.length && (
-                <div className="flex ml-1">
+                <div className="flex flex-wrap gap-1 ml-1">
                   {displayLabels.map((label) => (
                     <ModerationLabel
                       key={`${label.src}_${label.val}`}
@@ -293,14 +293,14 @@ const ListItem = <ItemType extends string>({
                 </div>
               )}
               {!!langTagsFromRecord?.length && (
-                <div className="flex ml-1">
+                <div className="flex flex-wrap gap-1 ml-1">
                   {langTagsFromRecord.map((tag) => (
                     <SubjectTag key={tag} tag={tag} />
                   ))}
                 </div>
               )}
               {!!displayTags?.length && (
-                <div className="flex ml-1">
+                <div className="flex flex-wrap gap-1 ml-1">
                   {displayTags.map((tag) => (
                     <SubjectTag key={tag} tag={tag} />
                   ))}
@@ -314,7 +314,7 @@ const ListItem = <ItemType extends string>({
             />
           )}
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-shrink-0">
           <ActionButton size="sm" appearance="outlined" onClick={onRemoveItem}>
             <TrashIcon className="h-3 w-3" />
           </ActionButton>


### PR DESCRIPTION
## Summary
- When an account has many tags/labels in the workspace panel, the row content overflows horizontally, pushing the action buttons (remove/expand) off-screen with no way to scroll to them
- This also causes the entire panel to shift right, making the top-level buttons (Show Action Form, Show Account Actions, etc.) inaccessible
- Tags now wrap to multiple lines instead of overflowing, and action buttons stay pinned to the right so they're always accessible

## Changes
- Added `min-w-0 flex-wrap gap-y-1` to the left content container so it can shrink and wrap
- Added `flex-wrap gap-1` to all three tag containers (labels, lang tags, subject tags)
- Added `flex-shrink-0` to the action buttons container so buttons never get pushed off-screen

## Test plan
- [ ] Open workspace with accounts that have many tags/labels
- [ ] Verify tags wrap to new lines instead of overflowing
- [ ] Verify trash and expand buttons are always visible and clickable
- [ ] Verify top-level panel buttons (Show Action Form, etc.) remain accessible
- [ ] Verify accounts with few/no tags still display correctly on a single line
- [ ] Check on narrow screen widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)