### PR TITLE
:lipstick: Show action row warning based on assignment status

### DIFF
--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -525,6 +525,7 @@ function ReportDetailLayout(props: {
   const subjectOptions = [subject]
 
   const router = useRouter()
+  const labelerAgent = useLabelerAgent()
   useReportArrowKeyNavigation(report.id)
   useReportAutoAdvance(report.id, report.status)
 
@@ -898,7 +899,7 @@ function ReportDetailLayout(props: {
 
           <ReportActionsBar
             report={report}
-            currentUserDid={config.did}
+            currentUserDid={labelerAgent.did}
             selectedAction={selectedAction}
             onActionSelect={setSelectedAction}
             subjectStatus={subjectStatus}

--- a/app/reports/[id]/page-content.tsx
+++ b/app/reports/[id]/page-content.tsx
@@ -898,6 +898,7 @@ function ReportDetailLayout(props: {
 
           <ReportActionsBar
             report={report}
+            currentUserDid={config.did}
             selectedAction={selectedAction}
             onActionSelect={setSelectedAction}
             subjectStatus={subjectStatus}

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -217,12 +217,14 @@ function NoteComposer({
 
 export function ReportActionsBar({
   report,
+  currentUserDid,
   selectedAction,
   onActionSelect,
   subjectStatus,
   onResolveAppeal,
 }: {
   report: ToolsOzoneReportDefs.ReportView
+  currentUserDid: string
   selectedAction: ReportActionType
   onActionSelect: (action: ReportActionType) => void
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
@@ -265,9 +267,33 @@ export function ReportActionsBar({
     ? selectedAction.charAt(0).toUpperCase() + selectedAction.slice(1)
     : 'Action'
 
+  const assignmentHelpText = !report.assignment
+    ? 'Please assign this report to yourself before proceeding with an action'
+    : report.assignment.did !== currentUserDid
+      ? 'You are not assigned to this report, please proceed with caution'
+      : null
+  const hasAvailableActions =
+    canEscalate ||
+    canNoAction ||
+    canReopen ||
+    (canAction &&
+      isAppeal &&
+      ((isSubjectTakendown && canTakedown) || canLabel)) ||
+    (canAction && !isAppeal && (canLabel || canTakedown))
+
   return (
     <div className="mb-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900 px-3 py-2">
+      {assignmentHelpText && hasAvailableActions && (
+        <p className="-mx-3 -mt-2 mb-2 rounded-t-lg border-b border-yellow-200 bg-yellow-50 px-3 py-2 text-xs font-medium text-yellow-900 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
+          {assignmentHelpText}
+        </p>
+      )}
       <div className="flex flex-row items-center gap-2 flex-wrap">
+        {assignmentHelpText && !hasAvailableActions && (
+          <p className="text-xs font-medium text-yellow-800 dark:text-yellow-200">
+            {assignmentHelpText}
+          </p>
+        )}
         {canEscalate && (
           <ActionButton
             appearance={pendingAction === 'escalate' ? 'primary' : 'outlined'}

--- a/components/reports/ReportActions.tsx
+++ b/components/reports/ReportActions.tsx
@@ -224,7 +224,7 @@ export function ReportActionsBar({
   onResolveAppeal,
 }: {
   report: ToolsOzoneReportDefs.ReportView
-  currentUserDid: string
+  currentUserDid?: string
   selectedAction: ReportActionType
   onActionSelect: (action: ReportActionType) => void
   subjectStatus?: ToolsOzoneModerationDefs.SubjectStatusView | null
@@ -269,7 +269,7 @@ export function ReportActionsBar({
 
   const assignmentHelpText = !report.assignment
     ? 'Please assign this report to yourself before proceeding with an action'
-    : report.assignment.did !== currentUserDid
+    : currentUserDid && report.assignment.did !== currentUserDid
       ? 'You are not assigned to this report, please proceed with caution'
       : null
   const hasAvailableActions =


### PR DESCRIPTION
<img width="602" height="511" alt="Screenshot 2026-08-04 at 10 53 30" src="https://github.com/user-attachments/assets/8d2eeeb6-f88c-4f60-be2a-514f4d009336" />

> On open report

<img width="596" height="417" alt="Screenshot 2026-08-04 at 10 59 18" src="https://github.com/user-attachments/assets/1729fce5-42f1-467f-8276-e5f7c38d814f" />

> On queued but unassigned report

<img width="603" height="498" alt="Screenshot 2026-08-04 at 11 08 55" src="https://github.com/user-attachments/assets/c1560733-10f9-4460-9f80-9fd22ecfe7ca" />

> On assigned report to unassigned user