### PR TITLE
Make workspace Batch ID editable

### DIFF
--- a/components/repositories/RevokeCredential.tsx
+++ b/components/repositories/RevokeCredential.tsx
@@ -19,7 +19,7 @@ import { ToolsOzoneCommunicationDefs } from '@atproto/api'
 import { MOD_EVENTS } from '@/mod-event/constants'
 import { compileTemplateContent } from '@/email/helpers'
 import { executeBatchedOperation, pluralize } from '@/lib/util'
-import { getBatchId, regenerateBatchId } from '@/lib/batchId'
+import { getBatchId, regenerateBatchId, setBatchId } from '@/lib/batchId'
 import {
   ActionPanelNames,
   hydrateModToolInfo,
@@ -200,6 +200,12 @@ function useRevokeCredentialsState() {
     toast.success('Batch ID updated')
   }
 
+  const handleBatchIdChange = (batchId: string) => {
+    // Persist edits so other consumers of the stored batch id stay in sync
+    setBatchId(batchId)
+    setCurrentBatchId(batchId)
+  }
+
   return {
     isRevokeModalOpen,
     setIsRevokeModalOpen,
@@ -210,6 +216,7 @@ function useRevokeCredentialsState() {
     externalUrl,
     setExternalUrl,
     handleRegenerateBatchId,
+    handleBatchIdChange,
   }
 }
 
@@ -244,6 +251,7 @@ export const RevokeCredentialsForm = ({
     externalUrl,
     setExternalUrl,
     handleRegenerateBatchId,
+    handleBatchIdChange,
   } = useRevokeCredentialsState()
 
   const templateName = emailTemplate?.name
@@ -344,6 +352,7 @@ export const RevokeCredentialsForm = ({
           setExternalUrl={setExternalUrl}
           currentBatchId={currentBatchId}
           handleRegenerateBatchId={handleRegenerateBatchId}
+          onBatchIdChange={handleBatchIdChange}
         />
       )}
 

--- a/components/workspace/ModToolForm.tsx
+++ b/components/workspace/ModToolForm.tsx
@@ -6,11 +6,13 @@ import { WORKSPACE_FORM_ID } from './constants'
 export const ModToolForm = ({
   currentBatchId,
   handleRegenerateBatchId,
+  onBatchIdChange,
   externalUrl,
   setExternalUrl,
 }: {
   currentBatchId: string
   handleRegenerateBatchId: () => void
+  onBatchIdChange?: (batchId: string) => void
   externalUrl?: string
   setExternalUrl?: (url: string) => void
 }) => {
@@ -31,20 +33,20 @@ export const ModToolForm = ({
         </FormLabel>
       </div>
 
-      <div className="mb-3 p-2 bg-gray-50 dark:bg-gray-800 rounded border">
-        <div className="flex items-center justify-between">
-          <div>
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Batch ID:
-            </span>
-            <span className="ml-2 text-sm text-gray-600 dark:text-gray-400 font-mono">
-              {currentBatchId}
-            </span>
-          </div>
-          <div>
+      <div className="mb-3">
+        <FormLabel label="Batch ID" htmlFor="batchId">
+          <div className="flex items-center gap-2">
+            <Input
+              type="text"
+              id="batchId"
+              className="block w-full font-mono"
+              value={currentBatchId}
+              onChange={(e) => onBatchIdChange?.(e.target.value)}
+              placeholder="Batch identifier"
+              autoComplete="off"
+            />
             <CopyButton
               text={currentBatchId}
-              className="mr-2"
               labelText="Batch ID "
               title={`Copy batch id to clipboard`}
             />
@@ -57,7 +59,7 @@ export const ModToolForm = ({
               <ArrowPathIcon className="h-3 w-3 text-gray-500 dark:text-gray-300" />
             </button>
           </div>
-        </div>
+        </FormLabel>
       </div>
     </>
   )

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -33,12 +33,12 @@ export const WorkspacePanelActionForm = ({
     setCurrentBatchId(newBatchId)
     toast.success('Workspace Batch ID updated')
   }
-
   const handleBatchIdChange = (batchId: string) => {
     // Persist edits so event submission picks up the user-provided value
     setBatchId(batchId)
     setCurrentBatchId(batchId)
   }
+  
   const isAckEvent = modEventType === MOD_EVENTS.ACKNOWLEDGE
   const isEmailEvent = modEventType === MOD_EVENTS.EMAIL
   const isTakedownEvent = modEventType === MOD_EVENTS.TAKEDOWN

--- a/components/workspace/PanelActionForm.tsx
+++ b/components/workspace/PanelActionForm.tsx
@@ -9,7 +9,7 @@ import { WORKSPACE_FORM_ID } from './constants'
 import { EmailComposer } from 'components/email/Composer'
 import { EmailComposerData } from 'components/email/helpers'
 import { ActionPolicySelector } from '@/reports/ModerationForm/ActionPolicySelector'
-import { getBatchId, regenerateBatchId } from '@/lib/batchId'
+import { getBatchId, regenerateBatchId, setBatchId } from '@/lib/batchId'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
 import { ModToolForm } from './ModToolForm'
@@ -32,6 +32,12 @@ export const WorkspacePanelActionForm = ({
     const newBatchId = regenerateBatchId()
     setCurrentBatchId(newBatchId)
     toast.success('Workspace Batch ID updated')
+  }
+
+  const handleBatchIdChange = (batchId: string) => {
+    // Persist edits so event submission picks up the user-provided value
+    setBatchId(batchId)
+    setCurrentBatchId(batchId)
   }
   const isAckEvent = modEventType === MOD_EVENTS.ACKNOWLEDGE
   const isEmailEvent = modEventType === MOD_EVENTS.EMAIL
@@ -213,6 +219,7 @@ export const WorkspacePanelActionForm = ({
           <ModToolForm
             currentBatchId={currentBatchId}
             handleRegenerateBatchId={handleRegenerateBatchId}
+            onBatchIdChange={handleBatchIdChange}
           />
 
           <div className="flex flex-row gap-2">

--- a/lib/batchId.ts
+++ b/lib/batchId.ts
@@ -18,6 +18,10 @@ export const getBatchId = (): string => {
   return batchId
 }
 
+export const setBatchId = (batchId: string): void => {
+  localStorage.setItem(BATCH_ID_KEY, batchId)
+}
+
 export const regenerateBatchId = (): string => {
   const newBatchId = generateBatchId()
   localStorage.setItem(BATCH_ID_KEY, newBatchId)


### PR DESCRIPTION
## What

Replaces the read-only Batch ID display in `ModToolForm` with an editable text input, so moderators can set a specific batch id (e.g. to continue an earlier batch or use a meaningful identifier) instead of only being able to regenerate it.

## How

- `lib/batchId.ts`: added `setBatchId()` to persist a user-provided value to localStorage. This matters because `useActionSubjects` reads the batch id from localStorage at submit time, not from component state.
- `components/workspace/ModToolForm.tsx`: swapped the read-only span for a controlled `Input` (same pattern as the External URL field), keeping the copy and regenerate buttons alongside it.
- `components/workspace/PanelActionForm.tsx` and `components/repositories/RevokeCredential.tsx`: wired an `onBatchIdChange` handler that persists edits via `setBatchId` and updates local state.

An emptied field falls back to a freshly generated id at submit time since `getBatchId()` regenerates when the stored value is missing/empty.

## Testing

- `yarn build` and `tsc --noEmit` pass; eslint clean on changed files.