### PR TITLE
Show oldest queued reports first by default

### DIFF
--- a/app/reports/beta/page-content.tsx
+++ b/app/reports/beta/page-content.tsx
@@ -33,7 +33,7 @@ const getSortParams = (params: ReadonlyURLSearchParams) => {
   let sortDirection = params.get('sortDirection')
 
   if (!['asc', 'desc'].includes(sortDirection ?? '')) {
-    sortDirection = 'desc'
+    sortDirection = 'asc'
   }
 
   if (!['createdAt', 'updatedAt'].includes(sortField ?? '')) {


### PR DESCRIPTION
## Summary

- default the report queue to ascending creation time so the oldest reports are shown first
- preserve explicit ascending or descending sort selections

Related backend pagination fix: https://github.com/bluesky-social/atproto/pull/5393

## Testing

- `yarn lint` (passes with existing warnings)
- `yarn type-check` (blocked by existing `recommendedPolicies` API type errors on `main`)