### PR TITLE
Add account preferences to repository details

### DIFF
--- a/components/repositories/AccountPreferences.tsx
+++ b/components/repositories/AccountPreferences.tsx
@@ -1,0 +1,410 @@
+'use client'
+
+import { AppBskyActorDefs } from '@atproto/api'
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/20/solid'
+import { useQuery } from '@tanstack/react-query'
+import { type ReactNode, useState } from 'react'
+
+import { LoadingFailedDense, LoadingDense } from '@/common/Loader'
+import { useLabelerAgent } from '@/shell/ConfigurationContext'
+
+const preferenceTitles: Record<string, string> = {
+  adultContentPref: 'Adult content',
+  contentLabelPref: 'Content filter',
+  savedFeedsPref: 'Saved feeds',
+  savedFeedsPrefV2: 'Saved feeds',
+  personalDetailsPref: 'Personal details',
+  declaredAgePref: 'Declared age',
+  feedViewPref: 'Following feed',
+  threadViewPref: 'Thread view',
+  interestsPref: 'Interests',
+  mutedWordsPref: 'Muted words',
+  hiddenPostsPref: 'Hidden posts',
+  bskyAppStatePref: 'Bluesky app',
+  labelersPref: 'Moderation services',
+  postInteractionSettingsPref: 'Post interactions',
+  verificationPrefs: 'Verification',
+  liveEventPreferences: 'Live events',
+}
+
+function preferenceName(type: string) {
+  const name = type.split('#').at(-1) || type
+  return preferenceTitles[name] || humanize(name)
+}
+
+function humanize(value: string) {
+  const label = value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replaceAll('_', ' ')
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+type PreferenceRow = {
+  label: string
+  value: unknown
+}
+
+function flattenPreference(
+  value: unknown,
+  path: string[] = [],
+): PreferenceRow[] {
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      return [{ label: path.map(humanize).join(' · '), value: [] }]
+    }
+    if (value.every((item) => typeof item !== 'object' || item === null)) {
+      return [{ label: path.map(humanize).join(' · '), value }]
+    }
+    return value.flatMap((item, index) =>
+      flattenPreference(item, [...path, String(index + 1)]),
+    )
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+    const fields = entries.filter(([key]) => key !== '$type')
+    if (!fields.length) {
+      const type = entries.find(([key]) => key === '$type')?.[1]
+      return [
+        {
+          label: path.map(humanize).join(' · '),
+          value: typeof type === 'string' ? preferenceName(type) : [],
+        },
+      ]
+    }
+    return fields.flatMap(([key, nestedValue]) =>
+      flattenPreference(nestedValue, [...path, key]),
+    )
+  }
+
+  return [{ label: path.map(humanize).join(' · '), value }]
+}
+
+function PreferenceValue({ value }: { value: unknown }) {
+  if (typeof value === 'boolean') {
+    return (
+      <span className={value ? 'text-green-700 dark:text-green-400' : ''}>
+        {value ? 'Enabled' : 'Disabled'}
+      </span>
+    )
+  }
+
+  if (value === null || value === undefined || value === '') {
+    return <span className="text-gray-400">Not set</span>
+  }
+
+  if (Array.isArray(value)) {
+    if (!value.length) return <span className="text-gray-400">None</span>
+    return <span className="break-words">{value.map(String).join(', ')}</span>
+  }
+
+  return <span className="break-words">{String(value)}</span>
+}
+
+type Preference = AppBskyActorDefs.Preferences[number]
+
+function PreferenceTable({
+  title,
+  headers,
+  rows,
+}: {
+  title: string
+  headers: string[]
+  rows: ReactNode[][]
+}) {
+  return (
+    <section className="mb-5">
+      <h5 className="mb-1.5 font-semibold text-gray-700 dark:text-gray-200">
+        {title}
+      </h5>
+      <div className="overflow-x-auto border-y border-gray-200 dark:border-slate-700">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-gray-50 text-gray-500 dark:bg-slate-800 dark:text-gray-400">
+            <tr>
+              {headers.map((header) => (
+                <th key={header} className="px-3 py-2 font-medium">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-slate-800">
+            {rows.length ? (
+              rows.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  {row.map((cell, cellIndex) => (
+                    <td
+                      key={cellIndex}
+                      className="px-3 py-2 align-top text-gray-900 dark:text-gray-200"
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={headers.length}
+                  className="px-3 py-2 text-gray-400"
+                >
+                  None
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function PreferenceSection({
+  type,
+  preferences,
+}: {
+  type: string
+  preferences: Preference[]
+}) {
+  const name = type.split('#').at(-1)
+  const title = preferenceName(type)
+
+  if (name === 'contentLabelPref') {
+    const rows = preferences.map((preference) => {
+      const item = preference as AppBskyActorDefs.ContentLabelPref
+      return [
+        item.label,
+        humanize(item.visibility),
+        item.labelerDid || 'All moderation services',
+      ]
+    })
+    return (
+      <PreferenceTable
+        title="Content filters"
+        headers={['Label', 'Visibility', 'Moderation service']}
+        rows={rows}
+      />
+    )
+  }
+
+  if (name === 'savedFeedsPrefV2') {
+    const rows = preferences.flatMap((preference) =>
+      (preference as AppBskyActorDefs.SavedFeedsPrefV2).items.map((item) => [
+        humanize(item.type),
+        item.value,
+        <PreferenceValue key="pinned" value={item.pinned} />,
+      ]),
+    )
+    return (
+      <PreferenceTable
+        title={title}
+        headers={['Type', 'Value', 'Pinned']}
+        rows={rows}
+      />
+    )
+  }
+
+  if (name === 'savedFeedsPref') {
+    const items = preferences.flatMap((preference) => {
+      const item = preference as AppBskyActorDefs.SavedFeedsPref
+      return Array.from(new Set([...item.saved, ...item.pinned])).map((value) => [
+        value,
+        item.saved.includes(value) ? 'Yes' : 'No',
+        item.pinned.includes(value) ? 'Yes' : 'No',
+      ])
+    })
+    return (
+      <PreferenceTable
+        title="Saved feeds (legacy)"
+        headers={['Value', 'Saved', 'Pinned']}
+        rows={items}
+      />
+    )
+  }
+
+  if (name === 'feedViewPref') {
+    const rows = preferences.map((preference) => {
+      const item = preference as AppBskyActorDefs.FeedViewPref
+      return [
+        item.feed,
+        <PreferenceValue key="replies" value={item.hideReplies} />,
+        <PreferenceValue key="reposts" value={item.hideReposts} />,
+        <PreferenceValue key="quotes" value={item.hideQuotePosts} />,
+        item.hideRepliesByLikeCount ?? 'Not set',
+      ]
+    })
+    return (
+      <PreferenceTable
+        title={title}
+        headers={[
+          'Feed',
+          'Hide replies',
+          'Hide reposts',
+          'Hide quotes',
+          'Minimum likes',
+        ]}
+        rows={rows}
+      />
+    )
+  }
+
+  if (name === 'mutedWordsPref') {
+    const rows = preferences.flatMap((preference) =>
+      (preference as AppBskyActorDefs.MutedWordsPref).items.map((item) => [
+        item.value,
+        item.targets.map(humanize).join(', '),
+        humanize(item.actorTarget),
+        item.expiresAt ? new Date(item.expiresAt).toLocaleString() : 'Never',
+      ]),
+    )
+    return (
+      <PreferenceTable
+        title={title}
+        headers={['Word or phrase', 'Targets', 'Applies to', 'Expires']}
+        rows={rows}
+      />
+    )
+  }
+
+  if (name === 'labelersPref') {
+    const rows = preferences.flatMap((preference) =>
+      (preference as AppBskyActorDefs.LabelersPref).labelers.map((item) => [
+        item.did,
+      ]),
+    )
+    return <PreferenceTable title={title} headers={['DID']} rows={rows} />
+  }
+
+  if (name === 'interestsPref') {
+    const interests = preferences.flatMap(
+      (preference) =>
+        (preference as AppBskyActorDefs.InterestsPref).tags,
+    )
+    return (
+      <PreferenceTable
+        title={title}
+        headers={['Interests']}
+        rows={[[interests.length ? interests.join(', ') : 'None']]}
+      />
+    )
+  }
+
+  if (name === 'hiddenPostsPref') {
+    const rows = preferences.flatMap((preference) =>
+      (preference as AppBskyActorDefs.HiddenPostsPref).items.map((uri) => [uri]),
+    )
+    return <PreferenceTable title={title} headers={['Post URI']} rows={rows} />
+  }
+
+  const rows = preferences.flatMap((preference, preferenceIndex) =>
+    flattenPreference(preference).map((row) => [
+      preferences.length > 1
+        ? `${preferenceIndex + 1} · ${row.label || 'Value'}`
+        : row.label || 'Value',
+      <PreferenceValue
+        key={`${preferenceIndex}-${row.label}`}
+        value={row.value}
+      />,
+    ]),
+  )
+  return (
+    <PreferenceTable title={title} headers={['Setting', 'Value']} rows={rows} />
+  )
+}
+
+export function AccountPreferences({ did }: { did: string }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const labelerAgent = useLabelerAgent()
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['accountPreferences', { did }],
+    enabled: isOpen,
+    cacheTime: 1000 * 60 * 5,
+    queryFn: async ({ signal }) => {
+      const params = new URLSearchParams({ did })
+      const response = await labelerAgent.fetchHandler(
+        `/xrpc/tools.ozone.moderation.getAccountPreferences?${params}`,
+        {
+          method: 'GET',
+          headers: { accept: 'application/json' },
+          signal,
+        },
+      )
+      const body = await response.text()
+      let data: {
+        error?: string
+        message?: string
+        preferences?: AppBskyActorDefs.Preferences
+      } = {}
+      try {
+        if (body) data = JSON.parse(body)
+      } catch {
+        // Fall through to the status-based error for non-JSON responses.
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          data.message ||
+            data.error ||
+            `Failed to load preferences (HTTP ${response.status})`,
+        )
+      }
+      if (!data.preferences) {
+        throw new Error('Preferences response is missing preferences')
+      }
+
+      return { preferences: data.preferences }
+    },
+  })
+
+  return (
+    <section className="mb-6" aria-labelledby="account-preferences-heading">
+      <button
+        type="button"
+        className="mb-2 flex items-center font-semibold text-gray-500 hover:text-gray-700 dark:text-gray-50 dark:hover:text-white"
+        aria-expanded={isOpen}
+        aria-controls="account-preferences-content"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        {isOpen ? (
+          <ChevronDownIcon className="mr-1 h-4 w-4" aria-hidden="true" />
+        ) : (
+          <ChevronRightIcon className="mr-1 h-4 w-4" aria-hidden="true" />
+        )}
+        <span id="account-preferences-heading">User Preferences</span>
+      </button>
+
+      {isOpen && (
+        <div id="account-preferences-content">
+          {isLoading ? (
+            <LoadingDense />
+          ) : error ? (
+            <div className="rounded-lg border border-red-200 p-3 text-red-700 dark:border-red-900 dark:text-red-300">
+              <LoadingFailedDense error={error} noPadding />
+            </div>
+          ) : !data?.preferences.length ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No user preferences found.
+            </p>
+          ) : (
+            Array.from(
+              data.preferences.reduce((sections, preference) => {
+                const type = preference.$type || 'unknownPreference'
+                sections.set(type, [...(sections.get(type) || []), preference])
+                return sections
+              }, new Map<string, Preference[]>()),
+            ).map(([type, preferences]) => (
+              <PreferenceSection
+                key={type}
+                type={type}
+                preferences={preferences}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/components/repositories/AccountView.tsx
+++ b/components/repositories/AccountView.tsx
@@ -63,6 +63,7 @@ import { useCopyAccountDetails } from './useCopyAccountDetails'
 import { getProfiles } from './api'
 import { VerificationBadge } from 'components/verification/Badge'
 import { AccountHistory } from './AccountHistory'
+import { AccountPreferences } from './AccountPreferences'
 import { Country } from './Country'
 import { AgeAssuranceBadge } from '@/mod-event/AgeAssuranceStateBadge'
 import { ManageView } from './ManageView'
@@ -678,6 +679,7 @@ function Details({
           invitesDisabled={repo.invitesDisabled}
         />
       </dl>
+      <AccountPreferences did={repo.did} />
       <AccountHistory did={repo.did} />
       {canShowDidHistory && <DidHistory did={repo.did} />}
       {isDidWeb && <DidWebDetails did={repo.did} />}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unlink-atproto": "node scripts/toggle-atproto.js --unlink"
   },
   "dependencies": {
-    "@atproto/api": "^0.20.38",
+    "@atproto/api": "0.20.42",
     "@atproto/oauth-client-browser": "^0.3.42",
     "@atproto/oauth-types": "^0.6.3",
     "@atproto/xrpc": "^0.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,19 +81,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atproto/api@npm:^0.20.38":
-  version: 0.20.38
-  resolution: "@atproto/api@npm:0.20.38"
+"@atproto/api@npm:0.20.42":
+  version: 0.20.42
+  resolution: "@atproto/api@npm:0.20.42"
   dependencies:
-    "@atproto/common-web": "npm:^0.5.9"
-    "@atproto/lexicon": "npm:^0.7.11"
-    "@atproto/syntax": "npm:^0.7.4"
-    "@atproto/xrpc": "npm:^0.8.10"
+    "@atproto/common-web": "npm:^0.5.10"
+    "@atproto/lexicon": "npm:^0.7.12"
+    "@atproto/syntax": "npm:^0.7.5"
+    "@atproto/xrpc": "npm:^0.8.11"
     await-lock: "npm:^3.0.0"
     multiformats: "npm:^13.0.0"
     tlds: "npm:^1.234.0"
     zod: "npm:^3.23.8"
-  checksum: 10c0/c10fa2bfa033316bab1a4dedd48476b84bc7f3883d792234e790c0eecb56f72e309eb0d6a2c5a8db7acdbce61c6c8e14d6ebff2f8e268319d4ae9d0b646588c4
+  checksum: 10c0/31c46a4c41eb54f2ad0ac2f10049e91e715a1598e1a61b32fbc3247b239f8952a3e9095aefc9660aa2d20420bb6632d97a7a1499ddadfc52183a296d32a41d98
   languageName: node
   linkType: hard
 
@@ -106,6 +106,18 @@ __metadata:
     "@atproto/syntax": "npm:^0.5.1"
     zod: "npm:^3.23.8"
   checksum: 10c0/10c1eb537a7d6fa35dd4b97adbf881dc78fba2fce19b57eb15957983f38a8042dacbf19c1ede346700384393a36e111d37d562525e4ad2475f95d573da21c985
+  languageName: node
+  linkType: hard
+
+"@atproto/common-web@npm:^0.5.10":
+  version: 0.5.10
+  resolution: "@atproto/common-web@npm:0.5.10"
+  dependencies:
+    "@atproto/lex-data": "npm:^0.1.7"
+    "@atproto/lex-json": "npm:^0.1.6"
+    "@atproto/syntax": "npm:^0.7.5"
+    zod: "npm:^3.23.8"
+  checksum: 10c0/f165cdf21cc9c7d38c64b5cd2406ca75ce5135d15896ac4ea7e2bfd608299af7f1fb40f09477e555b7fee4d283f3bc0492e2087073f355c54aa237f17ec1f098
   languageName: node
   linkType: hard
 
@@ -229,6 +241,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@atproto/lexicon@npm:^0.7.12":
+  version: 0.7.12
+  resolution: "@atproto/lexicon@npm:0.7.12"
+  dependencies:
+    "@atproto/common-web": "npm:^0.5.10"
+    "@atproto/syntax": "npm:^0.7.5"
+    multiformats: "npm:^13.0.0"
+    zod: "npm:^3.23.8"
+  checksum: 10c0/1e358d504bb5ffdeac17e633f9070ab64c480173a1642e00b0ec9e7cdb18c037922c428fea590c077a7e4d765035a3690069d25758e7605a42fbdd39edaa5d12
+  languageName: node
+  linkType: hard
+
 "@atproto/oauth-client-browser@npm:^0.3.42":
   version: 0.3.42
   resolution: "@atproto/oauth-client-browser@npm:0.3.42"
@@ -297,6 +321,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@atproto/syntax@npm:^0.7.5":
+  version: 0.7.5
+  resolution: "@atproto/syntax@npm:0.7.5"
+  dependencies:
+    iso-datestring-validator: "npm:^2.2.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/93db8d0c8045bd78e5bba5bfbc36a64e8c1e778a01a1fab9a63ccc853b48797f2d3680defcbba652fbeb84af3e44326818b42513cc8646c04705a38f833daf5b
+  languageName: node
+  linkType: hard
+
 "@atproto/xrpc@npm:^0.7.7":
   version: 0.7.7
   resolution: "@atproto/xrpc@npm:0.7.7"
@@ -314,6 +348,16 @@ __metadata:
     "@atproto/lexicon": "npm:^0.7.11"
     zod: "npm:^3.23.8"
   checksum: 10c0/98b47f907beb4c35d76ce596ec59076ad35651a9f669e9898ce4d00469f3a7b86e5e3309f9a9c9a793e7f03ed2497a96dd8ec2dc4aed60b563cd640530a26649
+  languageName: node
+  linkType: hard
+
+"@atproto/xrpc@npm:^0.8.11":
+  version: 0.8.11
+  resolution: "@atproto/xrpc@npm:0.8.11"
+  dependencies:
+    "@atproto/lexicon": "npm:^0.7.12"
+    zod: "npm:^3.23.8"
+  checksum: 10c0/93dab11a4eb5154282cc71227abc03e99310f54d8863edec2c6018420ce7ae9203dc4d4723e82862f576188466273f8d63b920f4e47c83d333f2f11932289688
   languageName: node
   linkType: hard
 
@@ -7005,7 +7049,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ozone@workspace:."
   dependencies:
-    "@atproto/api": "npm:^0.20.38"
+    "@atproto/api": "npm:0.20.42"
     "@atproto/oauth-client-browser": "npm:^0.3.42"
     "@atproto/oauth-types": "npm:^0.6.3"
     "@atproto/xrpc": "npm:^0.8.10"


### PR DESCRIPTION
## Summary

- add a read-only User Preferences section to repository details above Account History
- lazily request account preferences only when the collapsed section is expanded
- render saved feeds, content filters, feed controls, muted words, interests, moderation services, and hidden posts in shape-specific tables
- upgrade `@atproto/api` to 0.20.42 for the current preference lexicon types

The preferences request uses the agent's authenticated fetch handler directly. `@atproto/api` 0.20.42 does not yet bundle the `tools.ozone.moderation.getAccountPreferences` lexicon, so `Agent.call()` rejects the method before making a request. The fetch handler bypasses that lookup while preserving session authentication and Ozone proxy routing.

Depends on bluesky-social/atproto#5421.

## Verification

- `yarn type-check`
- `yarn build`
- `git diff --check`
- adversarial cross-model review: no findings

The production build reports existing lint warnings in unrelated files.

## AI assistance

Implemented and reviewed with Codex/LLM assistance.
