### PR TITLE
:lipstick: group report tags, add open in QAP button and hide move to  next item optionally

### DIFF
--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -87,7 +87,7 @@ import { ModToolContextPanel } from 'components/reports/ModToolContextPanel'
 import { ReportBatchLink } from 'components/reports/ReportBatchLink'
 import { useReportCreationEvent } from 'components/reports/useReportCreationEvent'
 import { getHandleFromSubjectView } from 'components/reports/utils'
-import { SubjectTag } from 'components/tags/SubjectTag'
+import { SubjectTagList } from 'components/tags/SubjectTagList'
 import { WorkspacePanel } from 'components/workspace/Panel'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -695,6 +695,7 @@ function ReportDetailLayout(props: {
               isAuthorTakendown={
                 !!record?.repo.moderation.subjectStatus?.takendown
               }
+              onOpenInActionPanel={onClickDid}
             >
               {!isSubjectDid && record?.repo && (
                 <div className="-ml-1 my-2">
@@ -788,11 +789,10 @@ function ReportDetailLayout(props: {
                 label="Tags"
                 className="flex flex-row items-center gap-2"
               >
-                <LabelList className="-mt-1 -ml-1 flex-wrap gap-1">
-                  {subjectStatus.tags.sort().map((tag) => (
-                    <SubjectTag key={tag} tag={tag} />
-                  ))}
-                </LabelList>
+                <SubjectTagList
+                  tags={subjectStatus.tags}
+                  className="-mt-1 -ml-1 flex-wrap gap-1"
+                />
               </FormLabel>
             </div>
           )}
@@ -815,11 +815,10 @@ function ReportDetailLayout(props: {
           {!!record?.repo.moderation.subjectStatus?.tags?.length && (
             <div className="mb-2 flex flex-row items-center">
               <div className="mr-2">Account Tags</div>
-              <LabelList className="-ml-1 flex-wrap gap-1">
-                {record.repo.moderation.subjectStatus.tags.sort().map((tag) => (
-                  <SubjectTag key={tag} tag={tag} />
-                ))}
-              </LabelList>
+              <SubjectTagList
+                tags={record.repo.moderation.subjectStatus.tags}
+                className="-ml-1 flex-wrap gap-1"
+              />
             </div>
           )}
 

--- a/components/common/Hover.tsx
+++ b/components/common/Hover.tsx
@@ -24,9 +24,12 @@ export const Hover = ({
   panelClassName = '',
 }: HoverProps) => {
   return (
-    <div tabIndex={0} className={`group relative w-fit ${className}`}>
+    <div
+      tabIndex={0}
+      className={`group/hover-card relative w-fit ${className}`}
+    >
       {children}
-      <div className="invisible opacity-0 transition-all delay-200 duration-150 group-hover:visible group-hover:opacity-100 group-hover:delay-0 group-focus-within:visible group-focus-within:opacity-100 group-focus-within:delay-0 absolute left-0 top-full z-10 pt-1">
+      <div className="invisible opacity-0 transition-all delay-200 duration-150 group-hover/hover-card:visible group-hover/hover-card:opacity-100 group-hover/hover-card:delay-0 group-focus-within/hover-card:visible group-focus-within/hover-card:opacity-100 group-focus-within/hover-card:delay-0 absolute left-0 top-full z-10 pt-1">
         <div
           className={`w-64 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-2.5 space-y-2 ${panelClassName}`}
         >

--- a/components/common/PreviewCard.tsx
+++ b/components/common/PreviewCard.tsx
@@ -1,6 +1,6 @@
 import { classNames, parseAtUri } from '@/lib/util'
 import { CollectionId, getCollectionName } from '@/reports/helpers/subject'
-import { LinkIcon, UserIcon } from '@heroicons/react/24/outline'
+import { EyeIcon, LinkIcon, UserIcon } from '@heroicons/react/24/outline'
 import { ReactNode, useState } from 'react'
 import { CopyButton } from './CopyButton'
 import { RecordCard, RepoCard } from './RecordCard'
@@ -31,10 +31,12 @@ function SubjectTitleWithIcon({
   subject,
   title,
   isAtUri,
+  onOpenInActionPanel,
 }: {
   subject: string
   title: ReactNode
   isAtUri: boolean
+  onOpenInActionPanel?: (subject: string) => void
 }) {
   const [showPopup, setShowPopup] = useState(false)
   const Icon = isAtUri ? LinkIcon : UserIcon
@@ -74,6 +76,19 @@ function SubjectTitleWithIcon({
           </>
         )}
       </span>
+      {onOpenInActionPanel && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onOpenInActionPanel(subject)
+          }}
+          title="Open subject in action panel"
+          className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 align-middle"
+        >
+          <EyeIcon className="h-4 w-4" />
+        </button>
+      )}
     </span>
   )
 }
@@ -85,6 +100,7 @@ export function PreviewCard({
   className,
   isAuthorDeactivated,
   isAuthorTakendown,
+  onOpenInActionPanel,
 }: {
   subject: string
   isAuthorDeactivated?: boolean
@@ -92,6 +108,7 @@ export function PreviewCard({
   title?: string | ReactNode
   children?: ReactNode
   className?: string
+  onOpenInActionPanel?: (subject: string) => void
 }) {
   if (subject.startsWith('at://')) {
     const displayTitle = title || getPreviewTitleForAtUri(subject)
@@ -102,6 +119,7 @@ export function PreviewCard({
             subject={subject}
             title={displayTitle}
             isAtUri={true}
+            onOpenInActionPanel={onOpenInActionPanel}
           />
         </p>
         <RecordCard
@@ -121,6 +139,7 @@ export function PreviewCard({
             subject={subject}
             title={title ? title : 'Reported user'}
             isAtUri={false}
+            onOpenInActionPanel={onOpenInActionPanel}
           />
         </p>
         <RepoCard did={subject} />

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -228,7 +228,7 @@ export function ReportActionsBar({
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
   onResolveAppeal?: () => Promise<void>
 }) {
-  const { autoAdvance, setAutoAdvance } = useReports(report.id)
+  const { autoAdvance, setAutoAdvance, nextReportId } = useReports(report.id)
 
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null)
   const [showNote, setShowNote] = useState(false)
@@ -366,12 +366,14 @@ export function ReportActionsBar({
         </button>
       </div>
 
-      <Checkbox
-        className="mt-2 flex items-center text-xs"
-        label="Advance to next after closing"
-        checked={!!autoAdvance}
-        onChange={(e) => setAutoAdvance(e.target.checked)}
-      />
+      {canNoAction && nextReportId !== null && (
+        <Checkbox
+          className="mt-2 flex items-center text-xs"
+          label="Advance to next after closing"
+          checked={!!autoAdvance}
+          onChange={(e) => setAutoAdvance(e.target.checked)}
+        />
+      )}
 
       {pendingAction && (
         <TransitionConfirmPanel

--- a/components/reports/table.tsx
+++ b/components/reports/table.tsx
@@ -39,7 +39,7 @@ import { AccountStrike } from '../subject/AccountStrike'
 import { PriorityScore } from '../subject/PriorityScore'
 import { ReviewStateIcon } from '../subject/ReviewStateMarker'
 import { StatView } from '../subject/Summary'
-import { SubjectTag } from '../tags/SubjectTag'
+import { SubjectTagList } from '../tags/SubjectTagList'
 import { AutomatedBadge } from './AutomatedBadge'
 import { MutedBadge } from './MutedBadge'
 
@@ -432,21 +432,14 @@ function ReportRow({
             ))}
           </LabelList>
         )}
-        {!!subjectTags?.length && (
-          <LabelList className="flex-wrap gap-0.5 mt-1">
-            {subjectTags.sort().map((tag) => (
-              <SubjectTag key={tag} tag={tag} />
-            ))}
-          </LabelList>
-        )}
+        <SubjectTagList tags={subjectTags} className="flex-wrap gap-0.5 mt-1" />
         {!!accountTagsForRecord?.length && (
           <div className="flex flex-row items-center gap-0.5 mt-1">
             <UserIcon className="h-3 w-3 shrink-0 text-gray-400" title="Account" />
-            <LabelList className="flex-wrap gap-0.5">
-              {accountTagsForRecord.sort().map((tag) => (
-                <SubjectTag key={tag} tag={tag} />
-              ))}
-            </LabelList>
+            <SubjectTagList
+              tags={accountTagsForRecord}
+              className="flex-wrap gap-0.5"
+            />
           </div>
         )}
       </td>

--- a/components/tags/SubjectTagList.tsx
+++ b/components/tags/SubjectTagList.tsx
@@ -1,0 +1,49 @@
+import { Hover } from '@/common/Hover'
+import { LabelChip, LabelList } from '@/common/labels/List'
+import { pluralize } from '@/lib/util'
+import { FlagIcon } from '@heroicons/react/24/solid'
+import { ComponentProps } from 'react'
+import { SubjectTag } from './SubjectTag'
+
+const isReportTag = (tag: string) => tag.startsWith('report:')
+
+// Renders a list of subject tags. Report tags (report:*) tend to pile up and
+// crowd out the more useful tags, so when there are 2+ of them they collapse
+// into a single "n types of reports" chip that reveals the full list on hover.
+export const SubjectTagList = ({
+  tags,
+  ...rest
+}: { tags?: string[] } & ComponentProps<typeof LabelList>) => {
+  if (!tags?.length) return null
+
+  const sorted = [...tags].sort()
+  const reportTags = sorted.filter(isReportTag)
+  const otherTags = sorted.filter((tag) => !isReportTag(tag))
+  const collapseReportTags = reportTags.length > 1
+
+  return (
+    <LabelList {...rest}>
+      {otherTags.map((tag) => (
+        <SubjectTag key={tag} tag={tag} />
+      ))}
+      {!collapseReportTags &&
+        reportTags.map((tag) => <SubjectTag key={tag} tag={tag} />)}
+      {collapseReportTags && (
+        <Hover
+          content={
+            <LabelList className="flex-wrap gap-1">
+              {reportTags.map((tag) => (
+                <SubjectTag key={tag} tag={tag} />
+              ))}
+            </LabelList>
+          }
+        >
+          <LabelChip>
+            <FlagIcon className="h-3 w-3" />{' '}
+            {pluralize(reportTags.length, 'report type')}
+          </LabelChip>
+        </Hover>
+      )}
+    </LabelList>
+  )
+}


### PR DESCRIPTION
<img width="446" height="317" alt="Screenshot 2026-07-21 at 11 13 53" src="https://github.com/user-attachments/assets/7e851980-08d7-4ec4-a486-50ad1e2f0a34" />

> Show grouped count of report tags, expand on hover

<img width="446" height="317" alt="Screenshot 2026-07-21 at 11 13 53" src="https://github.com/user-attachments/assets/0cedc7ce-c6c4-4fba-ae3e-3e7589c2aa77" />

> QAP button for subject in report view page